### PR TITLE
Add additional S3 permissions for the Image Registry Operator

### DIFF
--- a/manifests/03-cred-openshift-image-registry.yaml
+++ b/manifests/03-cred-openshift-image-registry.yaml
@@ -17,5 +17,13 @@ spec:
       action:
       - s3:CreateBucket
       - s3:DeleteBucket
+      - s3:PutBucketTagging
+      - s3:GetBucketTagging
+      - s3:PutEncryptionConfiguration
+      - s3:GetEncryptionConfiguration
+      - s3:PutLifecycleConfiguration
+      - s3:GetLifecycleConfiguration
+      - s3:GetBucketLocation
+      - s3:ListBucket
       resource: "*"
 ---


### PR DESCRIPTION
The image registry operator requires additional S3 permissions to function correctly:
      - s3:PutBucketTagging
      - s3:GetBucketTagging
      - s3:PutEncryptionConfiguration
      - s3:GetEncryptionConfiguration
      - s3:PutLifecycleConfiguration
      - s3:GetLifecycleConfiguration
      - s3:GetBucketLocation
      - s3:ListBucket