### PR TITLE
openshift-ingress: Change namespace and permissions

### DIFF
--- a/manifests/03-cred-openshift-ingress.yaml
+++ b/manifests/03-cred-openshift-ingress.yaml
@@ -8,26 +8,16 @@ metadata:
 spec:
   secretRef:
     name: cloud-credentials
-    namespace: openshift-ingress
+    namespace: openshift-ingress-operator
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1beta1
     kind: AWSProviderSpec
     statementEntries:
     - effect: Allow
       action:
-      - s3:CreateBucket
-      - s3:DeleteBucket
-      - elasticloadbalancing:AddTags
-      - elasticloadbalancing:ApplySecurityGroupsToLoadBalancer
-      - elasticloadbalancing:ConfigureHealthCheck
-      - elasticloadbalancing:CreateLoadBalancer
-      - elasticloadbalancing:CreateLoadBalancerListeners
-      - elasticloadbalancing:DeleteLoadBalancer
-      - elasticloadbalancing:DeleteLoadBalancerListeners
-      - elasticloadbalancing:DescribeLoadBalancerAttributes
       - elasticloadbalancing:DescribeLoadBalancers
-      - elasticloadbalancing:DescribeTags
-      - elasticloadbalancing:ModifyLoadBalancerAttributes
-      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+      - route53:ListHostedZones
+      - route53:ChangeResourceRecordSets
+      - tag:GetResources
       resource: "*"
 ---


### PR DESCRIPTION
Move the `cloud-credentials` secret from the operand namespace (`openshift-ingress`) to the operator namespace (`openshift-ingress-operator`): The operator already has permission to read secrets in its own namespace, but not from its operands', and the `cloud-credentials` secret is an input to the operator, not an operand, so having the secret in the operator's namespace simplifies RBAC and is more consistent with how we place other resources related to the operator.

Refine the set of permissions for cluster-ingress-operator: The operator needs to be able to look up Route 53 zones using the `ListHostedZones` and `GetResources` APIs, list load balancers using `DescribeLoadBalancers`, update hosted zones using the `ChangeResourceRecordSets` API, and nothing else.

This PR is related to [NE-140](https://jira.coreos.com/browse/NE-140).

* `manifests/03-cred-openshift-ingress.yaml`: Change the namespace for the secret from `openshift-ingress` to `openshift-ingress-operator`.
Update the permissions to be exactly what cluster-ingress-operator needs.

---

@ironcladlou