### PR TITLE
Add a credential for the AWS machine actuator.

### DIFF
--- a/manifests/03-cred-openshift-cluster-api.yaml
+++ b/manifests/03-cred-openshift-cluster-api.yaml
@@ -1,0 +1,31 @@
+apiVersion: cloudcredential.openshift.io/v1beta1
+kind: CredentialsRequest
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: openshift-cluster-api
+  namespace: openshift-cloud-credential-operator
+spec:
+  secretRef:
+    name: aws-cloud-credentials
+    namespace: openshift-cluster-api
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1beta1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - ec2:DescribeImages
+      - ec2:DescribeVpcs
+      - ec2:DescribeSubnets
+      - ec2:DescribeAvailabilityZones
+      - ec2:DescribeSecurityGroups
+      - ec2:RunInstances
+      - ec2:DescribeInstances
+      - ec2:TerminateInstances
+      - elasticloadbalancing:RegisterInstancesWithLoadBalancer
+      - elasticloadbalancing:DescribeLoadBalancers
+      - elasticloadbalancing:DescribeTargetGroups
+      - elasticloadbalancing:RegisterTargets
+      resource: "*"
+---


### PR DESCRIPTION
These permissions come from the client.go in the AWS actuator repo.

Hopefully the cloud team will have a little time to experiment with switching to this credential.

CC @enxebre @bison 