### PR TITLE
Remove secret controller refs.

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -46,7 +46,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	utilrand "k8s.io/apimachinery/pkg/util/rand"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 const (
@@ -820,11 +819,6 @@ func (a *AWSActuator) syncAccessKeySecret(cr *minterv1.CredentialsRequest, acces
 				"aws_secret_access_key": []byte(*accessKey.SecretAccessKey),
 			},
 		}
-		// Ensure secrets are "owned" by the credentials request that created or adopted them:
-		if err := controllerutil.SetControllerReference(cr, secret, a.Scheme); err != nil {
-			sLog.WithError(err).Error("error setting controller reference on secret")
-			return err
-		}
 
 		err := a.Client.Create(context.TODO(), secret)
 		if err != nil {
@@ -846,11 +840,6 @@ func (a *AWSActuator) syncAccessKeySecret(cr *minterv1.CredentialsRequest, acces
 	if accessKey != nil {
 		existingSecret.Data["aws_access_key_id"] = []byte(*accessKey.AccessKeyId)
 		existingSecret.Data["aws_secret_access_key"] = []byte(*accessKey.SecretAccessKey)
-	}
-	// Ensure secrets are "owned" by the credentials request that created or adopted them:
-	if err := controllerutil.SetControllerReference(cr, existingSecret, a.Scheme); err != nil {
-		sLog.WithError(err).Error("error setting controller reference on secret")
-		return err
 	}
 
 	if !reflect.DeepEqual(existingSecret, origSecret) {

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -409,6 +409,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				mockDeleteAccessKey(mockAWSClient, testAWSAccessKeyID)
 				return mockAWSClient
 			},
+			validate: func(c client.Client, t *testing.T) {
+				targetSecret := getSecret(c)
+				assert.Nil(t, targetSecret)
+			},
 		},
 		{
 			name: "new passthrough credential",


### PR DESCRIPTION
Attempted hotloop fix. These controller refs are not namespaced, but
link to a controller (the CredentialsRequest) in another namespace. This
appeared to work fine for cleanup etc, but I suspect it may be the cause
of the post-upgrade hotloop where the controller constantly reconciles
and creates, then re-syncs and sees no secret.

Instead we will delete the target secrets on CredentialsRequest deletion
ourselves.