### PR TITLE
refactor credentialsrequest controller

### DIFF
--- a/config/crds/cloudcredential_v1beta1_credentialsrequest.yaml
+++ b/config/crds/cloudcredential_v1beta1_credentialsrequest.yaml
@@ -96,7 +96,6 @@ spec:
           required:
           - provisioned
           - lastSyncGeneration
-          - conditions
           type: object
       required:
       - spec

--- a/manifests/0000_30_cloud-credential-operator_00_crd.yaml
+++ b/manifests/0000_30_cloud-credential-operator_00_crd.yaml
@@ -96,7 +96,6 @@ spec:
           required:
           - provisioned
           - lastSyncGeneration
-          - conditions
           type: object
       required:
       - spec

--- a/pkg/apis/cloudcredential/v1beta1/credentialsrequest_types.go
+++ b/pkg/apis/cloudcredential/v1beta1/credentialsrequest_types.go
@@ -66,7 +66,8 @@ type CredentialsRequestStatus struct {
 	ProviderStatus *runtime.RawExtension `json:"providerStatus,omitempty"`
 
 	// Conditions includes detailed status for the CredentialsRequest
-	Conditions []CredentialsRequestCondition `json:"conditions"`
+	// +optional
+	Conditions []CredentialsRequestCondition `json:"conditions,omitempty"`
 }
 
 // +genclient

--- a/pkg/controller/credentialsrequest/actuator/actuator.go
+++ b/pkg/controller/credentialsrequest/actuator/actuator.go
@@ -32,10 +32,6 @@ type Actuator interface {
 	Update(context.Context, *minterv1.CredentialsRequest) error
 	// Checks if the credentials currently exists.
 	Exists(context.Context, *minterv1.CredentialsRequest) (bool, error)
-	// NeedsUpdate will answer the question whether there is a need to update credentials
-	// based on whether any creds exist, or whether the existing creds no longer
-	// satisfy the CredentialsRequest
-	NeedsUpdate(context.Context, *minterv1.CredentialsRequest) (bool, error)
 }
 
 type DummyActuator struct {
@@ -43,10 +39,6 @@ type DummyActuator struct {
 
 func (a *DummyActuator) Exists(ctx context.Context, cr *minterv1.CredentialsRequest) (bool, error) {
 	return true, nil
-}
-
-func (a *DummyActuator) NeedsUpdate(ctx context.Context, cr *minterv1.CredentialsRequest) (bool, error) {
-	return false, nil
 }
 
 func (a *DummyActuator) Create(ctx context.Context, cr *minterv1.CredentialsRequest) error {
@@ -59,4 +51,21 @@ func (a *DummyActuator) Update(ctx context.Context, cr *minterv1.CredentialsRequ
 
 func (a *DummyActuator) Delete(ctx context.Context, cr *minterv1.CredentialsRequest) error {
 	return nil
+}
+
+type ActuatorError struct {
+	ErrReason minterv1.CredentialsRequestConditionType
+	Message   string
+}
+
+type ActuatorStatus interface {
+	Reason() minterv1.CredentialsRequestConditionType
+}
+
+func (e *ActuatorError) Error() string {
+	return e.Message
+}
+
+func (e *ActuatorError) Reason() minterv1.CredentialsRequestConditionType {
+	return e.ErrReason
 }

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -26,6 +26,7 @@ var (
 		"iam:DeleteUser",
 		"iam:DeleteUserPolicy",
 		"iam:GetUser",
+		"iam:GetUserPolicy",
 		"iam:ListAccessKeys",
 		"iam:PutUserPolicy",
 		"iam:TagUser",


### PR DESCRIPTION
move actuator logic into the actuator code (and reuse existing functionality where it makes sense)

create ActuatorError to allow passing specific error conditions back to the credentialsrequest controller (to allow setting specific Conditions as needed)

allow status.conditions to be empty (nothing wrong with everything healthy)

add GetUserPolicy to list of aws actions needed for the actuator in mint-mode

unrelated deployment requests/limits (from make generate)