### PR TITLE
aws: include operator version in UserAgent for AWS API calls

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -27,9 +27,11 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
+	"github.com/openshift/cloud-credential-operator/version"
 )
 
 const (
@@ -118,6 +120,10 @@ func NewClient(accessKeyID, secretAccessKey []byte) (Client, error) {
 	if err != nil {
 		return nil, err
 	}
+	s.Handlers.Build.PushBackNamed(request.NamedHandler{
+		Name: "openshift.io/cloud-credential-operator",
+		Fn:   request.MakeAddToUserAgentHandler("openshift.io cloud-credential-operator", version.Version),
+	})
 
 	return &awsClient{
 		iamClient: iam.New(s),


### PR DESCRIPTION
An example for include version information is `terraform-provider-aws` [1]

[1]: https://github.com/terraform-providers/terraform-provider-aws/blob/98f11aecb078d82fd7d9b59e5307874797d8f359/aws/config.go#L420