### PR TITLE
Remove hardcoded amd64 for multi-arch

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ COPY vendor/ vendor/
 COPY version/ version/
 
 # Build
-RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o manager github.com/openshift/cloud-credential-operator/cmd/manager
+RUN CGO_ENABLED=0 GOOS=linux go build -a -o manager github.com/openshift/cloud-credential-operator/cmd/manager
 
 # Copy the controller-manager into a thin image
 FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base


### PR DESCRIPTION
Remove hardcoded amd64 for multi-arch builds.