### PR TITLE
Update tagging to match newest scheme via installer.

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -122,6 +122,7 @@ func LoadInfrastructureName(c client.Client, logger log.FieldLogger) (string, er
 		logger.WithError(err).Error("error loading Infrastructure config 'cluster'")
 		return "", err
 	}
+
 	logger.Debugf("Loaded infrastructure name: %s", infra.Status.InfrastructureName)
 	return infra.Status.InfrastructureName, nil
 


### PR DESCRIPTION
The installer recently added Infrastructure.Status.InfrastructureName,
and installer created objects are created with the tag
k8s.io/cluster/infraName=owned.

Update to match, but because beta3 went out without this change,
we want to support upgrades but InfrastructureName would be unset
there. To handle this the operator will fall back to the legacy
openshiftClusterID, which the deprovision code still cleans up.