### PR TITLE
Make AWSProviderCodec generic for other clouds

### DIFF
--- a/pkg/apis/cloudcredential/v1/codec.go
+++ b/pkg/apis/cloudcredential/v1/codec.go
@@ -29,15 +29,15 @@ func NewScheme() (*runtime.Scheme, error) {
 	return SchemeBuilder.Build()
 }
 
-// AWSProviderCodec is a runtime codec for the AWS provider.
+// ProviderCodec is a runtime codec for providers.
 // +k8s:deepcopy-gen=false
-type AWSProviderCodec struct {
+type ProviderCodec struct {
 	encoder runtime.Encoder
 	decoder runtime.Decoder
 }
 
 // NewCodec creates a serializer/deserializer for the provider configuration
-func NewCodec() (*AWSProviderCodec, error) {
+func NewCodec() (*ProviderCodec, error) {
 	scheme, err := NewScheme()
 	if err != nil {
 		return nil, err
@@ -47,7 +47,7 @@ func NewCodec() (*AWSProviderCodec, error) {
 	if err != nil {
 		return nil, err
 	}
-	codec := AWSProviderCodec{
+	codec := ProviderCodec{
 		encoder: encoder,
 		decoder: codecFactory.UniversalDecoder(SchemeGroupVersion),
 	}
@@ -55,7 +55,7 @@ func NewCodec() (*AWSProviderCodec, error) {
 }
 
 // EncodeProvider serializes an object to the provider spec.
-func (codec *AWSProviderCodec) EncodeProviderSpec(in runtime.Object) (*runtime.RawExtension, error) {
+func (codec *ProviderCodec) EncodeProviderSpec(in runtime.Object) (*runtime.RawExtension, error) {
 	var buf bytes.Buffer
 	if err := codec.encoder.Encode(in, &buf); err != nil {
 		return nil, fmt.Errorf("encoding failed: %v", err)
@@ -64,20 +64,16 @@ func (codec *AWSProviderCodec) EncodeProviderSpec(in runtime.Object) (*runtime.R
 }
 
 // DecodeProviderSpec deserializes an object from the provider config.
-func (codec *AWSProviderCodec) DecodeProviderSpec(providerConfig *runtime.RawExtension, out runtime.Object) (*AWSProviderSpec, error) {
-	obj, _, err := codec.decoder.Decode(providerConfig.Raw, nil, out)
+func (codec *ProviderCodec) DecodeProviderSpec(providerConfig *runtime.RawExtension, out runtime.Object) error {
+	_, _, err := codec.decoder.Decode(providerConfig.Raw, nil, out)
 	if err != nil {
-		return nil, fmt.Errorf("decoding failure: %v", err)
+		return fmt.Errorf("decoding failure: %v", err)
 	}
-	s, ok := obj.(*AWSProviderSpec)
-	if !ok {
-		return nil, fmt.Errorf("error casting to AWSProviderSpec")
-	}
-	return s, nil
+	return nil
 }
 
 // EncodeProviderStatus serializes the provider status.
-func (codec *AWSProviderCodec) EncodeProviderStatus(in runtime.Object) (*runtime.RawExtension, error) {
+func (codec *ProviderCodec) EncodeProviderStatus(in runtime.Object) (*runtime.RawExtension, error) {
 	var buf bytes.Buffer
 	if err := codec.encoder.Encode(in, &buf); err != nil {
 		return nil, fmt.Errorf("encoding failed: %v", err)
@@ -86,19 +82,15 @@ func (codec *AWSProviderCodec) EncodeProviderStatus(in runtime.Object) (*runtime
 }
 
 // DecodeProviderStatus deserializes the provider status.
-func (codec *AWSProviderCodec) DecodeProviderStatus(providerStatus *runtime.RawExtension, out runtime.Object) (*AWSProviderStatus, error) {
+func (codec *ProviderCodec) DecodeProviderStatus(providerStatus *runtime.RawExtension, out runtime.Object) error {
 	if providerStatus != nil {
-		obj, _, err := codec.decoder.Decode(providerStatus.Raw, nil, out)
+		_, _, err := codec.decoder.Decode(providerStatus.Raw, nil, out)
 		if err != nil {
-			return nil, fmt.Errorf("decoding failure: %v", err)
+			return fmt.Errorf("decoding failure: %v", err)
 		}
-		s, ok := obj.(*AWSProviderStatus)
-		if !ok {
-			return nil, fmt.Errorf("error casting to AWSProviderStatus")
-		}
-		return s, nil
+		return nil
 	}
-	return &AWSProviderStatus{}, nil
+	return nil
 }
 
 func newEncoder(codecFactory *serializer.CodecFactory) (runtime.Encoder, error) {

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -61,7 +61,7 @@ var _ actuatoriface.Actuator = (*AWSActuator)(nil)
 // AWSActuator implements the CredentialsRequest Actuator interface to create credentials in AWS.
 type AWSActuator struct {
 	Client           client.Client
-	Codec            *minterv1.AWSProviderCodec
+	Codec            *minterv1.ProviderCodec
 	AWSClientBuilder func(accessKeyID, secretAccessKey []byte, infraName string) (ccaws.Client, error)
 	Scheme           *runtime.Scheme
 }
@@ -82,27 +82,28 @@ func NewAWSActuator(client client.Client, scheme *runtime.Scheme) (*AWSActuator,
 	}, nil
 }
 
-func DecodeProviderStatus(codec *minterv1.AWSProviderCodec, cr *minterv1.CredentialsRequest) (*minterv1.AWSProviderStatus, error) {
-	awsStatus := &minterv1.AWSProviderStatus{}
+func DecodeProviderStatus(codec *minterv1.ProviderCodec, cr *minterv1.CredentialsRequest) (*minterv1.AWSProviderStatus, error) {
+	awsStatus := minterv1.AWSProviderStatus{}
 	var err error
 	if cr.Status.ProviderStatus == nil {
-		return awsStatus, nil
+		return &awsStatus, nil
 	}
 
-	awsStatus, err = codec.DecodeProviderStatus(cr.Status.ProviderStatus, &minterv1.AWSProviderStatus{})
+	err = codec.DecodeProviderStatus(cr.Status.ProviderStatus, &awsStatus)
 	if err != nil {
 		return nil, fmt.Errorf("error decoding v1 provider status: %v", err)
 	}
-	return awsStatus, nil
+	return &awsStatus, nil
 }
 
-func DecodeProviderSpec(codec *minterv1.AWSProviderCodec, cr *minterv1.CredentialsRequest) (*minterv1.AWSProviderSpec, error) {
+func DecodeProviderSpec(codec *minterv1.ProviderCodec, cr *minterv1.CredentialsRequest) (*minterv1.AWSProviderSpec, error) {
 	if cr.Spec.ProviderSpec != nil {
-		awsSpec, err := codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &minterv1.AWSProviderSpec{})
+		awsSpec := minterv1.AWSProviderSpec{}
+		err := codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &awsSpec)
 		if err != nil {
 			return nil, fmt.Errorf("error decoding provider v1 spec: %v", err)
 		}
-		return awsSpec, nil
+		return &awsSpec, nil
 	}
 
 	return nil, fmt.Errorf("no providerSpec defined")

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -255,7 +255,8 @@ func getCredentialRequestStatements(crBytes []byte) ([]minterv1.StatementEntry, 
 		return statementList, err
 	}
 
-	awsSpec, err := awsCodec.DecodeProviderSpec(cr.Spec.ProviderSpec, &minterv1.AWSProviderSpec{})
+	awsSpec := minterv1.AWSProviderSpec{}
+	err = awsCodec.DecodeProviderSpec(cr.Spec.ProviderSpec, &awsSpec)
 	if err != nil {
 		return statementList, fmt.Errorf("error decoding spec.ProviderSpec: %v", err)
 	}


### PR DESCRIPTION
AWSProviderCodec is currently only usable in the AWS actuator even
though other cloud providers could make use of the provided
functionality.

This change replaces AWSProviderCodec with ProviderCodec that can be
used with different cloud provider spec and status implementations.
ProviderCodec uses a similar approach to the controller-runtime client
interfaces by writing to the `out runtime.Object` instead of returning a
separate value.

The upcoming PR for the azure actuator will depend on ProviderCodec.