### PR TITLE
provide pod logs via API on failures

### DIFF
--- a/manifests/0000_30_cloud-credential-operator_01_deployment.yaml
+++ b/manifests/0000_30_cloud-credential-operator_01_deployment.yaml
@@ -151,6 +151,7 @@ spec:
           value: 0.0.1-snapshot
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
+        terminationMessagePolicy: FallbackToLogsOnError
         name: manager
         ports:
         - containerPort: 9876


### PR DESCRIPTION
When pods fail, you normally get logs, but if other bits of the cluster fail they aren't always available.  This provides a snippet on crashes.