### PR TITLE
add cluster-reader role to aggregate

### DIFF
--- a/manifests/0000_30_cloud-credential-operator_00_clusterreader_clusterrole.yaml
+++ b/manifests/0000_30_cloud-credential-operator_00_clusterreader_clusterrole.yaml
@@ -1,0 +1,15 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:cloud-credential-operator:cluster-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+  - cloudcredential.openshift.io
+  resources:
+  - credentialsrequests
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
Adds permissions to non-sensitive API resources for cluster-reader.

The general rule is that they can read all non-escalating resources, so not things like secrets, oauthtokens.