### PR TITLE
Do not look for root creds during startup, instead validate for each request

### DIFF
--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -58,11 +58,11 @@ func (cw *clientWrapper) RootSecret(ctx context.Context) (*secret, error) {
 }
 
 func (cw *clientWrapper) Secret(ctx context.Context, key client.ObjectKey) (*secret, error) {
-	s := secret{}
+	s := &secret{}
 	if err := cw.Get(ctx, key, &s.Secret); err != nil {
 		return nil, err
 	}
-	return &s, nil
+	return s, nil
 }
 
 func (cw *clientWrapper) Mode(ctx context.Context) (string, error) {

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller.go
@@ -93,15 +93,15 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	// Create controller with dependencies set
 	c := &internalcontroller.Controller{
-		Do:       r,
-		Cache:    mgr.GetCache(),
-		Config:   mgr.GetConfig(),
-		Scheme:   mgr.GetScheme(),
-		Client:   mgr.GetClient(),
-		Recorder: mgr.GetRecorder(name),
-		Queue:    workqueue.NewNamedRateLimitingQueue(rateLimiter, name),
+		Do:                      r,
+		Cache:                   mgr.GetCache(),
+		Config:                  mgr.GetConfig(),
+		Scheme:                  mgr.GetScheme(),
+		Client:                  mgr.GetClient(),
+		Recorder:                mgr.GetRecorder(name),
+		Queue:                   workqueue.NewNamedRateLimitingQueue(rateLimiter, name),
 		MaxConcurrentReconciles: 1,
-		Name: name,
+		Name:                    name,
 	}
 
 	if err := mgr.Add(c); err != nil {

--- a/pkg/controller/credentialsrequest/status_test.go
+++ b/pkg/controller/credentialsrequest/status_test.go
@@ -168,14 +168,14 @@ func TestClusterOperatorVersion(t *testing.T) {
 		expectProgressingTransition      bool
 	}{
 		{
-			name: "test version upgraded",
+			name:                             "test version upgraded",
 			currentProgressingLastTransition: twentyHoursAgo,
 			currentVersion:                   "4.0.0-5",
 			releaseVersionEnv:                "4.0.0-10",
 			expectProgressingTransition:      true,
 		},
 		{
-			name: "test version constant",
+			name:                             "test version constant",
 			currentProgressingLastTransition: twentyHoursAgo,
 			currentVersion:                   "4.0.0-5",
 			releaseVersionEnv:                "4.0.0-5",


### PR DESCRIPTION
- Currently azure actuator doesnt startup, due to suspicion of uninitialized client.
- Initialize the actuator first and validate mode on each request.

Currently only azure specs are present in the cluster might need to change other operators to put valid requests based on platform