### PR TITLE
Azure secret annotator

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1142,3 +1142,21 @@ func (a *AWSActuator) loadClusterUUID(logger log.FieldLogger) (configv1.ClusterI
 	logger.WithField("clusterID", clusterVer.Spec.ClusterID).Debug("found cluster ID")
 	return clusterVer.Spec.ClusterID, nil
 }
+
+func isAWSCredentials(providerSpec *runtime.RawExtension) (bool, error) {
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		return false, err
+	}
+	unknown := runtime.Unknown{}
+	err = codec.DecodeProviderSpec(providerSpec, &unknown)
+	if err != nil {
+		return false, err
+	}
+	isAWS := unknown.Kind == reflect.TypeOf(minterv1.AWSProviderSpec{}).Name()
+	if !isAWS {
+		log.WithField("kind", unknown.Kind).
+			Info("actuator handles only azure credentials")
+	}
+	return isAWS, nil
+}

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -28,7 +28,8 @@ import (
 	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	minteraws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
+	awsannotator "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/aws"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -281,7 +282,7 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 		return err
 	}
 
-	if cloudCredsSecret.Annotations[secretannotator.AnnotationKey] == secretannotator.InsufficientAnnotation {
+	if cloudCredsSecret.Annotations[annotatorconst.AnnotationKey] == annotatorconst.InsufficientAnnotation {
 		msg := "cloud credentials insufficient to satisfy credentials request"
 		logger.Error(msg)
 		return &actuatoriface.ActuatorError{
@@ -290,13 +291,13 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 		}
 	}
 
-	if cloudCredsSecret.Annotations[secretannotator.AnnotationKey] == secretannotator.PassthroughAnnotation {
+	if cloudCredsSecret.Annotations[annotatorconst.AnnotationKey] == annotatorconst.PassthroughAnnotation {
 		logger.Debugf("provisioning with passthrough")
 		err := a.syncPassthrough(ctx, cr, cloudCredsSecret, logger)
 		if err != nil {
 			return err
 		}
-	} else if cloudCredsSecret.Annotations[secretannotator.AnnotationKey] == secretannotator.MintAnnotation {
+	} else if cloudCredsSecret.Annotations[annotatorconst.AnnotationKey] == annotatorconst.MintAnnotation {
 		logger.Debugf("provisioning with cred minting")
 		err := a.syncMint(ctx, cr, infraName, logger)
 		if err != nil {
@@ -314,8 +315,8 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 
 func (a *AWSActuator) syncPassthrough(ctx context.Context, cr *minterv1.CredentialsRequest, cloudCredsSecret *corev1.Secret, logger log.FieldLogger) error {
 	existingSecret, _, _ := a.loadExistingSecret(cr)
-	accessKeyID := string(cloudCredsSecret.Data[secretannotator.AwsAccessKeyName])
-	secretAccessKey := string(cloudCredsSecret.Data[secretannotator.AwsSecretAccessKeyName])
+	accessKeyID := string(cloudCredsSecret.Data[awsannotator.AwsAccessKeyName])
+	secretAccessKey := string(cloudCredsSecret.Data[awsannotator.AwsSecretAccessKeyName])
 	// userPolicy param empty because in passthrough mode this doesn't really have any meaning
 	err := a.syncAccessKeySecret(cr, accessKeyID, secretAccessKey, existingSecret, "", logger)
 	if err != nil {
@@ -908,7 +909,7 @@ func (a *AWSActuator) getCloudCredentialsSecret(ctx context.Context, logger log.
 	}
 
 	if !isSecretAnnotated(cloudCredSecret) {
-		logger.WithField("secret", fmt.Sprintf("%s/%s", secretannotator.CloudCredSecretNamespace, secretannotator.CloudCredSecretName)).Error("cloud cred secret not yet annotated")
+		logger.WithField("secret", fmt.Sprintf("%s/%s", annotatorconst.CloudCredSecretNamespace, annotatorconst.CloudCredSecretName)).Error("cloud cred secret not yet annotated")
 		return nil, &actuatoriface.ActuatorError{
 			ErrReason: minterv1.CredentialsProvisionFailure,
 			Message:   fmt.Sprintf("cannot proceed without cloud cred secret annotation"),
@@ -923,7 +924,7 @@ func isSecretAnnotated(secret *corev1.Secret) bool {
 		return false
 	}
 
-	if _, ok := secret.ObjectMeta.Annotations[secretannotator.AnnotationKey]; !ok {
+	if _, ok := secret.ObjectMeta.Annotations[annotatorconst.AnnotationKey]; !ok {
 		return false
 	}
 

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -19,10 +19,14 @@ package azure
 import (
 	"context"
 	"errors"
+	"reflect"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
+	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -58,7 +62,28 @@ func (a *Actuator) IsValidMode() error {
 	return errors.New("invalid mode")
 }
 
+func isAzureCredentials(providerSpec *runtime.RawExtension) (bool, error) {
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		return false, err
+	}
+	unknown := runtime.Unknown{}
+	err = codec.DecodeProviderSpec(providerSpec, &unknown)
+	if err != nil {
+		return false, err
+	}
+	isAzure := unknown.Kind == reflect.TypeOf(minterv1.AzureProviderSpec{}).Name()
+	if !isAzure {
+		log.WithField("kind", unknown.Kind).
+			Info("actuator handles only azure credentials")
+	}
+	return isAzure, nil
+}
+
 func (a *Actuator) Create(ctx context.Context, cr *minterv1.CredentialsRequest) error {
+	if isAzure, err := isAzureCredentials(cr.Spec.ProviderSpec); !isAzure {
+		return err
+	}
 	if err := a.IsValidMode(); err != nil {
 		return err
 	}
@@ -66,6 +91,9 @@ func (a *Actuator) Create(ctx context.Context, cr *minterv1.CredentialsRequest) 
 }
 
 func (a *Actuator) Delete(ctx context.Context, cr *minterv1.CredentialsRequest) error {
+	if isAzure, err := isAzureCredentials(cr.Spec.ProviderSpec); !isAzure {
+		return err
+	}
 	if err := a.IsValidMode(); err != nil {
 		return err
 	}
@@ -73,6 +101,9 @@ func (a *Actuator) Delete(ctx context.Context, cr *minterv1.CredentialsRequest) 
 }
 
 func (a *Actuator) Update(ctx context.Context, cr *minterv1.CredentialsRequest) error {
+	if isAzure, err := isAzureCredentials(cr.Spec.ProviderSpec); !isAzure {
+		return err
+	}
 	if err := a.IsValidMode(); err != nil {
 		return err
 	}
@@ -80,6 +111,9 @@ func (a *Actuator) Update(ctx context.Context, cr *minterv1.CredentialsRequest) 
 }
 
 func (a *Actuator) Exists(ctx context.Context, cr *minterv1.CredentialsRequest) (bool, error) {
+	if isAzure, err := isAzureCredentials(cr.Spec.ProviderSpec); !isAzure {
+		return false, err
+	}
 	if err := a.IsValidMode(); err != nil {
 		return false, err
 	}

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -22,7 +22,7 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -51,7 +51,7 @@ func (a *Actuator) IsValidMode() error {
 
 	switch mode {
 	// TODO: case secretannotator.MintAnnotation:
-	case secretannotator.PassthroughAnnotation:
+	case annotatorconst.PassthroughAnnotation:
 		return nil
 	}
 

--- a/pkg/azure/actuator_test.go
+++ b/pkg/azure/actuator_test.go
@@ -17,13 +17,37 @@ limitations under the License.
 package azure_test
 
 import (
+	"reflect"
 	"testing"
 
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/azure"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
+
+func TestDecodeToUnknown(t *testing.T) {
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		t.Fatalf("failed to create codec %#v", err)
+	}
+	var raw *runtime.RawExtension
+	aps := minterv1.AzureProviderSpec{}
+	raw, err = codec.EncodeProviderSpec(&aps)
+	if err != nil {
+		t.Fatalf("failed to encode codec %#v", err)
+	}
+	unknown := runtime.Unknown{}
+	err = codec.DecodeProviderStatus(raw, &unknown)
+	if err != nil {
+		t.Fatalf("should be able to decode to Unknown %#v", err)
+	}
+	if unknown.Kind != reflect.TypeOf(minterv1.AzureProviderSpec{}).Name() {
+		t.Fatalf("expected decoded kind to be %s but was %s", reflect.TypeOf(minterv1.AzureProviderSpec{}).Name(), unknown.Kind)
+	}
+}
 
 func TestAnnotations(t *testing.T) {
 	var tests = []struct {

--- a/pkg/azure/base.go
+++ b/pkg/azure/base.go
@@ -34,6 +34,9 @@ func (a *base) Delete(context.Context, *minterv1.CredentialsRequest) error {
 }
 
 func (a *base) Exists(ctx context.Context, cr *minterv1.CredentialsRequest) (bool, error) {
+	if isAzure, err := isAzureCredentials(cr.Spec.ProviderSpec); !isAzure {
+		return false, err
+	}
 	req, err := newRequest(cr)
 	if err != nil {
 		return false, err

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -22,7 +22,7 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -71,5 +71,5 @@ func (cw *clientWrapper) Mode(ctx context.Context) (string, error) {
 		return "", err
 	}
 
-	return rs.Annotations[secretannotator.AnnotationKey], nil
+	return rs.Annotations[annotatorconst.AnnotationKey], nil
 }

--- a/pkg/azure/const.go
+++ b/pkg/azure/const.go
@@ -1,0 +1,11 @@
+package azure
+
+const (
+	AzureClientID       = "azure_client_id"
+	AzureClientSecret   = "azure_client_secret"
+	AzureRegion         = "azure_region"
+	AzureResourceGroup  = "azure_resourcegroup"
+	AzureResourcePrefix = "azure_resource_prefix"
+	AzureSubscriptionID = "azure_subscription_id"
+	AzureTenantID       = "azure_tenant_id"
+)

--- a/pkg/azure/passthrough.go
+++ b/pkg/azure/passthrough.go
@@ -24,7 +24,6 @@ import (
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -83,12 +82,12 @@ func copySecret(cr *minterv1.CredentialsRequest, src *secret, dest *secret) {
 		},
 	}
 	dest.Data = map[string][]byte{
-		secretannotator.AzureClientID:       src.Data[secretannotator.AzureClientID],
-		secretannotator.AzureClientSecret:   src.Data[secretannotator.AzureClientSecret],
-		secretannotator.AzureRegion:         src.Data[secretannotator.AzureRegion],
-		secretannotator.AzureResourceGroup:  src.Data[secretannotator.AzureResourceGroup],
-		secretannotator.AzureResourcePrefix: src.Data[secretannotator.AzureResourcePrefix],
-		secretannotator.AzureSubscriptionID: src.Data[secretannotator.AzureSubscriptionID],
-		secretannotator.AzureTenantID:       src.Data[secretannotator.AzureTenantID],
+		AzureClientID:       src.Data[AzureClientID],
+		AzureClientSecret:   src.Data[AzureClientSecret],
+		AzureRegion:         src.Data[AzureRegion],
+		AzureResourceGroup:  src.Data[AzureResourceGroup],
+		AzureResourcePrefix: src.Data[AzureResourcePrefix],
+		AzureSubscriptionID: src.Data[AzureSubscriptionID],
+		AzureTenantID:       src.Data[AzureTenantID],
 	}
 }

--- a/pkg/azure/passthrough_test.go
+++ b/pkg/azure/passthrough_test.go
@@ -22,7 +22,7 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/azure"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -74,17 +74,17 @@ var (
 			Name:      azure.RootSecretName,
 			Namespace: azure.RootSecretNamespace,
 			Annotations: map[string]string{
-				secretannotator.AnnotationKey: secretannotator.PassthroughAnnotation,
+				annotatorconst.AnnotationKey: annotatorconst.PassthroughAnnotation,
 			},
 		},
 		Data: map[string][]byte{
-			secretannotator.AzureClientID:       []byte(rootClientID),
-			secretannotator.AzureClientSecret:   []byte(rootClientSecret),
-			secretannotator.AzureRegion:         []byte(rootRegion),
-			secretannotator.AzureResourceGroup:  []byte(rootResourceGroup),
-			secretannotator.AzureResourcePrefix: []byte(rootResourcePrefix),
-			secretannotator.AzureSubscriptionID: []byte(rootSubscriptionID),
-			secretannotator.AzureTenantID:       []byte(rootTenantID),
+			azure.AzureClientID:       []byte(rootClientID),
+			azure.AzureClientSecret:   []byte(rootClientSecret),
+			azure.AzureRegion:         []byte(rootRegion),
+			azure.AzureResourceGroup:  []byte(rootResourceGroup),
+			azure.AzureResourcePrefix: []byte(rootResourcePrefix),
+			azure.AzureSubscriptionID: []byte(rootSubscriptionID),
+			azure.AzureTenantID:       []byte(rootTenantID),
 		},
 	}
 
@@ -93,7 +93,7 @@ var (
 			Name:      azure.RootSecretName,
 			Namespace: azure.RootSecretNamespace,
 			Annotations: map[string]string{
-				secretannotator.AnnotationKey: "blah",
+				annotatorconst.AnnotationKey: "blah",
 			},
 		},
 	}
@@ -175,13 +175,13 @@ func TestPassthroughCreate(t *testing.T) {
 			key := client.ObjectKey{Namespace: cr.Spec.SecretRef.Namespace, Name: cr.Spec.SecretRef.Name}
 			err = f.Get(context.TODO(), key, &secret)
 			assert.Nil(t, err)
-			assert.Equal(t, secret.Data[secretannotator.AzureClientID], []byte(rootClientID))
-			assert.Equal(t, secret.Data[secretannotator.AzureClientSecret], []byte(rootClientSecret))
-			assert.Equal(t, secret.Data[secretannotator.AzureRegion], []byte(rootRegion))
-			assert.Equal(t, secret.Data[secretannotator.AzureResourceGroup], []byte(rootResourceGroup))
-			assert.Equal(t, secret.Data[secretannotator.AzureResourcePrefix], []byte(rootResourcePrefix))
-			assert.Equal(t, secret.Data[secretannotator.AzureSubscriptionID], []byte(rootSubscriptionID))
-			assert.Equal(t, secret.Data[secretannotator.AzureTenantID], []byte(rootTenantID))
+			assert.Equal(t, secret.Data[azure.AzureClientID], []byte(rootClientID))
+			assert.Equal(t, secret.Data[azure.AzureClientSecret], []byte(rootClientSecret))
+			assert.Equal(t, secret.Data[azure.AzureRegion], []byte(rootRegion))
+			assert.Equal(t, secret.Data[azure.AzureResourceGroup], []byte(rootResourceGroup))
+			assert.Equal(t, secret.Data[azure.AzureResourcePrefix], []byte(rootResourcePrefix))
+			assert.Equal(t, secret.Data[azure.AzureSubscriptionID], []byte(rootSubscriptionID))
+			assert.Equal(t, secret.Data[azure.AzureTenantID], []byte(rootTenantID))
 		})
 	}
 }
@@ -212,8 +212,8 @@ func TestPassthroughUpdate(t *testing.T) {
 			key := client.ObjectKey{Namespace: cr.Spec.SecretRef.Namespace, Name: cr.Spec.SecretRef.Name}
 			err = f.Get(context.TODO(), key, &secret)
 			assert.Nil(t, err)
-			assert.Equal(t, secret.Data[secretannotator.AzureClientID], []byte(rootClientID))
-			assert.Equal(t, secret.Data[secretannotator.AzureClientSecret], []byte(rootClientSecret))
+			assert.Equal(t, secret.Data[azure.AzureClientID], []byte(rootClientID))
+			assert.Equal(t, secret.Data[azure.AzureClientSecret], []byte(rootClientSecret))
 		})
 	}
 }

--- a/pkg/azure/secret.go
+++ b/pkg/azure/secret.go
@@ -17,7 +17,7 @@ limitations under the License.
 package azure
 
 import (
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	corev1 "k8s.io/api/core/v1"
 )
 
@@ -30,7 +30,7 @@ func (s *secret) HasAnnotation() bool {
 		return false
 	}
 
-	if _, ok := s.ObjectMeta.Annotations[secretannotator.AnnotationKey]; !ok {
+	if _, ok := s.ObjectMeta.Annotations[annotatorconst.AnnotationKey]; !ok {
 		return false
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -20,12 +20,12 @@ import (
 	awsactuator "github.com/openshift/cloud-credential-operator/pkg/aws/actuator"
 	"github.com/openshift/cloud-credential-operator/pkg/azure"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/platform"
 
 	configv1 "github.com/openshift/api/config/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
-	utils "github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -53,7 +53,7 @@ func AddToManager(m manager.Manager) error {
 		// https://github.com/openshift/api/blob/master/config/v1/types_infrastructure.go#L11
 		var err error
 		var a actuator.Actuator
-		plat, err := utils.PlatformType(m)
+		plat, err := platform.Get(m)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -17,20 +17,15 @@ limitations under the License.
 package controller
 
 import (
-	"context"
-
 	awsactuator "github.com/openshift/cloud-credential-operator/pkg/aws/actuator"
 	"github.com/openshift/cloud-credential-operator/pkg/azure"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
 
 	configv1 "github.com/openshift/api/config/v1"
 
-	"k8s.io/apimachinery/pkg/types"
-	"k8s.io/client-go/tools/clientcmd"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
+	utils "github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 	log "github.com/sirupsen/logrus"
 )
 
@@ -58,7 +53,7 @@ func AddToManager(m manager.Manager) error {
 		// https://github.com/openshift/api/blob/master/config/v1/types_infrastructure.go#L11
 		var err error
 		var a actuator.Actuator
-		plat, err := platformType(m)
+		plat, err := utils.PlatformType(m)
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -84,35 +79,4 @@ func AddToManager(m manager.Manager) error {
 		}
 	}
 	return nil
-}
-
-func platformType(m manager.Manager) (configv1.PlatformType, error) {
-	client, err := getClient()
-	if err != nil {
-		return configv1.NonePlatformType, err
-	}
-	infraName := types.NamespacedName{Name: "cluster"}
-	infra := &configv1.Infrastructure{}
-	err = client.Get(context.Background(), infraName, infra)
-	if err != nil {
-		return configv1.NonePlatformType, err
-	}
-	return infra.Status.Platform, nil
-}
-
-func getClient() (client.Client, error) {
-	rules := clientcmd.NewDefaultClientConfigLoadingRules()
-	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
-	cfg, err := kubeconfig.ClientConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	//apis.AddToScheme(scheme.Scheme)
-	dynamicClient, err := client.New(cfg, client.Options{})
-	if err != nil {
-		return nil, err
-	}
-
-	return dynamicClient, nil
 }

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -44,7 +44,7 @@ import (
 	minteraws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/aws/actuator"
 	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -989,13 +989,13 @@ func createTestNamespace(namespace string) *corev1.Namespace {
 
 func testInsufficientAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey string) *corev1.Secret {
 	s := testAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey)
-	s.Annotations[secretannotator.AnnotationKey] = secretannotator.InsufficientAnnotation
+	s.Annotations[annotatorconst.AnnotationKey] = annotatorconst.InsufficientAnnotation
 	return s
 }
 
 func testPassthroughAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey string) *corev1.Secret {
 	s := testAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey)
-	s.Annotations[secretannotator.AnnotationKey] = secretannotator.PassthroughAnnotation
+	s.Annotations[annotatorconst.AnnotationKey] = annotatorconst.PassthroughAnnotation
 	return s
 }
 
@@ -1005,7 +1005,7 @@ func testAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey string) *c
 			Name:      name,
 			Namespace: namespace,
 			Annotations: map[string]string{
-				secretannotator.AnnotationKey: secretannotator.MintAnnotation,
+				annotatorconst.AnnotationKey: annotatorconst.MintAnnotation,
 			},
 		},
 		Data: map[string][]byte{

--- a/pkg/controller/platform/platform.go
+++ b/pkg/controller/platform/platform.go
@@ -1,4 +1,4 @@
-package utils
+package platform
 
 import (
 	"context"
@@ -10,8 +10,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-// PlatformType queries the ku8s api for the infrastructure config map and retrieves the current platform.
-func PlatformType(m manager.Manager) (configv1.PlatformType, error) {
+// Get queries the ku8s api for the infrastructure config map and retrieves the current platform.
+func Get(m manager.Manager) (configv1.PlatformType, error) {
 	client, err := getClient()
 	if err != nil {
 		return configv1.NonePlatformType, err

--- a/pkg/controller/secretannotator/aws/reconciler.go
+++ b/pkg/controller/secretannotator/aws/reconciler.go
@@ -1,0 +1,166 @@
+package aws
+
+import (
+	"context"
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
+)
+
+const (
+	// TODO: dynamically detect which environment we're running on
+	AWSCloudCredSecretName   = "aws-creds"
+	CloudCredSecretNamespace = "kube-system"
+
+	AwsAccessKeyName       = "aws_access_key_id"
+	AwsSecretAccessKeyName = "aws_secret_access_key"
+)
+
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileCloudCredSecret{
+		Client:           mgr.GetClient(),
+		Logger:           log.WithField("controller", constants.ControllerName),
+		AWSClientBuilder: ccaws.NewClient,
+	}
+}
+
+func cloudCredSecretObjectCheck(secret metav1.Object) bool {
+	return secret.GetNamespace() == CloudCredSecretNamespace && secret.GetName() == AWSCloudCredSecretName
+}
+
+func Add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New(constants.ControllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to cluster cloud secret
+	p := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return cloudCredSecretObjectCheck(e.MetaNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return cloudCredSecretObjectCheck(e.Meta)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return cloudCredSecretObjectCheck(e.Meta)
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, p)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+var _ reconcile.Reconciler = &ReconcileCloudCredSecret{}
+
+type ReconcileCloudCredSecret struct {
+	client.Client
+	Logger           log.FieldLogger
+	AWSClientBuilder func(accessKeyID, secretAccessKey []byte, infraName string) (ccaws.Client, error)
+}
+
+// Reconcile will annotate the cloud cred secret to indicate the capabilities of the cred's capabilities:
+// 1) 'mint' for indicating that the creds can be used to create new sub-creds
+// 2) 'passthrough' for indicating that the creds are capable enough for other components to reuse the creds as-is
+// 3) 'insufficient' for indicating that the creds are not usable for the cluster
+// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;update
+func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	r.Logger.Info("validating cloud cred secret")
+
+	secret := &corev1.Secret{}
+	err := r.Get(context.Background(), request.NamespacedName, secret)
+	if err != nil {
+		r.Logger.Debugf("secret not found: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	err = r.validateCloudCredsSecret(secret)
+	if err != nil {
+		r.Logger.Errorf("error while validating cloud credentials: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secret) error {
+	accessKey, ok := secret.Data[AwsAccessKeyName]
+	if !ok {
+		r.Logger.Errorf("Couldn't fetch key containing AWS_ACCESS_KEY_ID from cloud cred secret")
+		return r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
+	}
+
+	secretKey, ok := secret.Data[AwsSecretAccessKeyName]
+	if !ok {
+		r.Logger.Errorf("Couldn't fetch key containing AWS_SECRET_ACCESS_KEY from cloud cred secret")
+		return r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
+	}
+
+	infraName, err := utils.LoadInfrastructureName(r.Client, r.Logger)
+	if err != nil {
+		return err
+	}
+	awsClient, err := r.AWSClientBuilder(accessKey, secretKey, infraName)
+	if err != nil {
+		return fmt.Errorf("error creating aws client: %v", err)
+	}
+
+	// Can we mint new creds?
+	cloudCheckResult, err := utils.CheckCloudCredCreation(awsClient, r.Logger)
+	if err != nil {
+		r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
+		return fmt.Errorf("failed checking create cloud creds: %v", err)
+	}
+
+	if cloudCheckResult {
+		r.Logger.Info("Verified cloud creds can be used for minting new creds")
+		return r.updateSecretAnnotations(secret, constants.MintAnnotation)
+	}
+
+	// Else, can we just pass through the current creds?
+	cloudCheckResult, err = utils.CheckCloudCredPassthrough(awsClient, r.Logger)
+	if err != nil {
+		r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
+		return fmt.Errorf("failed checking passthrough cloud creds: %v", err)
+	}
+
+	if cloudCheckResult {
+		r.Logger.Info("Verified cloud creds can be used as-is (passthrough)")
+		return r.updateSecretAnnotations(secret, constants.PassthroughAnnotation)
+	}
+
+	// Else, these creds aren't presently useful
+	r.Logger.Warning("Cloud creds unable to be used for either minting or passthrough")
+	return r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
+}
+
+func (r *ReconcileCloudCredSecret) updateSecretAnnotations(secret *corev1.Secret, value string) error {
+	secretAnnotations := secret.GetAnnotations()
+	if secretAnnotations == nil {
+		secretAnnotations = map[string]string{}
+	}
+
+	secretAnnotations[constants.AnnotationKey] = value
+	secret.SetAnnotations(secretAnnotations)
+
+	return r.Update(context.Background(), secret)
+}

--- a/pkg/controller/secretannotator/aws/reconciler.go
+++ b/pkg/controller/secretannotator/aws/reconciler.go
@@ -25,8 +25,7 @@ import (
 
 const (
 	// TODO: dynamically detect which environment we're running on
-	AWSCloudCredSecretName   = "aws-creds"
-	CloudCredSecretNamespace = "kube-system"
+	AWSCloudCredSecretName = "aws-creds"
 
 	AwsAccessKeyName       = "aws_access_key_id"
 	AwsSecretAccessKeyName = "aws_secret_access_key"
@@ -41,7 +40,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 }
 
 func cloudCredSecretObjectCheck(secret metav1.Object) bool {
-	return secret.GetNamespace() == CloudCredSecretNamespace && secret.GetName() == AWSCloudCredSecretName
+	return secret.GetNamespace() == constants.CloudCredSecretNamespace && secret.GetName() == AWSCloudCredSecretName
 }
 
 func Add(mgr manager.Manager, r reconcile.Reconciler) error {

--- a/pkg/controller/secretannotator/azure/reconciler.go
+++ b/pkg/controller/secretannotator/azure/reconciler.go
@@ -1,0 +1,100 @@
+package azure
+
+import (
+	"context"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
+	log "github.com/sirupsen/logrus"
+)
+
+const (
+	cloudCredSecretName      = "azure-credentials"
+	cloudCredSecretNamespace = "kube-system"
+)
+
+var _ reconcile.Reconciler = &ReconcileCloudCredSecret{}
+
+type ReconcileCloudCredSecret struct {
+	client.Client
+	Logger log.FieldLogger
+}
+
+func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
+	return &ReconcileCloudCredSecret{
+		Client: mgr.GetClient(),
+		Logger: log.WithField("controller", constants.ControllerName),
+	}
+}
+
+func Add(mgr manager.Manager, r reconcile.Reconciler) error {
+	// Create a new controller
+	c, err := controller.New(constants.ControllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// Watch for changes to cluster cloud secret
+	p := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return cloudCredSecretObjectCheck(e.MetaNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return cloudCredSecretObjectCheck(e.Meta)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return cloudCredSecretObjectCheck(e.Meta)
+		},
+	}
+	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, p)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func cloudCredSecretObjectCheck(secret metav1.Object) bool {
+	return secret.GetNamespace() == cloudCredSecretNamespace && secret.GetName() == cloudCredSecretName
+}
+
+func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	r.Logger.Info("validating cloud cred secret")
+
+	secret := &corev1.Secret{}
+	err := r.Get(context.Background(), request.NamespacedName, secret)
+	if err != nil {
+		r.Logger.Debugf("secret not found: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	r.Logger.Info("Platform is azure: using passthrough")
+	err = r.updateSecretAnnotations(secret, constants.PassthroughAnnotation)
+	if err != nil {
+		r.Logger.Errorf("error while validating cloud credentials: %v", err)
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
+}
+
+func (r *ReconcileCloudCredSecret) updateSecretAnnotations(secret *corev1.Secret, value string) error {
+	secretAnnotations := secret.GetAnnotations()
+	if secretAnnotations == nil {
+		secretAnnotations = map[string]string{}
+	}
+
+	secretAnnotations[constants.AnnotationKey] = value
+	secret.SetAnnotations(secretAnnotations)
+
+	return r.Update(context.Background(), secret)
+}

--- a/pkg/controller/secretannotator/azure/reconciler.go
+++ b/pkg/controller/secretannotator/azure/reconciler.go
@@ -19,8 +19,7 @@ import (
 )
 
 const (
-	cloudCredSecretName      = "azure-credentials"
-	cloudCredSecretNamespace = "kube-system"
+	cloudCredSecretName = "azure-credentials"
 )
 
 var _ reconcile.Reconciler = &ReconcileCloudCredSecret{}
@@ -64,7 +63,7 @@ func Add(mgr manager.Manager, r reconcile.Reconciler) error {
 }
 
 func cloudCredSecretObjectCheck(secret metav1.Object) bool {
-	return secret.GetNamespace() == cloudCredSecretNamespace && secret.GetName() == cloudCredSecretName
+	return secret.GetNamespace() == constants.CloudCredSecretNamespace && secret.GetName() == cloudCredSecretName
 }
 
 func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {

--- a/pkg/controller/secretannotator/azure/reconciler_test.go
+++ b/pkg/controller/secretannotator/azure/reconciler_test.go
@@ -1,0 +1,83 @@
+package azure_test
+
+import (
+	"context"
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	"github.com/openshift/cloud-credential-operator/pkg/apis"
+
+	ccazure "github.com/openshift/cloud-credential-operator/pkg/azure"
+	. "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/azure"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
+)
+
+const (
+	testNamespace = "test"
+)
+
+func TestAzureSecretAnnotatorReconcile(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+	configv1.Install(scheme.Scheme)
+	existingSecret := []runtime.Object{&corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "azure-credentials",
+			Namespace: testNamespace,
+		},
+		Data: map[string][]byte{
+			ccazure.AzureClientID:       []byte("AZURE_CLIENT_ID"),
+			ccazure.AzureClientSecret:   []byte("AZURE_CLIENT_SECRET"),
+			ccazure.AzureRegion:         []byte("AZURE_REGION"),
+			ccazure.AzureResourceGroup:  []byte("AZURE_RESOURCEGROUP"),
+			ccazure.AzureResourcePrefix: []byte("AZURE_RESOURCE_PREFIX"),
+			ccazure.AzureSubscriptionID: []byte("AZURE_SUBSCRIPTION_ID"),
+			ccazure.AzureTenantID:       []byte("AZURE_TENANT_ID"),
+		},
+	}}
+
+	fakeClient := fake.NewFakeClient(existingSecret...)
+
+	rcc := &ReconcileCloudCredSecret{
+		Client: fakeClient,
+		Logger: log.WithField("controller", "testController"),
+	}
+
+	_, err := rcc.Reconcile(reconcile.Request{
+		NamespacedName: types.NamespacedName{
+			Name:      "azure-credentials",
+			Namespace: testNamespace,
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	secret := &corev1.Secret{}
+	fakeClient.Get(context.TODO(), client.ObjectKey{Name: "azure-credentials", Namespace: testNamespace}, secret)
+	validateAnnotation(t, secret, annotatorconst.PassthroughAnnotation)
+}
+
+func validateAnnotation(t *testing.T, secret *corev1.Secret, annotation string) {
+	if secret.ObjectMeta.Annotations == nil {
+		t.Errorf("unexpected empty annotations on secret")
+	}
+	if _, ok := secret.ObjectMeta.Annotations[annotatorconst.AnnotationKey]; !ok {
+		t.Errorf("missing annotation")
+	}
+
+	assert.Exactly(t, annotation, secret.ObjectMeta.Annotations[annotatorconst.AnnotationKey])
+}

--- a/pkg/controller/secretannotator/constants/const.go
+++ b/pkg/controller/secretannotator/constants/const.go
@@ -1,0 +1,25 @@
+package constants
+
+const (
+	ControllerName = "secretannotator"
+
+	// TODO: dynamically detect which environment we're running on
+	CloudCredSecretName      = "aws-creds"
+	CloudCredSecretNamespace = "kube-system"
+
+	AnnotationKey = "cloudcredential.openshift.io/mode"
+
+	// MintAnnottation is used whenever it is determined that the cloud creds
+	// are sufficient for minting new creds to satisfy a CredentialsRequest
+	MintAnnotation = "mint"
+
+	// PassthroughAnnotation is used whenever it is determined that the cloud creds
+	// are sufficient for passing through to satisfy a CredentialsRequest.
+	// This would be based on having creds that can satisfy the static list of creds
+	// found in this repo's manifests/ dir.
+	PassthroughAnnotation = "passthrough"
+
+	// InsufficientAnnotation is used to indicate that the creds do not have
+	// sufficient permissions for cluster runtime.
+	InsufficientAnnotation = "insufficient"
+)

--- a/pkg/controller/secretannotator/constants/const.go
+++ b/pkg/controller/secretannotator/constants/const.go
@@ -3,8 +3,6 @@ package constants
 const (
 	ControllerName = "secretannotator"
 
-	// TODO: dynamically detect which environment we're running on
-	CloudCredSecretName      = "aws-creds"
 	CloudCredSecretNamespace = "kube-system"
 
 	AnnotationKey = "cloudcredential.openshift.io/mode"

--- a/pkg/controller/secretannotator/secretannotator_controller.go
+++ b/pkg/controller/secretannotator/secretannotator_controller.go
@@ -17,199 +17,31 @@ limitations under the License.
 package secretannotator
 
 import (
-	"context"
 	"fmt"
+	"log"
 
-	log "github.com/sirupsen/logrus"
-	"sigs.k8s.io/controller-runtime/pkg/event"
-	"sigs.k8s.io/controller-runtime/pkg/predicate"
-
-	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
+	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
-	"sigs.k8s.io/controller-runtime/pkg/reconcile"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
-	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
-)
-
-const (
-	controllerName = "secretannotator"
-
-	// TODO: dynamically detect which environment we're running on
-	CloudCredSecretName      = "aws-creds"
-	CloudCredSecretNamespace = "kube-system"
-
-	AnnotationKey = "cloudcredential.openshift.io/mode"
-
-	// MintAnnottation is used whenever it is determined that the cloud creds
-	// are sufficient for minting new creds to satisfy a CredentialsRequest
-	MintAnnotation = "mint"
-
-	// PassthroughAnnotation is used whenever it is determined that the cloud creds
-	// are sufficient for passing through to satisfy a CredentialsRequest.
-	// This would be based on having creds that can satisfy the static list of creds
-	// found in this repo's manifests/ dir.
-	PassthroughAnnotation = "passthrough"
-
-	// InsufficientAnnotation is used to indicate that the creds do not have
-	// sufficient permissions for cluster runtime.
-	InsufficientAnnotation = "insufficient"
-
-	AwsAccessKeyName       = "aws_access_key_id"
-	AwsSecretAccessKeyName = "aws_secret_access_key"
-
-	AzureClientID       = "azure_client_id"
-	AzureClientSecret   = "azure_client_secret"
-	AzureRegion         = "azure_region"
-	AzureResourceGroup  = "azure_resourcegroup"
-	AzureResourcePrefix = "azure_resource_prefix"
-	AzureSubscriptionID = "azure_subscription_id"
-	AzureTenantID       = "azure_tenant_id"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/platform"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/aws"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/azure"
 )
 
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
-}
-
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	return &ReconcileCloudCredSecret{
-		Client:           mgr.GetClient(),
-		logger:           log.WithField("controller", controllerName),
-		AWSClientBuilder: ccaws.NewClient,
-	}
-}
-
-func cloudCredSecretObjectCheck(secret metav1.Object) bool {
-	if secret.GetNamespace() == CloudCredSecretNamespace && secret.GetName() == CloudCredSecretName {
-		return true
-	}
-	return false
-}
-
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
-	// Create a new controller
-	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	platformType, err := platform.Get(mgr)
 	if err != nil {
-		return err
+		log.Fatal(err)
 	}
 
-	// Watch for changes to cluster cloud secret
-	p := predicate.Funcs{
-		UpdateFunc: func(e event.UpdateEvent) bool {
-			return cloudCredSecretObjectCheck(e.MetaNew)
-		},
-		CreateFunc: func(e event.CreateEvent) bool {
-			return cloudCredSecretObjectCheck(e.Meta)
-		},
-		DeleteFunc: func(e event.DeleteEvent) bool {
-			return cloudCredSecretObjectCheck(e.Meta)
-		},
-	}
-	err = c.Watch(&source.Kind{Type: &corev1.Secret{}}, &handler.EnqueueRequestForObject{}, p)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-var _ reconcile.Reconciler = &ReconcileCloudCredSecret{}
-
-type ReconcileCloudCredSecret struct {
-	client.Client
-	logger           log.FieldLogger
-	AWSClientBuilder func(accessKeyID, secretAccessKey []byte, infraName string) (ccaws.Client, error)
-}
-
-// Reconcile will annotate the cloud cred secret to indicate the capabilities of the cred's capabilities:
-// 1) 'mint' for indicating that the creds can be used to create new sub-creds
-// 2) 'passthrough' for indicating that the creds are capable enough for other components to reuse the creds as-is
-// 3) 'insufficient' for indicating that the creds are not usable for the cluster
-// +kubebuilder:rbac:groups=core,resources=secrets,verbs=get;list;watch;update
-func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
-	r.logger.Info("validating cloud cred secret")
-
-	secret := &corev1.Secret{}
-	err := r.Get(context.Background(), request.NamespacedName, secret)
-	if err != nil {
-		r.logger.Debugf("secret not found: %v", err)
-		return reconcile.Result{}, err
+	switch platformType {
+	case configv1.AzurePlatformType:
+		return azure.Add(mgr, azure.NewReconciler(mgr))
+	case configv1.AWSPlatformType:
+	default: // returning the AWS implementation for default to avoid changing any behavior
+		return aws.Add(mgr, aws.NewReconciler(mgr))
 	}
 
-	err = r.validateCloudCredsSecret(secret)
-	if err != nil {
-		r.logger.Errorf("error while validating cloud credentials: %v", err)
-		return reconcile.Result{}, err
-	}
-
-	return reconcile.Result{}, nil
-}
-
-func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secret) error {
-
-	accessKey, ok := secret.Data[AwsAccessKeyName]
-	if !ok {
-		r.logger.Errorf("Couldn't fetch key containing AWS_ACCESS_KEY_ID from cloud cred secret")
-		return r.updateSecretAnnotations(secret, InsufficientAnnotation)
-	}
-
-	secretKey, ok := secret.Data[AwsSecretAccessKeyName]
-	if !ok {
-		r.logger.Errorf("Couldn't fetch key containing AWS_SECRET_ACCESS_KEY from cloud cred secret")
-		return r.updateSecretAnnotations(secret, InsufficientAnnotation)
-	}
-
-	infraName, err := utils.LoadInfrastructureName(r.Client, r.logger)
-	if err != nil {
-		return err
-	}
-	awsClient, err := r.AWSClientBuilder(accessKey, secretKey, infraName)
-	if err != nil {
-		return fmt.Errorf("error creating aws client: %v", err)
-	}
-
-	// Can we mint new creds?
-	cloudCheckResult, err := utils.CheckCloudCredCreation(awsClient, r.logger)
-	if err != nil {
-		r.updateSecretAnnotations(secret, InsufficientAnnotation)
-		return fmt.Errorf("failed checking create cloud creds: %v", err)
-	}
-
-	if cloudCheckResult {
-		r.logger.Info("Verified cloud creds can be used for minting new creds")
-		return r.updateSecretAnnotations(secret, MintAnnotation)
-	}
-
-	// Else, can we just pass through the current creds?
-	cloudCheckResult, err = utils.CheckCloudCredPassthrough(awsClient, r.logger)
-	if err != nil {
-		r.updateSecretAnnotations(secret, InsufficientAnnotation)
-		return fmt.Errorf("failed checking passthrough cloud creds: %v", err)
-	}
-
-	if cloudCheckResult {
-		r.logger.Info("Verified cloud creds can be used as-is (passthrough)")
-		return r.updateSecretAnnotations(secret, PassthroughAnnotation)
-	}
-
-	// Else, these creds aren't presently useful
-	r.logger.Warning("Cloud creds unable to be used for either minting or passthrough")
-	return r.updateSecretAnnotations(secret, InsufficientAnnotation)
-}
-
-func (r *ReconcileCloudCredSecret) updateSecretAnnotations(secret *corev1.Secret, value string) error {
-	secretAnnotations := secret.GetAnnotations()
-	if secretAnnotations == nil {
-		secretAnnotations = map[string]string{}
-	}
-
-	secretAnnotations[AnnotationKey] = value
-	secret.SetAnnotations(secretAnnotations)
-
-	return r.Update(context.Background(), secret)
+	// this should never be reached, as we have a default handling in the above switch
+	return fmt.Errorf("platform not supported")
 }

--- a/pkg/controller/secretannotator/secretannotator_controller.go
+++ b/pkg/controller/secretannotator/secretannotator_controller.go
@@ -17,8 +17,6 @@ limitations under the License.
 package secretannotator
 
 import (
-	"fmt"
-
 	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -39,10 +37,8 @@ func Add(mgr manager.Manager) error {
 	case configv1.AzurePlatformType:
 		return azure.Add(mgr, azure.NewReconciler(mgr))
 	case configv1.AWSPlatformType:
+		return aws.Add(mgr, aws.NewReconciler(mgr))
 	default: // returning the AWS implementation for default to avoid changing any behavior
 		return aws.Add(mgr, aws.NewReconciler(mgr))
 	}
-
-	// this should never be reached, as we have a default handling in the above switch
-	return fmt.Errorf("platform not supported")
 }

--- a/pkg/controller/secretannotator/secretannotator_controller.go
+++ b/pkg/controller/secretannotator/secretannotator_controller.go
@@ -18,7 +18,6 @@ package secretannotator
 
 import (
 	"fmt"
-	"log"
 
 	configv1 "github.com/openshift/api/config/v1"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -26,10 +25,12 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/controller/platform"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/azure"
+	log "github.com/sirupsen/logrus"
 )
 
 func Add(mgr manager.Manager) error {
 	platformType, err := platform.Get(mgr)
+	log.Infof("Setting up secret annotator. Platform Type is %s", platformType)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/controller/utils/platform.go
+++ b/pkg/controller/utils/platform.go
@@ -1,0 +1,43 @@
+package utils
+
+import (
+	"context"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/clientcmd"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+)
+
+// PlatformType queries the ku8s api for the infrastructure config map and retrieves the current platform.
+func PlatformType(m manager.Manager) (configv1.PlatformType, error) {
+	client, err := getClient()
+	if err != nil {
+		return configv1.NonePlatformType, err
+	}
+	infraName := types.NamespacedName{Name: "cluster"}
+	infra := &configv1.Infrastructure{}
+	err = client.Get(context.Background(), infraName, infra)
+	if err != nil {
+		return configv1.NonePlatformType, err
+	}
+	return infra.Status.Platform, nil
+}
+
+func getClient() (client.Client, error) {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	kubeconfig := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, &clientcmd.ConfigOverrides{})
+	cfg, err := kubeconfig.ClientConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	//apis.AddToScheme(scheme.Scheme)
+	dynamicClient, err := client.New(cfg, client.Options{})
+	if err != nil {
+		return nil, err
+	}
+
+	return dynamicClient, nil
+}


### PR DESCRIPTION
The current azure passthrough setup forgot to implement the `secretannotator` for azure. 
As a result, no credentials where ever delivered in response to a credential request.

To resolve that : 

- added the azure implementation for the secret-annotator
  - moved aws in its own package `pkg/controller/secretannotator/aws`
  - added `pkg/controller/secretannotator/azure`
  - made `pkg/controller/secretannotator/controller.go` decide on which implementation to run depending on the platform

to make this refactoring possible, some parts had to move around :

- added `pkg/controller/platform` that retrieves the `platformtype` from a `Manager`
- added a `pkg/controller/secretannotator/constants` package to make it possible to share variables across the different packages without circular dependencies
- moved aws secretannotator tests under aws, and azure ones under azure

The code structure has changed quite a bit, but apart from the switch case in secretannotator, the aws logic is untouched, and there is a single place where the code path splits, which should reduce risks of impacting the existing.

@juan-lee @abhinavdahiya 