### PR TITLE
Drop memory limits on operator deployment.

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -67,8 +67,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         resources:
-          limits:
-            memory: 500Mi
           requests:
             cpu: 10m
             memory: 150Mi


### PR DESCRIPTION
CCO found to crash loop on clusters with 2000+ namespaces. Remove this
arbitrary restriction.