### PR TITLE
generate deployment and crd into the right filename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin/*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE stuff
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go rbac --name cloud-credential-operator
 	# kustomize and move to manifests dir for release image:
-	kustomize build config > manifests/0000_30_cloud-credential-operator_01_deployment.yaml
-	cp config/crds/cloudcredential_v1_credentialsrequest.yaml manifests/0000_30_cloud-credential-operator_00_v1_crd.yaml
+	kustomize build config > manifests/01_deployment.yaml
+	cp config/crds/cloudcredential_v1_credentialsrequest.yaml manifests/00_v1_crd.yaml
 
 # Run go fmt against code
 fmt:

--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -159,8 +159,6 @@ spec:
           name: webhook-server
           protocol: TCP
         resources:
-          limits:
-            memory: 500Mi
           requests:
             cpu: 10m
             memory: 150Mi
@@ -170,14 +168,14 @@ spec:
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 10
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "node.kubernetes.io/unreachable"
-        operator: "Exists"
-        effect: "NoExecute"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
         tolerationSeconds: 120
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoExecute"
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
         tolerationSeconds: 120


### PR DESCRIPTION
remove the memory limit as originally intented in #68.

the deployment yaml changes are a no-op. just changes the order of the keys.

update the location where we copy the crd to (match the current filenames in manifets/*).

update gitignore to cover vscode directories.