### PR TITLE
Separate packages imported by installer from packages importing controller-runtime client

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -231,7 +231,7 @@ func (a *AWSActuator) needsUpdate(ctx context.Context, cr *minterv1.CredentialsR
 
 	} else {
 		// for passthrough creds, just see if we have the permissions requested in the credentialsrequest
-		goodEnough, err := utils.CheckPermissionsUsingQueryClient(readAWSClient, awsClient, awsSpec.StatementEntries, logger)
+		goodEnough, err := ccaws.CheckPermissionsUsingQueryClient(readAWSClient, awsClient, awsSpec.StatementEntries, logger)
 		if err != nil {
 			return true, fmt.Errorf("error validating whether current creds are good enough: %v", err)
 		}
@@ -732,7 +732,7 @@ func (a *AWSActuator) buildRootAWSClient(cr *minterv1.CredentialsRequest, infraN
 	logger.Debug("loading AWS credentials from secret")
 	// TODO: Running in a 4.0 cluster we expect this secret to exist. When we run in a Hive
 	// cluster, we need to load different secrets for each cluster.
-	accessKeyID, secretAccessKey, err := minteraws.LoadCredsFromSecret(a.Client, rootAWSCredsSecretNamespace, rootAWSCredsSecret)
+	accessKeyID, secretAccessKey, err := utils.LoadCredsFromSecret(a.Client, rootAWSCredsSecretNamespace, rootAWSCredsSecret)
 	if err != nil {
 		return nil, err
 	}
@@ -759,14 +759,14 @@ func (a *AWSActuator) buildReadAWSClient(cr *minterv1.CredentialsRequest, infraN
 	// If we're operating on those credentials, just use the root creds.
 	if cr.Spec.SecretRef.Name == roAWSCredsSecret && cr.Spec.SecretRef.Namespace == roAWSCredsSecretNamespace {
 		log.Debug("operating our our RO creds, using root creds for all AWS client operations")
-		accessKeyID, secretAccessKey, err = minteraws.LoadCredsFromSecret(a.Client, rootAWSCredsSecretNamespace, rootAWSCredsSecret)
+		accessKeyID, secretAccessKey, err = utils.LoadCredsFromSecret(a.Client, rootAWSCredsSecretNamespace, rootAWSCredsSecret)
 		if err != nil {
 			return nil, err
 		}
 	} else {
 		// TODO: Running in a 4.0 cluster we expect this secret to exist. When we run in a Hive
 		// cluster, we need to load different secrets for each cluster.
-		accessKeyID, secretAccessKey, err = minteraws.LoadCredsFromSecret(a.Client, roAWSCredsSecretNamespace, roAWSCredsSecret)
+		accessKeyID, secretAccessKey, err = utils.LoadCredsFromSecret(a.Client, roAWSCredsSecretNamespace, roAWSCredsSecret)
 		if err != nil {
 			if errors.IsNotFound(err) {
 				logger.Warn("read-only creds not found, using root creds client")

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -17,14 +17,6 @@ limitations under the License.
 package aws
 
 import (
-	"context"
-	"fmt"
-
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/types"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/request"
@@ -32,11 +24,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/iam/iamiface"
 	"github.com/openshift/cloud-credential-operator/version"
-)
-
-const (
-	awsCredsSecretIDKey     = "aws_access_key_id"
-	awsCredsSecretAccessKey = "aws_secret_access_key"
 )
 
 //go:generate mockgen -source=./client.go -destination=./mock/client_generated.go -package=mock
@@ -128,29 +115,4 @@ func NewClient(accessKeyID, secretAccessKey []byte, infraName string) (Client, e
 	return &awsClient{
 		iamClient: iam.New(s),
 	}, nil
-}
-
-func LoadCredsFromSecret(kubeClient client.Client, namespace, secretName string) ([]byte, []byte, error) {
-
-	secret := &corev1.Secret{}
-	err := kubeClient.Get(context.TODO(),
-		types.NamespacedName{
-			Name:      secretName,
-			Namespace: namespace,
-		},
-		secret)
-	if err != nil {
-		return nil, nil, err
-	}
-	accessKeyID, ok := secret.Data[awsCredsSecretIDKey]
-	if !ok {
-		return nil, nil, fmt.Errorf("AWS credentials secret %v did not contain key %v",
-			secretName, awsCredsSecretIDKey)
-	}
-	secretAccessKey, ok := secret.Data[awsCredsSecretAccessKey]
-	if !ok {
-		return nil, nil, fmt.Errorf("AWS credentials secret %v did not contain key %v",
-			secretName, awsCredsSecretAccessKey)
-	}
-	return accessKeyID, secretAccessKey, nil
 }

--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -1,0 +1,245 @@
+package aws
+
+import (
+	"fmt"
+
+	log "github.com/sirupsen/logrus"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/arn"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/serializer"
+)
+
+// credMintingActions is a list of AWS verbs needed to run in the mode where the
+// cloud-credential-operator can mint new creds to satisfy CredentialRequest CRDs
+var (
+	credMintingActions = []string{
+		"iam:CreateAccessKey",
+		"iam:CreateUser",
+		"iam:DeleteAccessKey",
+		"iam:DeleteUser",
+		"iam:DeleteUserPolicy",
+		"iam:GetUser",
+		"iam:GetUserPolicy",
+		"iam:ListAccessKeys",
+		"iam:PutUserPolicy",
+		"iam:TagUser",
+		"iam:SimulatePrincipalPolicy", // needed so we can verify the above list of course
+	}
+
+	credPassthroughActions = []string{
+		// so we can query whether we have the below list of creds
+		"iam:GetUser",
+		"iam:SimulatePrincipalPolicy",
+
+		// openshift-ingress
+		"elasticloadbalancing:DescribeLoadBalancers",
+		"route53:ListHostedZones",
+		"route53:ChangeResourceRecordSets",
+		"tag:GetResources",
+
+		// openshift-image-registry
+		"s3:CreateBucket",
+		"s3:DeleteBucket",
+		"s3:PutBucketTagging",
+		"s3:GetBucketTagging",
+		"s3:PutEncryptionConfiguration",
+		"s3:GetEncryptionConfiguration",
+		"s3:PutLifecycleConfiguration",
+		"s3:GetLifecycleConfiguration",
+		"s3:GetBucketLocation",
+		"s3:ListBucket",
+		"s3:HeadBucket",
+		"s3:GetObject",
+		"s3:PutObject",
+		"s3:DeleteObject",
+		"s3:ListBucketMultipartUploads",
+		"s3:AbortMultipartUpload",
+
+		// openshift-cluster-api
+		"ec2:DescribeImages",
+		"ec2:DescribeVpcs",
+		"ec2:DescribeSubnets",
+		"ec2:DescribeAvailabilityZones",
+		"ec2:DescribeSecurityGroups",
+		"ec2:RunInstances",
+		"ec2:DescribeInstances",
+		"ec2:TerminateInstances",
+		"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+		"elasticloadbalancing:DescribeLoadBalancers",
+		"elasticloadbalancing:DescribeTargetGroups",
+		"elasticloadbalancing:RegisterTargets",
+		"ec2:DescribeVpcs",
+		"ec2:DescribeSubnets",
+		"ec2:DescribeAvailabilityZones",
+		"ec2:DescribeSecurityGroups",
+		"ec2:RunInstances",
+		"ec2:DescribeInstances",
+		"ec2:TerminateInstances",
+		"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
+		"elasticloadbalancing:DescribeLoadBalancers",
+		"elasticloadbalancing:DescribeTargetGroups",
+		"elasticloadbalancing:RegisterTargets",
+
+		// iam-ro
+		"iam:GetUser",
+		"iam:GetUserPolicy",
+		"iam:ListAccessKeys",
+	}
+
+	credentailRequestScheme = runtime.NewScheme()
+	credentialRequestCodec  = serializer.NewCodecFactory(credentailRequestScheme)
+)
+
+const (
+	infrastructureConfigName = "cluster"
+)
+
+func init() {
+	if err := minterv1.AddToScheme(credentailRequestScheme); err != nil {
+		panic(err)
+	}
+}
+
+// CheckCloudCredCreation will see whether we have enough permissions to create new sub-creds
+func CheckCloudCredCreation(awsClient Client, logger log.FieldLogger) (bool, error) {
+	return CheckPermissionsAgainstActions(awsClient, credMintingActions, logger)
+}
+
+// getClientDetails will return the *iam.User associated with the provided client's credentials,
+// a boolean indicating whether the user is the 'root' account, and any error encountered
+// while trying to gather the info.
+func getClientDetails(awsClient Client) (*iam.User, bool, error) {
+	rootUser := false
+
+	user, err := awsClient.GetUser(nil)
+	if err != nil {
+		return nil, rootUser, fmt.Errorf("error querying username: %v", err)
+	}
+
+	// Detect whether the AWS account's root user is being used
+	parsed, err := arn.Parse(*user.User.Arn)
+	if err != nil {
+		return nil, rootUser, fmt.Errorf("error parsing user's ARN: %v", err)
+	}
+	if parsed.AccountID == *user.User.UserId {
+		rootUser = true
+	}
+
+	return user.User, rootUser, nil
+}
+
+// CheckPermissionsUsingQueryClient will use queryClient to query whether the credentials in targetClient can perform the actions
+// listed in the statementEntries. queryClient will need iam:GetUser and iam:SimulatePrincipalPolicy
+func CheckPermissionsUsingQueryClient(queryClient, targetClient Client, statementEntries []minterv1.StatementEntry, logger log.FieldLogger) (bool, error) {
+	targetUser, isRoot, err := getClientDetails(targetClient)
+	if err != nil {
+		return false, fmt.Errorf("error gathering AWS credentials details: %v", err)
+	}
+	if isRoot {
+		// warn about using the root creds, and just return that the creds are good enough
+		logger.Warn("Using the AWS account root user is not recommended: https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html")
+		return true, nil
+	}
+
+	allowList := []*string{}
+	for _, statement := range statementEntries {
+		for _, action := range statement.Action {
+			allowList = append(allowList, aws.String(action))
+		}
+	}
+
+	results, err := queryClient.SimulatePrincipalPolicy(&iam.SimulatePrincipalPolicyInput{
+		PolicySourceArn: targetUser.Arn,
+		ActionNames:     allowList,
+	})
+	if err != nil {
+		return false, fmt.Errorf("error simulating policy: %v", err)
+	}
+
+	// Either they are all allowed and we return 'true', or it's a failure
+	allClear := true
+	for _, result := range results.EvaluationResults {
+		if *result.EvalDecision != "allowed" {
+			// Don't return on the first failure, so we can log the full list
+			// of failed/denied actions
+			logger.WithField("action", *result.EvalActionName).Warning("Action not allowed with tested creds")
+			allClear = false
+		}
+	}
+
+	if !allClear {
+		logger.Warningf("Tested creds not able to perform all requested actions")
+		return false, nil
+	}
+
+	return true, nil
+
+}
+
+// CheckPermissionsAgainstStatementList will test to see whether the list of actions in the provided
+// list of StatementEntries can work with the credentials used by the passed-in awsClient
+func CheckPermissionsAgainstStatementList(awsClient Client, statementEntries []minterv1.StatementEntry, logger log.FieldLogger) (bool, error) {
+	return CheckPermissionsUsingQueryClient(awsClient, awsClient, statementEntries, logger)
+}
+
+// CheckPermissionsAgainstActions will take the static list of Actions to check whether the provided
+// awsClient creds have sufficient permissions to perform the actions.
+// Will return true/false indicating whether the permissions are sufficient.
+func CheckPermissionsAgainstActions(awsClient Client, actionList []string, logger log.FieldLogger) (bool, error) {
+	statementList := []minterv1.StatementEntry{
+		{
+			Action:   actionList,
+			Resource: "*",
+			Effect:   "Allow",
+		},
+	}
+
+	return CheckPermissionsAgainstStatementList(awsClient, statementList, logger)
+}
+
+// CheckCloudCredPassthrough will see if the provided creds are good enough to pass through
+// to other components as-is based on the static list of permissions needed by the various
+// users of CredentialsRequests
+// TODO: move away from static list (to dynamic passthrough validation?)
+func CheckCloudCredPassthrough(awsClient Client, logger log.FieldLogger) (bool, error) {
+	return CheckPermissionsAgainstActions(awsClient, credPassthroughActions, logger)
+}
+
+func readCredentialRequest(cr []byte) (*minterv1.CredentialsRequest, error) {
+
+	newObj, err := runtime.Decode(credentialRequestCodec.UniversalDecoder(minterv1.SchemeGroupVersion), cr)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding credentialrequest: %v", err)
+	}
+	return newObj.(*minterv1.CredentialsRequest), nil
+}
+
+func getCredentialRequestStatements(crBytes []byte) ([]minterv1.StatementEntry, error) {
+	statementList := []minterv1.StatementEntry{}
+
+	awsCodec, err := minterv1.NewCodec()
+	if err != nil {
+		return statementList, fmt.Errorf("error creating credentialrequest codec: %v", err)
+	}
+
+	cr, err := readCredentialRequest(crBytes)
+	if err != nil {
+		return statementList, err
+	}
+
+	awsSpec := minterv1.AWSProviderSpec{}
+	err = awsCodec.DecodeProviderSpec(cr.Spec.ProviderSpec, &awsSpec)
+	if err != nil {
+		return statementList, fmt.Errorf("error decoding spec.ProviderSpec: %v", err)
+	}
+
+	statementList = append(statementList, awsSpec.StatementEntries...)
+
+	return statementList, nil
+}

--- a/pkg/controller/secretannotator/aws/reconciler.go
+++ b/pkg/controller/secretannotator/aws/reconciler.go
@@ -124,7 +124,7 @@ func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secre
 	}
 
 	// Can we mint new creds?
-	cloudCheckResult, err := utils.CheckCloudCredCreation(awsClient, r.Logger)
+	cloudCheckResult, err := ccaws.CheckCloudCredCreation(awsClient, r.Logger)
 	if err != nil {
 		r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
 		return fmt.Errorf("failed checking create cloud creds: %v", err)
@@ -136,7 +136,7 @@ func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secre
 	}
 
 	// Else, can we just pass through the current creds?
-	cloudCheckResult, err = utils.CheckCloudCredPassthrough(awsClient, r.Logger)
+	cloudCheckResult, err = ccaws.CheckCloudCredPassthrough(awsClient, r.Logger)
 	if err != nil {
 		r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
 		return fmt.Errorf("failed checking passthrough cloud creds: %v", err)

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -4,113 +4,44 @@ import (
 	"context"
 	"fmt"
 
-	log "github.com/sirupsen/logrus"
-
-	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
-	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	log "github.com/sirupsen/logrus"
+
 	configv1 "github.com/openshift/api/config/v1"
-
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/arn"
-	"github.com/aws/aws-sdk-go/service/iam"
-
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/apimachinery/pkg/runtime/serializer"
-	"k8s.io/apimachinery/pkg/types"
-)
-
-// credMintingActions is a list of AWS verbs needed to run in the mode where the
-// cloud-credential-operator can mint new creds to satisfy CredentialRequest CRDs
-var (
-	credMintingActions = []string{
-		"iam:CreateAccessKey",
-		"iam:CreateUser",
-		"iam:DeleteAccessKey",
-		"iam:DeleteUser",
-		"iam:DeleteUserPolicy",
-		"iam:GetUser",
-		"iam:GetUserPolicy",
-		"iam:ListAccessKeys",
-		"iam:PutUserPolicy",
-		"iam:TagUser",
-		"iam:SimulatePrincipalPolicy", // needed so we can verify the above list of course
-	}
-
-	credPassthroughActions = []string{
-		// so we can query whether we have the below list of creds
-		"iam:GetUser",
-		"iam:SimulatePrincipalPolicy",
-
-		// openshift-ingress
-		"elasticloadbalancing:DescribeLoadBalancers",
-		"route53:ListHostedZones",
-		"route53:ChangeResourceRecordSets",
-		"tag:GetResources",
-
-		// openshift-image-registry
-		"s3:CreateBucket",
-		"s3:DeleteBucket",
-		"s3:PutBucketTagging",
-		"s3:GetBucketTagging",
-		"s3:PutEncryptionConfiguration",
-		"s3:GetEncryptionConfiguration",
-		"s3:PutLifecycleConfiguration",
-		"s3:GetLifecycleConfiguration",
-		"s3:GetBucketLocation",
-		"s3:ListBucket",
-		"s3:HeadBucket",
-		"s3:GetObject",
-		"s3:PutObject",
-		"s3:DeleteObject",
-		"s3:ListBucketMultipartUploads",
-		"s3:AbortMultipartUpload",
-
-		// openshift-cluster-api
-		"ec2:DescribeImages",
-		"ec2:DescribeVpcs",
-		"ec2:DescribeSubnets",
-		"ec2:DescribeAvailabilityZones",
-		"ec2:DescribeSecurityGroups",
-		"ec2:RunInstances",
-		"ec2:DescribeInstances",
-		"ec2:TerminateInstances",
-		"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-		"elasticloadbalancing:DescribeLoadBalancers",
-		"elasticloadbalancing:DescribeTargetGroups",
-		"elasticloadbalancing:RegisterTargets",
-		"ec2:DescribeVpcs",
-		"ec2:DescribeSubnets",
-		"ec2:DescribeAvailabilityZones",
-		"ec2:DescribeSecurityGroups",
-		"ec2:RunInstances",
-		"ec2:DescribeInstances",
-		"ec2:TerminateInstances",
-		"elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-		"elasticloadbalancing:DescribeLoadBalancers",
-		"elasticloadbalancing:DescribeTargetGroups",
-		"elasticloadbalancing:RegisterTargets",
-
-		// iam-ro
-		"iam:GetUser",
-		"iam:GetUserPolicy",
-		"iam:ListAccessKeys",
-	}
-
-	credentailRequestScheme = runtime.NewScheme()
-	credentialRequestCodec  = serializer.NewCodecFactory(credentailRequestScheme)
 )
 
 const (
-	infrastructureConfigName = "cluster"
+	awsCredsSecretIDKey     = "aws_access_key_id"
+	awsCredsSecretAccessKey = "aws_secret_access_key"
 )
 
-func init() {
-	if err := minterv1.AddToScheme(credentailRequestScheme); err != nil {
-		panic(err)
+func LoadCredsFromSecret(kubeClient client.Client, namespace, secretName string) ([]byte, []byte, error) {
+
+	secret := &corev1.Secret{}
+	err := kubeClient.Get(context.TODO(),
+		types.NamespacedName{
+			Name:      secretName,
+			Namespace: namespace,
+		},
+		secret)
+	if err != nil {
+		return nil, nil, err
 	}
+	accessKeyID, ok := secret.Data[awsCredsSecretIDKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("AWS credentials secret %v did not contain key %v",
+			secretName, awsCredsSecretIDKey)
+	}
+	secretAccessKey, ok := secret.Data[awsCredsSecretAccessKey]
+	if !ok {
+		return nil, nil, fmt.Errorf("AWS credentials secret %v did not contain key %v",
+			secretName, awsCredsSecretAccessKey)
+	}
+	return accessKeyID, secretAccessKey, nil
 }
 
 // LoadInfrastructureName loads the cluster Infrastructure config and returns the infra name
@@ -126,142 +57,4 @@ func LoadInfrastructureName(c client.Client, logger log.FieldLogger) (string, er
 	logger.Debugf("Loaded infrastructure name: %s", infra.Status.InfrastructureName)
 	return infra.Status.InfrastructureName, nil
 
-}
-
-// CheckCloudCredCreation will see whether we have enough permissions to create new sub-creds
-func CheckCloudCredCreation(awsClient ccaws.Client, logger log.FieldLogger) (bool, error) {
-	return CheckPermissionsAgainstActions(awsClient, credMintingActions, logger)
-}
-
-// getClientDetails will return the *iam.User associated with the provided client's credentials,
-// a boolean indicating whether the user is the 'root' account, and any error encountered
-// while trying to gather the info.
-func getClientDetails(awsClient ccaws.Client) (*iam.User, bool, error) {
-	rootUser := false
-
-	user, err := awsClient.GetUser(nil)
-	if err != nil {
-		return nil, rootUser, fmt.Errorf("error querying username: %v", err)
-	}
-
-	// Detect whether the AWS account's root user is being used
-	parsed, err := arn.Parse(*user.User.Arn)
-	if err != nil {
-		return nil, rootUser, fmt.Errorf("error parsing user's ARN: %v", err)
-	}
-	if parsed.AccountID == *user.User.UserId {
-		rootUser = true
-	}
-
-	return user.User, rootUser, nil
-}
-
-// CheckPermissionsUsingQueryClient will use queryClient to query whether the credentials in targetClient can perform the actions
-// listed in the statementEntries. queryClient will need iam:GetUser and iam:SimulatePrincipalPolicy
-func CheckPermissionsUsingQueryClient(queryClient, targetClient ccaws.Client, statementEntries []minterv1.StatementEntry, logger log.FieldLogger) (bool, error) {
-	targetUser, isRoot, err := getClientDetails(targetClient)
-	if err != nil {
-		return false, fmt.Errorf("error gathering AWS credentials details: %v", err)
-	}
-	if isRoot {
-		// warn about using the root creds, and just return that the creds are good enough
-		logger.Warn("Using the AWS account root user is not recommended: https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html")
-		return true, nil
-	}
-
-	allowList := []*string{}
-	for _, statement := range statementEntries {
-		for _, action := range statement.Action {
-			allowList = append(allowList, aws.String(action))
-		}
-	}
-
-	results, err := queryClient.SimulatePrincipalPolicy(&iam.SimulatePrincipalPolicyInput{
-		PolicySourceArn: targetUser.Arn,
-		ActionNames:     allowList,
-	})
-	if err != nil {
-		return false, fmt.Errorf("error simulating policy: %v", err)
-	}
-
-	// Either they are all allowed and we return 'true', or it's a failure
-	allClear := true
-	for _, result := range results.EvaluationResults {
-		if *result.EvalDecision != "allowed" {
-			// Don't return on the first failure, so we can log the full list
-			// of failed/denied actions
-			logger.WithField("action", *result.EvalActionName).Warning("Action not allowed with tested creds")
-			allClear = false
-		}
-	}
-
-	if !allClear {
-		logger.Warningf("Tested creds not able to perform all requested actions")
-		return false, nil
-	}
-
-	return true, nil
-
-}
-
-// CheckPermissionsAgainstStatementList will test to see whether the list of actions in the provided
-// list of StatementEntries can work with the credentials used by the passed-in awsClient
-func CheckPermissionsAgainstStatementList(awsClient ccaws.Client, statementEntries []minterv1.StatementEntry, logger log.FieldLogger) (bool, error) {
-	return CheckPermissionsUsingQueryClient(awsClient, awsClient, statementEntries, logger)
-}
-
-// CheckPermissionsAgainstActions will take the static list of Actions to check whether the provided
-// awsClient creds have sufficient permissions to perform the actions.
-// Will return true/false indicating whether the permissions are sufficient.
-func CheckPermissionsAgainstActions(awsClient ccaws.Client, actionList []string, logger log.FieldLogger) (bool, error) {
-	statementList := []minterv1.StatementEntry{
-		{
-			Action:   actionList,
-			Resource: "*",
-			Effect:   "Allow",
-		},
-	}
-
-	return CheckPermissionsAgainstStatementList(awsClient, statementList, logger)
-}
-
-// CheckCloudCredPassthrough will see if the provided creds are good enough to pass through
-// to other components as-is based on the static list of permissions needed by the various
-// users of CredentialsRequests
-// TODO: move away from static list (to dynamic passthrough validation?)
-func CheckCloudCredPassthrough(awsClient ccaws.Client, logger log.FieldLogger) (bool, error) {
-	return CheckPermissionsAgainstActions(awsClient, credPassthroughActions, logger)
-}
-
-func readCredentialRequest(cr []byte) (*minterv1.CredentialsRequest, error) {
-
-	newObj, err := runtime.Decode(credentialRequestCodec.UniversalDecoder(minterv1.SchemeGroupVersion), cr)
-	if err != nil {
-		return nil, fmt.Errorf("error decoding credentialrequest: %v", err)
-	}
-	return newObj.(*minterv1.CredentialsRequest), nil
-}
-
-func getCredentialRequestStatements(crBytes []byte) ([]minterv1.StatementEntry, error) {
-	statementList := []minterv1.StatementEntry{}
-
-	awsCodec, err := minterv1.NewCodec()
-	if err != nil {
-		return statementList, fmt.Errorf("error creating credentialrequest codec: %v", err)
-	}
-
-	cr, err := readCredentialRequest(crBytes)
-	if err != nil {
-		return statementList, err
-	}
-
-	awsSpec := minterv1.AWSProviderSpec{}
-	err = awsCodec.DecodeProviderSpec(cr.Spec.ProviderSpec, &awsSpec)
-	if err != nil {
-		return statementList, fmt.Errorf("error decoding spec.ProviderSpec: %v", err)
-	}
-
-	statementList = append(statementList, awsSpec.StatementEntries...)
-
-	return statementList, nil
 }


### PR DESCRIPTION
Right now, the installer imports the following packages:

```go
ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
credvalidator "github.com/openshift/cloud-credential-operator/pkg/controller/utils"
```
Disadvantage of the current layout in `cloud-controller-operator` repo causes
`sigs.k8s.io/controller-runtime/pkg/client` package to be imported as well.
The newer version of `sigs.k8s.io/controller-runtime/pkg/client` package requires new
data type(s) from `k8s.io/apimachinery` which are not available in k8s 1.12 (which
is currently imported by the installer).

Also most of the exported methods/functions were used solely by aws part
of the cloud-controller-operator. Moving aws specific bits under pkg/aws
improves importability by other projects and removes the need
for importing `sigs.k8s.io/controller-runtime/pkg/client` bits that are
not used be the installer anyway.