### PR TITLE
Bug 1723892: Backport removal of memory restrictions for cred operator.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ bin/*
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+# IDE stuff
+.vscode

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go rbac --name cloud-credential-operator
 	# kustomize and move to manifests dir for release image:
-	kustomize build config > manifests/0000_30_cloud-credential-operator_01_deployment.yaml
-	cp config/crds/cloudcredential_v1_credentialsrequest.yaml manifests/0000_30_cloud-credential-operator_00_v1_crd.yaml
+	kustomize build config > manifests/01_deployment.yaml
+	cp config/crds/cloudcredential_v1_credentialsrequest.yaml manifests/00_v1_crd.yaml
 
 # Run go fmt against code
 fmt:

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -67,8 +67,6 @@ spec:
         imagePullPolicy: IfNotPresent
         name: manager
         resources:
-          limits:
-            memory: 500Mi
           requests:
             cpu: 10m
             memory: 150Mi

--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -159,8 +159,6 @@ spec:
           name: webhook-server
           protocol: TCP
         resources:
-          limits:
-            memory: 500Mi
           requests:
             cpu: 10m
             memory: 150Mi
@@ -170,14 +168,14 @@ spec:
       priorityClassName: system-cluster-critical
       terminationGracePeriodSeconds: 10
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: "Exists"
-        effect: "NoSchedule"
-      - key: "node.kubernetes.io/unreachable"
-        operator: "Exists"
-        effect: "NoExecute"
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
         tolerationSeconds: 120
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoExecute"
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
         tolerationSeconds: 120


### PR DESCRIPTION
Backport two commits to drop the memory limits on the cred operator pods:

9e492ed1565900c559c203618eda274e5caf13ff
f19a108f3585806f24c04ca72275f214bcd217e6

 This prevents OOMs in large clusters with a lot of namespaces or secrets.