### PR TITLE
ignore credentialsRequests for other clouds

### DIFF
--- a/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
+++ b/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
@@ -131,6 +131,12 @@ const (
 	// CredentialsDeprovisionFailure is true whenever there is an error when trying
 	// to clean up any previously-created cloud resources
 	CredentialsDeprovisionFailure CredentialsRequestConditionType = "CredentialsDeprovisionFailure"
+	// Ignored is true when the CredentialsRequest's ProviderSpec is for
+	// a different infrastructure platform than what the cluster has been
+	// deployed to. This is normal as the release image contains CredentialsRequests for all
+	// possible clouds/infrastructure, and cloud-credential-operator will only act on the
+	// CredentialsRequests where the cloud/infra matches.
+	Ignored CredentialsRequestConditionType = "Ignored"
 )
 
 func init() {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -40,7 +40,7 @@ const (
 var AddToManagerFuncs []func(manager.Manager) error
 
 // AddToManagerWithActuatorFuncs is a list of functions to add all Controllers with Actuators to the Manager
-var AddToManagerWithActuatorFuncs []func(manager.Manager, actuator.Actuator) error
+var AddToManagerWithActuatorFuncs []func(manager.Manager, actuator.Actuator, configv1.PlatformType) error
 
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m manager.Manager) error {
@@ -88,7 +88,7 @@ func AddToManager(m manager.Manager) error {
 			log.Info("initializing no-op actuator (unsupported platform)")
 			a = &actuator.DummyActuator{}
 		}
-		if err := f(m, a); err != nil {
+		if err := f(m, a, plat); err != nil {
 			return err
 		}
 	}

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -386,6 +386,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 						return mockRootGCPClient, nil
 					},
 				},
+				platformType: configv1.GCPPlatformType,
 			}
 
 			_, err := rcr.Reconcile(reconcile.Request{
@@ -440,6 +441,9 @@ func testGCPCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
 
 	gcpStatus, err := codec.EncodeProviderStatus(
 		&minterv1.GCPProviderStatus{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GCPProviderSpec",
+			},
 			ServiceAccountID: testGCPServiceAccountID,
 		},
 	)
@@ -470,6 +474,9 @@ func testGCPPassthroughCredentialsRequest(t *testing.T) *minterv1.CredentialsReq
 	}
 	gcpProvSpec, err := codec.EncodeProviderSpec(
 		&minterv1.GCPProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GCPProviderSpec",
+			},
 			PredefinedRoles: []string{
 				testRoleName,
 			},

--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -12,6 +13,8 @@ import (
 	log "github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 )
 
 const (
@@ -57,4 +60,19 @@ func LoadInfrastructureName(c client.Client, logger log.FieldLogger) (string, er
 	logger.Debugf("Loaded infrastructure name: %s", infra.Status.InfrastructureName)
 	return infra.Status.InfrastructureName, nil
 
+}
+
+// GetCredentialsRequestCloudType decodes a Spec.ProviderSpec and returns the kind
+// field.
+func GetCredentialsRequestCloudType(providerSpec *runtime.RawExtension) (string, error) {
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		return "", err
+	}
+	unknown := runtime.Unknown{}
+	err = codec.DecodeProviderSpec(providerSpec, &unknown)
+	if err != nil {
+		return "", err
+	}
+	return unknown.Kind, nil
 }


### PR DESCRIPTION
currently COO will go down a codepath for CredentialsRequest objects that are intended for a different cloud such that the Status.Provisioned will show True even though the credrequest was ignored.
    
fix up the credentialsrequest controller to actively ignore credentialsrequests for different cloud platforms than the one the cluster has been deployed to.
    
update the status calculation to also ignore the invalid credentialsrequests objects when reporting the cluster operator status.

TODO: add condition to credRequests for other clouds/platforms

this PR builds on top of #77 