### PR TITLE
Bug 1726451: Add clusteroperator version level gate.

### DIFF
--- a/manifests/10_cluster-operator.yaml
+++ b/manifests/10_cluster-operator.yaml
@@ -2,3 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: cloud-credential
+status:
+  versions:
+  - name: operator
+    version: "0.0.1-snapshot"
+


### PR DESCRIPTION
This should prevent scenarios where the CVO proceeds without waiting for
the cred operator to report success.