### PR TITLE
implement GCP passthrough mode (and add service API checks)

### DIFF
--- a/pkg/controller/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller.go
@@ -420,6 +420,8 @@ func (r *ReconcileCredentialsRequest) Reconcile(request reconcile.Request) (reco
 	}
 	if syncErr != nil {
 		logger.Errorf("error syncing credentials: %v", syncErr)
+		// TODO: set condition if previously satisfied credrequest can now
+		// not be satisfied (but keeping provisioned==True).
 		cr.Status.Provisioned = false
 
 		switch t := syncErr.(type) {

--- a/pkg/controller/utils/gcp/utils_test.go
+++ b/pkg/controller/utils/gcp/utils_test.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2019 The OpenShift Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package gcp
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestPermissionsFiltering(t *testing.T) {
+	tests := []struct {
+		name             string
+		origPermList     []string
+		filterOutList    []string
+		expectedPermList []string
+	}{
+		{
+			name: "leave original list untouched",
+			origPermList: []string{
+				"permA",
+				"permB",
+				"permC",
+			},
+			filterOutList: []string{
+				"permX",
+				"permY",
+				"permZ",
+			},
+			expectedPermList: []string{
+				"permA",
+				"permB",
+				"permC",
+			},
+		},
+		{
+			name: "filter out perms",
+			origPermList: []string{
+				"permA",
+				"permB",
+				"permC",
+				"permD",
+			},
+			filterOutList: []string{
+				"permB",
+				"permC",
+				"permZ",
+			},
+			expectedPermList: []string{
+				"permA",
+				"permD",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			filteredPerms := filterOutPermissions(test.origPermList, test.filterOutList)
+
+			assert.Equal(t, len(test.expectedPermList), len(filteredPerms))
+
+			for _, expectedPerm := range test.expectedPermList {
+				found := false
+				for _, filteredPerm := range filteredPerms {
+					if expectedPerm == filteredPerm {
+						found = true
+						break
+					}
+				}
+				assert.True(t, found, "Did not find expected perm in list")
+			}
+
+		})
+	}
+}

--- a/pkg/gcp/actuator/role.go
+++ b/pkg/gcp/actuator/role.go
@@ -1,0 +1,47 @@
+/*
+Copyright 2019 The OpenShift Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actuator
+
+import (
+	"context"
+	"fmt"
+
+	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	ccgcp "github.com/openshift/cloud-credential-operator/pkg/gcp"
+)
+
+func getPermissionsFromRoles(gcpClient ccgcp.Client, roles []string) ([]string, error) {
+	permList := []string{}
+
+	for _, roleName := range roles {
+		role, err := gcpClient.GetRole(context.TODO(), &iamadminpb.GetRoleRequest{
+			Name: roleName,
+		})
+		if status.Code(err) == codes.NotFound {
+			return permList, fmt.Errorf("role %s not found: %v", roleName, err)
+		} else if err != nil {
+			return permList, fmt.Errorf("error getting role details: %v", err)
+		}
+
+		permList = append(permList, role.IncludedPermissions...)
+	}
+
+	return permList, nil
+}

--- a/pkg/gcp/actuator/utils.go
+++ b/pkg/gcp/actuator/utils.go
@@ -122,7 +122,7 @@ func loadCredsFromSecret(kubeClient client.Client, namespace, secretName string)
 
 	jsonBytes, ok := secret.Data[gcpSecretJSONKey]
 	if !ok {
-		return nil, fmt.Errorf("GCP credentials secret %s did not container key %s",
+		return nil, fmt.Errorf("GCP credentials secret %s did not contain key %s",
 			secretName, gcpSecretJSONKey)
 	}
 


### PR DESCRIPTION
- [x] handle the case when the root creds are in passthrough mode.
- [x] add checks for passthrough and mint mode where we check that the service APIs are enabled/available before proceeding to process the CredentialsRequest.

Note that passthrough mode is handled differently than in AWS. In AWS we work with a static list of permissions that are needed for the cluster to run with. For GCP passthrough mode, the decision on whether we can satisfy a CredentialsRequest is dynamic. All we absolutely need for passthrough mode is the ability to list service APIs (to determine whether any particular service API is enabled), the ability to get the details for a specific role (so we can determine whether the role exists and the permissions attached to that role), and the ability to get the details of a project (so we can get the project number for a given project name). All the other permissions attached to the root creds in passthrough mode would pass/fail a permissions check during the TestIamPermissions() calls.