### PR TITLE
added NewClientSession to AWS client for users that require session tokens

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -102,11 +102,11 @@ func NewClient(accessKeyID, secretAccessKey []byte, infraName string) (Client, e
 }
 
 // NewClientSession allows for clients with session tokens to connect
-func NewClientWithSessionToken(accessKeyID, secretAccessKey []byte, sessionToken string, infraName string) (Client, error) {
+func NewClientWithSessionToken(accessKeyID, secretAccessKey []byte, sessionToken, infraName string) (Client, error) {
 	awsConfig := &awssdk.Config{}
 
 	awsConfig.Credentials = credentials.NewStaticCredentials(
-		string(accessKeyID), string(secretAccessKey), sessionToken)
+		string(accessKeyID), string(secretAccessKey), string(sessionToken))
 
 	s, err := session.NewSession(awsConfig)
 	if err != nil {

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -98,11 +98,11 @@ func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error)
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
 func NewClient(accessKeyID, secretAccessKey []byte, infraName string) (Client, error) {
-	return NewClientSession(accessKeyID, secretAccessKey, "", infraName)
+	return NewClientWithSessionToken(accessKeyID, secretAccessKey, "", infraName)
 }
 
 // NewClientSession allows for clients with session tokens to connect
-func NewClientSession(accessKeyID, secretAccessKey []byte, sessionToken string, infraName string) (Client, error) {
+func NewClientWithSessionToken(accessKeyID, secretAccessKey []byte, sessionToken string, infraName string) (Client, error) {
 	awsConfig := &awssdk.Config{}
 
 	awsConfig.Credentials = credentials.NewStaticCredentials(

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -98,10 +98,15 @@ func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error)
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
 func NewClient(accessKeyID, secretAccessKey []byte, infraName string) (Client, error) {
+	return NewClientSession(accessKeyID, secretAccessKey, "", infraName)
+}
+
+// NewClientSession allows for clients with session tokens to connect
+func NewClientSession(accessKeyID, secretAccessKey []byte, sessionToken string, infraName string) (Client, error) {
 	awsConfig := &awssdk.Config{}
 
 	awsConfig.Credentials = credentials.NewStaticCredentials(
-		string(accessKeyID), string(secretAccessKey), "")
+		string(accessKeyID), string(secretAccessKey), sessionToken)
 
 	s, err := session.NewSession(awsConfig)
 	if err != nil {


### PR DESCRIPTION
Overview: Added function NewClientSession in the aws client.  This function allows for the session token to be passed in and on to the aws api.

Reason for adding: The project [Openshift/installer](https://github.com/openshift/installer) uses cloud-credential-operator to [create an AWS client](https://github.com/openshift/installer/blob/4d88d536bc0f27c03713fcb4feeb27d5fae8a023/pkg/asset/installconfig/aws/permissions.go#L198).  The goal is to add this functionality here then modify the installer to call this new function