### PR TITLE
Bug 1727012: add upgradeable condition unconditionally

### DIFF
--- a/pkg/controller/credentialsrequest/status.go
+++ b/pkg/controller/credentialsrequest/status.go
@@ -237,6 +237,15 @@ func computeStatusConditions(conditions []configv1.ClusterOperatorStatusConditio
 	conditions = clusteroperator.SetStatusCondition(conditions,
 		availableCondition)
 
+	// CCO doesn't have the idea of upgradeable vs not-upgradeable, but should report that condition nevertheless.
+	// Always be upgradeable.
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	conditions = clusteroperator.SetStatusCondition(conditions,
+		upgradeableCondition)
+
 	// Log all conditions we set:
 	for _, c := range conditions {
 		log.WithFields(log.Fields{

--- a/pkg/controller/credentialsrequest/status_test.go
+++ b/pkg/controller/credentialsrequest/status_test.go
@@ -200,6 +200,13 @@ func TestClusterOperatorStatus(t *testing.T) {
 				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonNoCredentialsFailing),
 			},
 		},
+		{
+			name:         "set upgradeable condition",
+			credRequests: []minterv1.CredentialsRequest{},
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{
+				testCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, ""),
+			},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
operators should report upgradeability. add upgradeable status when calculating clusteroperator status

addresses BZ https://bugzilla.redhat.com/show_bug.cgi?id=1727012

