### PR TITLE
Bug 1729021: utilize the permissionBoundary of the current user if available

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1051,8 +1051,19 @@ func userHasTag(user *iam.User, key, val string) bool {
 }
 
 func (a *AWSActuator) createUser(logger log.FieldLogger, awsClient minteraws.Client, username string) (*iam.CreateUserOutput, error) {
-	input := &iam.CreateUserInput{
-		UserName: aws.String(username),
+	userInput := &iam.GetUserInput{}
+	currentUser, err := awsClient.GetUser(userInput)
+	
+	var input *iam.CreateUserInput
+	if currentUser != nil && currentUser.User.PermissionsBoundary != nil {
+		input = &iam.CreateUserInput{
+			UserName:            aws.String(username),
+			PermissionsBoundary: currentUser.User.PermissionsBoundary.PermissionsBoundaryArn,
+		}
+	} else {
+		input = &iam.CreateUserInput{
+			UserName: aws.String(username),
+		}
 	}
 
 	uLog := logger.WithField("userName", username)

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -165,6 +165,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetUser(mockAWSClient)
 				mockCreateUser(mockAWSClient)
 				mockPutUserPolicy(mockAWSClient)
 				mockCreateAccessKey(mockAWSClient, testAWSAccessKeyID, testAWSSecretAccessKey)
@@ -219,6 +220,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetUser(mockAWSClient)
 				mockCreateUser(mockAWSClient)
 				mockPutUserPolicy(mockAWSClient)
 				mockCreateAccessKey(mockAWSClient, testAWSAccessKeyID, testAWSSecretAccessKey)
@@ -802,6 +804,48 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "pass along any existing permissions boundary",
+			existing: []runtime.Object{
+				createTestNamespace(testNamespace),
+				createTestNamespace(testSecretNamespace),
+				testCredentialsRequest(t),
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
+				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
+				testClusterVersion(),
+				testInfrastructure(testInfraName),
+			},
+			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetUserWithPermissionsBoundary(mockAWSClient)
+
+				mockCreateUserWithPermissionsBoundary(mockAWSClient)
+				mockPutUserPolicy(mockAWSClient)
+				mockCreateAccessKey(mockAWSClient, testAWSAccessKeyID, testAWSSecretAccessKey)
+				mockTagUser(mockAWSClient)
+				return mockAWSClient
+			},
+			mockReadAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetUserNotFound(mockAWSClient)
+				mockGetUserPolicyMissing(mockAWSClient)
+				mockListAccessKeysEmpty(mockAWSClient)
+				return mockAWSClient
+			},
+			validate: func(c client.Client, t *testing.T) {
+				targetSecret := getSecret(c)
+				if assert.NotNil(t, targetSecret) {
+					assert.Equal(t, testAWSAccessKeyID,
+						string(targetSecret.Data["aws_access_key_id"]))
+					assert.Equal(t, testAWSSecretAccessKey,
+						string(targetSecret.Data["aws_secret_access_key"]))
+				}
+				cr := getCR(c)
+				assert.True(t, cr.Status.Provisioned)
+				assert.Equal(t, int64(testCRGeneration), int64(cr.Status.LastSyncGeneration))
+				assert.NotNil(t, cr.Status.LastSyncTimestamp)
+			},
+		},
 	}
 
 	for _, test := range tests {
@@ -900,6 +944,8 @@ const (
 	testRootAWSSecretAccessKey = "rootsecretkey"
 	testReadAWSAccessKeyID     = "readaccesskey"
 	testReadAWSSecretAccessKey = "readsecretkey"
+	testPermissionsBoundaryARN = "some:boundary:ARN:1234"
+	testPermissionBoundaryType = "Policy" // currently the only allowed value in AWS
 )
 
 var (
@@ -1052,6 +1098,18 @@ func mockGetUserNotFound(mockAWSClient *mockaws.MockClient) {
 	mockAWSClient.EXPECT().GetUser(gomock.Any()).Return(nil, awserr.New(iam.ErrCodeNoSuchEntityException, "no such entity", nil)).AnyTimes()
 }
 
+func mockGetUserWithPermissionsBoundary(mockAWSClient *mockaws.MockClient) {
+	mockAWSClient.EXPECT().GetUser(gomock.Any()).Return(
+		&iam.GetUserOutput{
+			User: &iam.User{
+				PermissionsBoundary: &iam.AttachedPermissionsBoundary{
+					PermissionsBoundaryArn:  aws.String(testPermissionsBoundaryARN),
+					PermissionsBoundaryType: aws.String(testPermissionBoundaryType),
+				},
+			},
+		}, nil)
+}
+
 func mockGetUser(mockAWSClient *mockaws.MockClient) {
 	mockAWSClient.EXPECT().GetUser(gomock.Any()).Return(
 		&iam.GetUserOutput{
@@ -1113,6 +1171,25 @@ func mockListAccessKeys(mockAWSClient *mockaws.MockClient, accessKeyID string) {
 			AccessKeyMetadata: []*iam.AccessKeyMetadata{
 				{
 					AccessKeyId: aws.String(accessKeyID),
+				},
+			},
+		}, nil)
+}
+
+func mockCreateUserWithPermissionsBoundary(mockAWSClient *mockaws.MockClient) {
+	mockAWSClient.EXPECT().CreateUser(
+		&iam.CreateUserInput{
+			UserName:            aws.String(testAWSUser),
+			PermissionsBoundary: aws.String(testPermissionsBoundaryARN),
+		}).Return(
+		&iam.CreateUserOutput{
+			User: &iam.User{
+				UserName: aws.String(testAWSUser),
+				UserId:   aws.String(testAWSUserID),
+				Arn:      aws.String(testAWSARN),
+				PermissionsBoundary: &iam.AttachedPermissionsBoundary{
+					PermissionsBoundaryArn:  aws.String(testPermissionsBoundaryARN),
+					PermissionsBoundaryType: aws.String(testPermissionBoundaryType),
 				},
 			},
 		}, nil)


### PR DESCRIPTION
Our IAM root user has a permission boundary set. This means, every IAM user created by that root user has to have the permission boundary set.

We experienced failure in the installation of Openshift 4 on AWS because the user object to be created fails to pull the permission boundary of the provided user that is used to do the installation.