### PR TITLE
Revert "Bug 1726451: Add clusteroperator version level gate."

### DIFF
--- a/manifests/10_cluster-operator.yaml
+++ b/manifests/10_cluster-operator.yaml
@@ -2,8 +2,3 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: cloud-credential
-status:
-  versions:
-  - name: operator
-    version: "0.0.1-snapshot"
-


### PR DESCRIPTION
This reverts commit 4e137365484bdc5ea86ee5b0cac2fe60b3d3d36c.

We're seeing increased error rates as a result of this change. It is likely the upgrade bug we've seen in the wild but cannot reproduce, only now blocking upgrade because of the level gate. We suspect this was caused by the lack of leader election, but we did not backport leader election along with this change. We will try again next week with both changes. 