### PR TITLE
Support AWS temporary credentials

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -79,7 +79,7 @@ func NewAWSActuator(client client.Client, scheme *runtime.Scheme) (*AWSActuator,
 	return &AWSActuator{
 		Codec:            codec,
 		Client:           client,
-		AWSClientBuilder: ccaws.NewClient,
+		AWSClientBuilder: ccaws.NewClientWithCreds,
 		Scheme:           scheme,
 	}, nil
 }

--- a/pkg/aws/mock/client_generated.go
+++ b/pkg/aws/mock/client_generated.go
@@ -6,6 +6,7 @@ package mock
 
 import (
 	iam "github.com/aws/aws-sdk-go/service/iam"
+	sts "github.com/aws/aws-sdk-go/service/sts"
 	gomock "github.com/golang/mock/gomock"
 	reflect "reflect"
 )
@@ -106,6 +107,21 @@ func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.Del
 func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
+}
+
+// GetCallerIdentity mocks base method
+func (m *MockClient) GetCallerIdentity(arg0 *sts.GetCallerIdentityInput) (*sts.GetCallerIdentityOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetCallerIdentity", arg0)
+	ret0, _ := ret[0].(*sts.GetCallerIdentityOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetCallerIdentity indicates an expected call of GetCallerIdentity
+func (mr *MockClientMockRecorder) GetCallerIdentity(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCallerIdentity", reflect.TypeOf((*MockClient)(nil).GetCallerIdentity), arg0)
 }
 
 // GetUser mocks base method

--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -2,6 +2,7 @@ package aws
 
 import (
 	"fmt"
+	"strings"
 
 	log "github.com/sirupsen/logrus"
 
@@ -111,39 +112,42 @@ func CheckCloudCredCreation(awsClient Client, logger log.FieldLogger) (bool, err
 	return CheckPermissionsAgainstActions(awsClient, credMintingActions, logger)
 }
 
-// getClientDetails will return the *iam.User associated with the provided client's credentials,
-// a boolean indicating whether the user is the 'root' account, and any error encountered
-// while trying to gather the info.
-func getClientDetails(awsClient Client) (*iam.User, bool, error) {
-	rootUser := false
-
-	user, err := awsClient.GetUser(nil)
+// getCallerIdentity will return the Account, Arn and UserId associated with current client's credentials,
+// and any error encountered while trying to gather the info.
+func getCallerIdentity(awsClient Client) (*string, *string, *string, error) {
+	out, err := awsClient.GetCallerIdentity(nil)
 	if err != nil {
-		return nil, rootUser, fmt.Errorf("error querying username: %v", err)
+		return nil, nil, nil, fmt.Errorf("error querying caller's identity: %v", err)
 	}
+	return out.Account, out.Arn, out.UserId, nil
+}
 
-	// Detect whether the AWS account's root user is being used
-	parsed, err := arn.Parse(*user.User.Arn)
+func isAssumedRole(callerArn *string) (bool, error) {
+	parsed, err := arn.Parse(*callerArn)
 	if err != nil {
-		return nil, rootUser, fmt.Errorf("error parsing user's ARN: %v", err)
+		return false, fmt.Errorf("error parsing caller's ARN: %v", err)
 	}
-	if parsed.AccountID == *user.User.UserId {
-		rootUser = true
-	}
-
-	return user.User, rootUser, nil
+	return strings.HasPrefix(parsed.Resource, "assumed-role/"), nil
 }
 
 // CheckPermissionsUsingQueryClient will use queryClient to query whether the credentials in targetClient can perform the actions
 // listed in the statementEntries. queryClient will need iam:GetUser and iam:SimulatePrincipalPolicy
 func CheckPermissionsUsingQueryClient(queryClient, targetClient Client, statementEntries []minterv1.StatementEntry, logger log.FieldLogger) (bool, error) {
-	targetUser, isRoot, err := getClientDetails(targetClient)
+	accountID, arn, userID, err := getCallerIdentity(targetClient)
 	if err != nil {
 		return false, fmt.Errorf("error gathering AWS credentials details: %v", err)
 	}
-	if isRoot {
+	if *accountID == *userID {
 		// warn about using the root creds, and just return that the creds are good enough
 		logger.Warn("Using the AWS account root user is not recommended: https://docs.aws.amazon.com/general/latest/gr/managing-aws-access-keys.html")
+		return true, nil
+	}
+	assumedRole, err := isAssumedRole(arn)
+	if err != nil {
+		return false, fmt.Errorf("error checking arn: %v", err)
+	}
+	if assumedRole {
+		logger.Warn("Using assumed role %s, cannot validate permissions beforehand.", arn)
 		return true, nil
 	}
 
@@ -155,7 +159,7 @@ func CheckPermissionsUsingQueryClient(queryClient, targetClient Client, statemen
 	}
 
 	results, err := queryClient.SimulatePrincipalPolicy(&iam.SimulatePrincipalPolicyInput{
-		PolicySourceArn: targetUser.Arn,
+		PolicySourceArn: arn,
 		ActionNames:     allowList,
 	})
 	if err != nil {

--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -147,7 +147,7 @@ func CheckPermissionsUsingQueryClient(queryClient, targetClient Client, statemen
 		return false, fmt.Errorf("error checking arn: %v", err)
 	}
 	if assumedRole {
-		logger.Warn("Using assumed role %s, cannot validate permissions beforehand.", arn)
+		logger.Warnf("Using assumed role %s, cannot validate permissions beforehand.", *arn)
 		return true, nil
 	}
 

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -49,6 +49,7 @@ import (
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/service/iam"
 )
 
@@ -827,10 +828,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 					Client: fakeClient,
 					Codec:  codec,
 					Scheme: scheme.Scheme,
-					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, infraName string) (minteraws.Client, error) {
-						if string(accessKeyID) == testRootAWSAccessKeyID {
+					AWSClientBuilder: func(creds *credentials.Value, infraName string) (minteraws.Client, error) {
+						if creds.AccessKeyID == testRootAWSAccessKeyID {
 							return mockRootAWSClient, nil
-						} else if string(accessKeyID) == testAWSAccessKeyID {
+						} else if creds.AccessKeyID == testAWSAccessKeyID {
 							return mockSecretAWSClient, nil
 						} else {
 							return mockReadAWSClient, nil

--- a/pkg/controller/secretannotator/aws/reconciler.go
+++ b/pkg/controller/secretannotator/aws/reconciler.go
@@ -37,7 +37,7 @@ func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileCloudCredSecret{
 		Client:           mgr.GetClient(),
 		Logger:           log.WithField("controller", constants.ControllerName),
-		AWSClientBuilder: ccaws.NewClient,
+		AWSClientBuilder: ccaws.NewClientWithCreds,
 	}
 }
 


### PR DESCRIPTION
Similar to #87 

Context: in lots of AWS deployments, auth to AWS is done through temporary credentials. Either by [assuming a role](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user.html) from an IAM user, or from an instance running with an [instance profile](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_use_switch-role-ec2_instance-profiles.html). Using root user, or long-term access keys is not recommended (see [Best Practices for managing AWS Access Keys](https://docs.aws.amazon.com/general/latest/gr/aws-access-keys-best-practices.html)).

This PR introduces the following changes:
* a variant of `NewClient` taking `*credentials.Value`
* `CheckPermissionsUsingQueryClient` has been changed in order to accept assumed roles. It uses `GetCallerIdentity` instead of `GetUser` as this is a more versatile way to determine auth context. Unfortunately the call to `SimulatePrincipalPolicy` is not reliable when using an assumed role (in my case, the simulation claims `ec2:RunInstances` is denied by AWS Organizations, but in reality it works just fine) , so the validation is skipped in such context. 