### PR TITLE
gcp: match secret name/key to installer manifest

### DIFF
--- a/pkg/controller/secretannotator/gcp/reconciler.go
+++ b/pkg/controller/secretannotator/gcp/reconciler.go
@@ -25,11 +25,11 @@ import (
 
 const (
 	// GCPCloudCredSecretName is the name of the secret created by installer containing cloud creds.
-	GCPCloudCredSecretName = "gcp-creds"
+	GCPCloudCredSecretName = "gcp-credentials"
 
 	// GCPAuthJSONKey is the key name in GCP credentials secrets where the json auth
 	// contents will be stored.
-	GCPAuthJSONKey = "serviceaccount.json"
+	GCPAuthJSONKey = "service_account.json"
 )
 
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -46,11 +46,11 @@ import (
 
 const (
 	rootGCPCredsSecretNamespace = "kube-system"
-	rootGCPCredsSecret          = "gcp-creds"
+	rootGCPCredsSecret          = "gcp-credentials"
 	roGCPCredsSecretNamespace   = "openshift-cloud-credential-operator"
 	roGCPCredsSecret            = "cloud-credential-operator-iam-ro-creds"
 
-	gcpSecretJSONKey = "serviceaccount.json"
+	gcpSecretJSONKey = "service_account.json"
 )
 
 var _ actuatoriface.Actuator = (*Actuator)(nil)


### PR DESCRIPTION
Matches root creds secret name and key to what the installer lays down:
https://github.com/openshift/installer/blob/e597acb90ffde7a521450750d57ec5554f73c752/data/data/manifests/openshift/cloud-creds-secret.yaml.template#L10