### PR TITLE
Split call to check permissions into chunks

### DIFF
--- a/pkg/controller/utils/gcp/utils_test.go
+++ b/pkg/controller/utils/gcp/utils_test.go
@@ -17,8 +17,14 @@ limitations under the License.
 package gcp
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/openshift/cloud-credential-operator/pkg/gcp/mock"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 )
 
 func TestPermissionsFiltering(t *testing.T) {
@@ -84,6 +90,54 @@ func TestPermissionsFiltering(t *testing.T) {
 				assert.True(t, found, "Did not find expected perm in list")
 			}
 
+		})
+	}
+}
+
+func perms(low, hi int) []string {
+	count := hi - low
+	result := make([]string, 0, count)
+	for i := 0; i < count; i++ {
+		result = append(result, fmt.Sprintf("permission%d", low+i))
+	}
+	return result
+}
+
+func TestCheckPermissionsAgainstPermissionListChunking(t *testing.T) {
+	p := perms
+	tests := []struct {
+		count  int
+		chunks [][]string
+	}{
+		{count: 0, chunks: nil},
+		{count: 2, chunks: [][]string{p(0, 2)}},
+		{count: 100, chunks: [][]string{p(0, 100)}},
+		{count: 101, chunks: [][]string{p(0, 100), p(100, 101)}},
+		{count: 230, chunks: [][]string{p(0, 100), p(100, 200), p(200, 230)}},
+		{count: 300, chunks: [][]string{p(0, 100), p(100, 200), p(200, 300)}},
+		{count: 379, chunks: [][]string{p(0, 100), p(100, 200), p(200, 300), p(300, 379)}},
+	}
+
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("count=%d", test.count), func(t *testing.T) {
+			mockClient := mock.NewMockClient(gomock.NewController(t))
+			logger := log.New()
+
+			mockClient.EXPECT().GetProjectName().AnyTimes().Return("fake")
+			permissionsList := perms(0, test.count)
+
+			for _, chunk := range test.chunks {
+				permRequest := &cloudresourcemanager.TestIamPermissionsRequest{
+					Permissions: chunk,
+				}
+				mockClient.EXPECT().TestIamPermissions("fake", permRequest).Return(&cloudresourcemanager.TestIamPermissionsResponse{
+					Permissions: chunk,
+				}, nil)
+
+			}
+			hasPermissions, err := CheckPermissionsAgainstPermissionList(mockClient, permissionsList, logger)
+			assert.Nil(t, err)
+			assert.True(t, hasPermissions)
 		})
 	}
 }


### PR DESCRIPTION
The call to check available permissions only allows 100 permissions at a
time per check. This change splits the call into multiple calls when
there are more than 100 permissions to check.