### PR TITLE
Bug 1743728: pkg/azure: also provide operators access to the resource group containing public DNS zone

### DIFF
--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -62,6 +62,7 @@ rules:
   - config.openshift.io
   resources:
   - infrastructures
+  - dnses
   verbs:
   - get
   - list

--- a/pkg/azure/actuator_test.go
+++ b/pkg/azure/actuator_test.go
@@ -240,7 +240,7 @@ func TestActuatorCreateUpdateDelete(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			fakeClient := fake.NewFakeClient(&clusterInfra, &rootSecretMintAnnotation, test.credentialRequest)
+			fakeClient := fake.NewFakeClient(&clusterInfra, &clusterDNS, &rootSecretMintAnnotation, test.credentialRequest)
 
 			mockCtrl := gomock.NewController(t)
 

--- a/pkg/azure/passthrough_test.go
+++ b/pkg/azure/passthrough_test.go
@@ -127,6 +127,17 @@ var (
 			},
 		},
 	}
+
+	clusterDNS = openshiftapiv1.DNS{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Spec: openshiftapiv1.DNSSpec{
+			PublicZone: &openshiftapiv1.DNSZone{
+				ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/os4-common/providers/Microsoft.Network/dnszones/devcluster.openshift.com",
+			},
+		},
+	}
 )
 
 type testInput struct {
@@ -180,7 +191,7 @@ func TestPassthroughCreate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := fake.NewFakeClient(&validRootSecret, &validSecret, &clusterInfra)
+			f := fake.NewFakeClient(&validRootSecret, &validSecret, &clusterInfra, &clusterDNS)
 			actuator, err := azure.NewActuator(f)
 			assert.Nil(t, err)
 
@@ -221,7 +232,7 @@ func TestPassthroughUpdate(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			f := fake.NewFakeClient(&validRootSecret, &validSecret, &clusterInfra)
+			f := fake.NewFakeClient(&validRootSecret, &validSecret, &clusterInfra, &clusterDNS)
 			actuator, err := azure.NewActuator(f)
 			assert.Nil(t, err)
 

--- a/pkg/azure/resourceid.go
+++ b/pkg/azure/resourceid.go
@@ -1,0 +1,94 @@
+package azure
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// The original code is from https://github.com/terraform-providers/terraform-provider-azurerm/blob/84163e6088f1dcd91fd437f0a559aa3fc5e87525/azurerm/helpers/azure/resourceid.go#L1
+
+// resourceID represents a parsed long-form Azure Resource Manager ID
+// with the Subscription ID, Resource Group and the Provider as top-
+// level fields, and other key-value pairs available via a map in the
+// Path field.
+type resourceID struct {
+	SubscriptionID string
+	ResourceGroup  string
+	Provider       string
+	Path           map[string]string
+}
+
+// parseAzureResourceID converts a long-form Azure Resource Manager ID
+// into a ResourceID. We make assumptions about the structure of URLs,
+// which is obviously not good, but the best thing available given the
+// SDK.
+func parseAzureResourceID(id string) (*resourceID, error) {
+	idURL, err := url.ParseRequestURI(id)
+	if err != nil {
+		return nil, fmt.Errorf("cannot parse Azure ID: %s", err)
+	}
+
+	path := idURL.Path
+
+	path = strings.TrimPrefix(path, "/")
+	path = strings.TrimSuffix(path, "/")
+
+	components := strings.Split(path, "/")
+
+	// We should have an even number of key-value pairs.
+	if len(components)%2 != 0 {
+		return nil, fmt.Errorf("The number of path segments is not divisible by 2 in %q", path)
+	}
+
+	var subscriptionID string
+
+	// Put the constituent key-value pairs into a map
+	componentMap := make(map[string]string, len(components)/2)
+	for current := 0; current < len(components); current += 2 {
+		key := components[current]
+		value := components[current+1]
+
+		// Check key/value for empty strings.
+		if key == "" || value == "" {
+			return nil, fmt.Errorf("Key/Value cannot be empty strings. Key: '%s', Value: '%s'", key, value)
+		}
+
+		if key == "subscriptions" && subscriptionID == "" {
+			subscriptionID = value
+		} else {
+			componentMap[key] = value
+		}
+	}
+
+	// Build up a ResourceID from the map
+	idObj := &resourceID{}
+	idObj.Path = componentMap
+
+	if subscriptionID != "" {
+		idObj.SubscriptionID = subscriptionID
+	} else {
+		return nil, fmt.Errorf("no subscription ID found in: %q", path)
+	}
+
+	if resourceGroup, ok := componentMap["resourceGroups"]; ok {
+		idObj.ResourceGroup = resourceGroup
+		delete(componentMap, "resourceGroups")
+	} else if resourceGroup, ok := componentMap["resourcegroups"]; ok {
+		// Some Azure APIs are weird and provide things in lower case...
+		// However it's not clear whether the casing of other elements in the URI
+		// matter, so we explicitly look for that case here.
+		idObj.ResourceGroup = resourceGroup
+		delete(componentMap, "resourcegroups")
+	} else {
+		return nil, fmt.Errorf("no resource group name found in: %q", path)
+	}
+
+	// It is OK not to have a provider in the case of a resource group
+	if provider, ok := componentMap["providers"]; ok {
+		idObj.Provider = provider
+		delete(componentMap, "providers")
+	}
+
+	return idObj, nil
+}

--- a/pkg/azure/resourceid_test.go
+++ b/pkg/azure/resourceid_test.go
@@ -1,0 +1,157 @@
+package azure
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseAzureResourceID(t *testing.T) {
+	testCases := []struct {
+		id                 string
+		expectedResourceID *resourceID
+		expectError        string
+	}{
+		{
+			// Missing "resourceGroups".
+			"/subscriptions/00000000-0000-0000-0000-000000000000//myResourceGroup/",
+			nil,
+			"Key/Value cannot be empty strings. Key: '', Value: 'myResourceGroup'",
+		},
+		{
+			// Empty resource group ID.
+			"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups//",
+			nil,
+			"Key/Value cannot be empty strings. Key: 'resourceGroups', Value: ''",
+		},
+		{
+			"random",
+			nil,
+			"cannot parse Azure ID: parse random: invalid URI for request",
+		},
+		{
+			"/subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+			nil,
+			"no resource group name found in: \"subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038\"",
+		},
+		{
+			"subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+			nil,
+			"cannot parse Azure ID: parse subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038: invalid URI for request",
+		},
+		{
+			"/subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1",
+			&resourceID{
+				SubscriptionID: "6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+				ResourceGroup:  "testGroup1",
+				Provider:       "",
+				Path:           map[string]string{},
+			},
+			"",
+		},
+		{
+			"/subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1/providers/Microsoft.Network",
+			&resourceID{
+				SubscriptionID: "6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+				ResourceGroup:  "testGroup1",
+				Provider:       "Microsoft.Network",
+				Path:           map[string]string{},
+			},
+			"",
+		},
+		{
+			// Missing leading /
+			"subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/",
+			nil,
+			"cannot parse Azure ID: parse subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/",
+		},
+		{
+			"/subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1",
+			&resourceID{
+				SubscriptionID: "6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+				ResourceGroup:  "testGroup1",
+				Provider:       "Microsoft.Network",
+				Path: map[string]string{
+					"virtualNetworks": "virtualNetwork1",
+				},
+			},
+			"",
+		},
+		{
+			"/subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1?api-version=2006-01-02-preview",
+			&resourceID{
+				SubscriptionID: "6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+				ResourceGroup:  "testGroup1",
+				Provider:       "Microsoft.Network",
+				Path: map[string]string{
+					"virtualNetworks": "virtualNetwork1",
+				},
+			},
+			"",
+		},
+		{
+			"/subscriptions/6d74bdd2-9f84-11e5-9bd9-7831c1c4c038/resourceGroups/testGroup1/providers/Microsoft.Network/virtualNetworks/virtualNetwork1/subnets/publicInstances1?api-version=2006-01-02-preview",
+			&resourceID{
+				SubscriptionID: "6d74bdd2-9f84-11e5-9bd9-7831c1c4c038",
+				ResourceGroup:  "testGroup1",
+				Provider:       "Microsoft.Network",
+				Path: map[string]string{
+					"virtualNetworks": "virtualNetwork1",
+					"subnets":         "publicInstances1",
+				},
+			},
+			"",
+		},
+		{
+			"/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourcegroups/acceptanceTestResourceGroup1/providers/Microsoft.Cdn/profiles/acceptanceTestCdnProfile1",
+			&resourceID{
+				SubscriptionID: "34ca515c-4629-458e-bf7c-738d77e0d0ea",
+				ResourceGroup:  "acceptanceTestResourceGroup1",
+				Provider:       "Microsoft.Cdn",
+				Path: map[string]string{
+					"profiles": "acceptanceTestCdnProfile1",
+				},
+			},
+			"",
+		},
+		{
+			"/subscriptions/34ca515c-4629-458e-bf7c-738d77e0d0ea/resourceGroups/testGroup1/providers/Microsoft.ServiceBus/namespaces/testNamespace1/topics/testTopic1/subscriptions/testSubscription1",
+			&resourceID{
+				SubscriptionID: "34ca515c-4629-458e-bf7c-738d77e0d0ea",
+				ResourceGroup:  "testGroup1",
+				Provider:       "Microsoft.ServiceBus",
+				Path: map[string]string{
+					"namespaces":    "testNamespace1",
+					"topics":        "testTopic1",
+					"subscriptions": "testSubscription1",
+				},
+			},
+			"",
+		},
+		{
+			"/subscriptions/11111111-1111-1111-1111-111111111111/resourceGroups/example-resources/providers/Microsoft.ApiManagement/service/service1/subscriptions/22222222-2222-2222-2222-222222222222",
+			&resourceID{
+				SubscriptionID: "11111111-1111-1111-1111-111111111111",
+				ResourceGroup:  "example-resources",
+				Provider:       "Microsoft.ApiManagement",
+				Path: map[string]string{
+					"service":       "service1",
+					"subscriptions": "22222222-2222-2222-2222-222222222222",
+				},
+			},
+			"",
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run("", func(t *testing.T) {
+			parsed, err := parseAzureResourceID(test.id)
+			if test.expectError == "" {
+				assert.NoError(t, err)
+			} else {
+				assert.Errorf(t, err, test.expectError)
+			}
+			assert.Equal(t, test.expectedResourceID, parsed)
+		})
+	}
+}


### PR DESCRIPTION
cluster-ingress-operator updates the records in the public DNS zone that is used by the cluster, hence separate from the resource group created for the cluster.
The DNS or dnses.config.openshift.io/v1 object's `.spec.publicZone` is optional, and when set the, resource-group from the ID will be used.

The current api doesn't allow scoping permissions to a single resource, therefore, the permissions are provided to the entire resource group.
Also adds a resourceid helper to find the resource group for the public zone ID.