### PR TITLE
allow 32 char infraID in generated Service Principal names

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -7,6 +7,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -75,4 +76,40 @@ func GetCredentialsRequestCloudType(providerSpec *runtime.RawExtension) (string,
 		return "", err
 	}
 	return unknown.Kind, nil
+}
+
+// GenerateUniqueNameWithFieldLimits will take infraName and crName and shorten them if necessary to no longer
+// than their respective MaxLen argument. it will then add a unique ending to the resulting name
+// by appending '-<5 random chars>' to the resulting string.
+// Example: passing "thisIsInfraName", 8, "thisIsCrName", 8 will return:
+//		'thisIsIn-thisIsCr-<5 random chars>'
+func GenerateUniqueNameWithFieldLimits(infraName string, infraNameMaxLen int, crName string, crNameMaxlen int) (string, error) {
+	genName, err := GenerateNameWithFieldLimits(infraName, infraNameMaxLen, crName, crNameMaxlen)
+	if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%s-%s", genName, utilrand.String(5)), nil
+}
+
+// GenerateNameWithFieldLimits lets you pass in two strings which will be clipped to their respective
+// maximum lengths.
+// Example: passing "thisIsInfraName", 8, "thisIsCrName", 8 will return:
+//      'thisIsIn-thisIsCr'
+func GenerateNameWithFieldLimits(infraName string, infraNameMaxLen int, crName string, crNameLen int) (string, error) {
+	if crName == "" {
+		return "", fmt.Errorf("empty credential request name")
+	}
+
+	infraPrefix := ""
+	if infraName != "" {
+		if len(infraName) > infraNameMaxLen {
+			infraName = infraName[0:infraNameMaxLen]
+		}
+		infraPrefix = infraName + "-"
+	}
+	if len(crName) > crNameLen {
+		crName = crName[0:crNameLen]
+	}
+	return fmt.Sprintf("%s%s", infraPrefix, crName), nil
 }

--- a/pkg/controller/utils/utils_test.go
+++ b/pkg/controller/utils/utils_test.go
@@ -1,4 +1,4 @@
-package actuator
+package utils
 
 import (
 	"regexp"
@@ -43,7 +43,7 @@ func TestGenerateName(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			generatedName, err := generateUniqueNameWithFieldLimits(test.infraName, test.infraNameMaxLen, test.credentialName, test.credentialNameMaxLen)
+			generatedName, err := GenerateUniqueNameWithFieldLimits(test.infraName, test.infraNameMaxLen, test.credentialName, test.credentialNameMaxLen)
 			if test.expectedError {
 				assert.Error(t, err, "Expected error returned")
 			} else {

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -291,7 +291,7 @@ func (a *Actuator) syncMint(ctx context.Context, cr *minterv1.CredentialsRequest
 		// The service account id has a max length of 30 chars
 		// split it into 12-11-5 where the resuling string becomes:
 		// <infraName chopped to 12 chars>-<crName chopped to 11 chars>-<random 5 chars>
-		svcAcctID, err := generateUniqueNameWithFieldLimits(infraName, 12, cr.Name, 11)
+		svcAcctID, err := utils.GenerateUniqueNameWithFieldLimits(infraName, 12, cr.Name, 11)
 		if err != nil {
 			return fmt.Errorf("error generating service account ID: %v", err)
 		}
@@ -341,7 +341,7 @@ func (a *Actuator) syncMint(ctx context.Context, cr *minterv1.CredentialsRequest
 
 		// The service account name field has a 100 char max, so generate a name consisting of the
 		// infraName chopped to 50 chars + the crName chopped to 49 chars (separated by a '-').
-		svcAcctName, err := generateNameWithFieldLimits(infraName, 50, cr.Name, 49) // 100 total char limit
+		svcAcctName, err := utils.GenerateNameWithFieldLimits(infraName, 50, cr.Name, 49)
 		if err != nil {
 			return fmt.Errorf("error generating service acocunt name: %v", err)
 		}

--- a/pkg/gcp/actuator/utils.go
+++ b/pkg/gcp/actuator/utils.go
@@ -25,7 +25,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
-	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 )
@@ -66,42 +65,6 @@ func decodeGCPAuthStringToJSON(authJSONBytes []byte) (*gcpAuthJSON, error) {
 		return nil, err
 	}
 	return authJSON, nil
-}
-
-// generateUniqueNameWithFieldLimits will take infraName and crName and shorten them if necessary to no longer
-// than their respective MaxLen argument. it will then add a unique ending to the resulting name
-// by appended '-<5 random chars>' to the resulting string.
-// Example: passing "thisIsInfraName", 8, "thisIsCrName", 8 will return:
-//		'thisIsIn-thisIsCr-<5 random chars>'
-func generateUniqueNameWithFieldLimits(infraName string, infraNameMaxLen int, crName string, crNameMaxlen int) (string, error) {
-	genName, err := generateNameWithFieldLimits(infraName, infraNameMaxLen, crName, crNameMaxlen)
-	if err != nil {
-		return "", err
-	}
-
-	return fmt.Sprintf("%s-%s", genName, utilrand.String(5)), nil
-}
-
-// generateNameWithFieldLimits lets you pass in two strings which will be clipped to their respective
-// maximum lengths.
-// Example: passing "thisIsInfraName", 8, "thisIsCrName", 8 will return:
-//      'thisIsIn-thisIsCr'
-func generateNameWithFieldLimits(infraName string, infraNameMaxLen int, crName string, crNameLen int) (string, error) {
-	if crName == "" {
-		return "", fmt.Errorf("empty credential request name")
-	}
-
-	infraPrefix := ""
-	if infraName != "" {
-		if len(infraName) > infraNameMaxLen {
-			infraName = infraName[0:infraNameMaxLen]
-		}
-		infraPrefix = infraName + "-"
-	}
-	if len(crName) > crNameLen {
-		crName = crName[0:crNameLen]
-	}
-	return fmt.Sprintf("%s%s", infraPrefix, crName), nil
 }
 
 func extractKeyIDFromKeyName(keyName string) string {


### PR DESCRIPTION
Azure allows a 93 character service principal name. Preserve the entire 32 character infraID (max length from the installer) and leave 54 characters for the credentialsRequest name, and a final 5 chars for randomness (all fields separated by dashes).