### PR TITLE
handle the posibilitiy of paginated results from SimulatePrincipalPolicy

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -42,6 +42,7 @@ type Client interface {
 	PutUserPolicy(*iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error)
 	GetUserPolicy(*iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error)
 	SimulatePrincipalPolicy(*iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error)
+	SimulatePrincipalPolicyPages(*iam.SimulatePrincipalPolicyInput, func(*iam.SimulatePolicyResponse, bool) bool) error
 	TagUser(*iam.TagUserInput) (*iam.TagUserOutput, error)
 }
 
@@ -90,6 +91,10 @@ func (c *awsClient) GetUserPolicy(input *iam.GetUserPolicyInput) (*iam.GetUserPo
 
 func (c *awsClient) SimulatePrincipalPolicy(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
 	return c.iamClient.SimulatePrincipalPolicy(input)
+}
+
+func (c *awsClient) SimulatePrincipalPolicyPages(input *iam.SimulatePrincipalPolicyInput, fn func(*iam.SimulatePolicyResponse, bool) bool) error {
+	return c.iamClient.SimulatePrincipalPolicyPages(input, fn)
 }
 
 func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error) {

--- a/pkg/aws/mock/client_generated.go
+++ b/pkg/aws/mock/client_generated.go
@@ -198,6 +198,20 @@ func (mr *MockClientMockRecorder) SimulatePrincipalPolicy(arg0 interface{}) *gom
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicy", reflect.TypeOf((*MockClient)(nil).SimulatePrincipalPolicy), arg0)
 }
 
+// SimulatePrincipalPolicyPages mocks base method
+func (m *MockClient) SimulatePrincipalPolicyPages(arg0 *iam.SimulatePrincipalPolicyInput, arg1 func(*iam.SimulatePolicyResponse, bool) bool) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SimulatePrincipalPolicyPages", arg0, arg1)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SimulatePrincipalPolicyPages indicates an expected call of SimulatePrincipalPolicyPages
+func (mr *MockClientMockRecorder) SimulatePrincipalPolicyPages(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyPages", reflect.TypeOf((*MockClient)(nil).SimulatePrincipalPolicyPages), arg0, arg1)
+}
+
 // TagUser mocks base method
 func (m *MockClient) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
- [x] add and use SimulatePrincipalPolicyPages() to the AWS client so that we can handle a multi-paged response from AWS
- [x] update test cases to mock up the SimulatePrincipalPolicyPages() responses