### PR TITLE
Bug 1747366: Allow use of global proxy

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -31,6 +31,8 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
+  annotations:
+    config.openshift.io/inject-proxy: "manager"
 spec:
   selector:
     matchLabels:
@@ -79,4 +81,25 @@ spec:
           - --log-level
           - debug
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - name: cco-trusted-ca
+          mountPath: /etc/pki/ca-trust/extracted/pem/
       terminationGracePeriodSeconds: 10
+      volumes:
+      - name: cco-trusted-ca
+        configMap:
+          optional: true
+          name: cco-trusted-ca
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    # This label ensures that the OpenShift Certificate Authority bundle
+    # is added to the ConfigMap.
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: cco-trusted-ca
+  namespace: openshift-cloud-credential-operator

--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -112,6 +112,14 @@ subjects:
   namespace: openshift-cloud-credential-operator
 ---
 apiVersion: v1
+kind: ConfigMap
+metadata:
+  labels:
+    config.openshift.io/inject-trusted-cabundle: "true"
+  name: cco-trusted-ca
+  namespace: openshift-cloud-credential-operator
+---
+apiVersion: v1
 kind: Service
 metadata:
   labels:
@@ -129,6 +137,8 @@ spec:
 apiVersion: apps/v1
 kind: Deployment
 metadata:
+  annotations:
+    config.openshift.io/inject-proxy: manager
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -167,6 +177,9 @@ spec:
             cpu: 10m
             memory: 150Mi
         terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /etc/pki/ca-trust/extracted/pem/
+          name: cco-trusted-ca
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
@@ -183,3 +196,11 @@ spec:
         key: node.kubernetes.io/not-ready
         operator: Exists
         tolerationSeconds: 120
+      volumes:
+      - configMap:
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          name: cco-trusted-ca
+          optional: true
+        name: cco-trusted-ca


### PR DESCRIPTION
create a configmap that will be populated with the cluster's certificate bundle.
mark that configmap as an optional volume for the CCO pod.

TODO: watch the configmap for changes and restart COO as necessary.