### PR TITLE
Bug 1758666: copy trust bundle when actually defined

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -76,14 +76,18 @@ spec:
         - containerPort: 9876
           name: webhook-server
           protocol: TCP
-        command:
-          - /root/manager
-          - --log-level
-          - debug
+        command: ["/bin/bash", "-ec"]
+        args:
+        - |
+          if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          fi
+          exec /root/manager --log-level=debug
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: cco-trusted-ca
-          mountPath: /etc/pki/ca-trust/extracted/pem/
+          mountPath: /var/run/configmaps/trusted-ca-bundle
       terminationGracePeriodSeconds: 10
       volumes:
       - name: cco-trusted-ca

--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -158,10 +158,16 @@ spec:
         controller-tools.k8s.io: "1.0"
     spec:
       containers:
-      - command:
-        - /root/manager
-        - --log-level
-        - debug
+      - args:
+        - |
+          if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          fi
+          exec /root/manager --log-level=debug
+        command:
+        - /bin/bash
+        - -ec
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
@@ -178,7 +184,7 @@ spec:
             memory: 150Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /etc/pki/ca-trust/extracted/pem/
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
           name: cco-trusted-ca
       nodeSelector:
         node-role.kubernetes.io/master: ""


### PR DESCRIPTION
Dependent on the speed at which other components are restarted during a 4.1 to 4.2 upgrade, the CCO could be upgraded to a version that expects a trust bundle before it's fulfilled all credential requests thus causing the upgrade to deadlock because the CNO has not yet populated the trust bundle. Therefore, only utilize the trust bundle when it exists.