### PR TITLE
Add support for manually disabling the operator.

### DIFF
--- a/manifests/01_operator_configmap.yaml
+++ b/manifests/01_operator_configmap.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-credential-operator-config
+  namespace: openshift-cloud-credential-operator
+data:
+  disabled: "false"

--- a/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
+++ b/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
@@ -39,6 +39,9 @@ const (
 
 	// CloudCredOperatorNamespace is the namespace where the credentials operator runs.
 	CloudCredOperatorNamespace = "openshift-cloud-credential-operator"
+
+	// CloudCredOperatorConfigMap is an optional ConfigMap that can be used to alter behavior of the operator.
+	CloudCredOperatorConfigMap = "cloud-credential-operator-config"
 )
 
 // NOTE: Run "make" to regenerate code after modifying this file

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller.go
@@ -272,9 +272,18 @@ func (r *ReconcileCredentialsRequest) Reconcile(request reconcile.Request) (reco
 		}
 	}()
 
+	operatorIsDisabled, err := utils.IsOperatorDisabled(r.Client, logger)
+	if err != nil {
+		logger.WithError(err).Error("error checking if operator is disabled")
+		return reconcile.Result{}, err
+	} else if operatorIsDisabled {
+		logger.Infof("operator disabled in %s ConfigMap", minterv1.CloudCredOperatorConfigMap)
+		return reconcile.Result{}, err
+	}
+
 	logger.Info("syncing credentials request")
 	cr := &minterv1.CredentialsRequest{}
-	err := r.Get(context.TODO(), request.NamespacedName, cr)
+	err = r.Get(context.TODO(), request.NamespacedName, cr)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			logger.Debug("credentials request no longer exists")

--- a/pkg/controller/secretannotator/aws/reconciler.go
+++ b/pkg/controller/secretannotator/aws/reconciler.go
@@ -18,6 +18,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
@@ -85,8 +86,17 @@ type ReconcileCloudCredSecret struct {
 func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	r.Logger.Info("validating cloud cred secret")
 
+	operatorIsDisabled, err := utils.IsOperatorDisabled(r.Client, r.Logger)
+	if err != nil {
+		r.Logger.WithError(err).Error("error checking if operator is disabled")
+		return reconcile.Result{}, err
+	} else if operatorIsDisabled {
+		r.Logger.Infof("operator disabled in %s ConfigMap", minterv1.CloudCredOperatorConfigMap)
+		return reconcile.Result{}, err
+	}
+
 	secret := &corev1.Secret{}
-	err := r.Get(context.Background(), request.NamespacedName, secret)
+	err = r.Get(context.Background(), request.NamespacedName, secret)
 	if err != nil {
 		r.Logger.Debugf("secret not found: %v", err)
 		return reconcile.Result{}, err

--- a/pkg/controller/secretannotator/aws/reconciler_test.go
+++ b/pkg/controller/secretannotator/aws/reconciler_test.go
@@ -40,6 +40,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"github.com/openshift/cloud-credential-operator/pkg/apis"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
 
@@ -102,6 +103,14 @@ func TestSecretAnnotatorReconcile(t *testing.T) {
 				return mockAWSClient
 			},
 			validateAnnotationValue: constants.MintAnnotation,
+		},
+		{
+			name:     "operator disabled",
+			existing: []runtime.Object{testSecret(), testOperatorConfigMap("true")},
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				return mockAWSClient
+			},
 		},
 		{
 			name:     "detect root user creds",
@@ -226,6 +235,18 @@ func testSecret() *corev1.Secret {
 		},
 	}
 	return s
+}
+
+func testOperatorConfigMap(disabled string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      minterv1.CloudCredOperatorConfigMap,
+			Namespace: minterv1.CloudCredOperatorNamespace,
+		},
+		Data: map[string]string{
+			"disabled": disabled,
+		},
+	}
 }
 
 func mockGetRootUser(mockAWSClient *mockaws.MockClient) {

--- a/pkg/controller/secretannotator/gcp/reconciler_test.go
+++ b/pkg/controller/secretannotator/gcp/reconciler_test.go
@@ -37,6 +37,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/openshift/cloud-credential-operator/pkg/apis"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	ccgcp "github.com/openshift/cloud-credential-operator/pkg/gcp"
 	mockgcp "github.com/openshift/cloud-credential-operator/pkg/gcp/mock"
 
@@ -95,6 +96,14 @@ func TestSecretAnnotatorReconcile(t *testing.T) {
 				return mockGCPClient
 			},
 			validateAnnotationValue: constants.MintAnnotation,
+		},
+		{
+			name:     "operator disabled",
+			existing: []runtime.Object{testSecret(), testOperatorConfigMap("true")},
+			mockGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
+				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
+				return mockGCPClient
+			},
 		},
 		{
 			name:     "cred passthrough mode",
@@ -226,6 +235,18 @@ func testSecret() *corev1.Secret {
 		},
 	}
 	return s
+}
+
+func testOperatorConfigMap(disabled string) *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      minterv1.CloudCredOperatorConfigMap,
+			Namespace: minterv1.CloudCredOperatorNamespace,
+		},
+		Data: map[string]string{
+			"disabled": disabled,
+		},
+	}
 }
 
 func mockGetProjectName(mockGCPClient *mockgcp.MockClient) {


### PR DESCRIPTION
Introduces the optional cloud-credential-operator-config ConfigMap. If
present, with a "disabled" key set to "true", all controllers will no-op
and the ClusterOperator will report available=true, progressing=false,
degraded=false, upgradable=true.

Unfortunately this requires two of our three controllers to have explicit code to
check right now. The configmap monitoring controller remains running.