### PR TITLE
Annotate new configmap so CVO will allow changes.

### DIFF
--- a/manifests/01_operator_configmap.yaml
+++ b/manifests/01_operator_configmap.yaml
@@ -3,5 +3,7 @@ kind: ConfigMap
 metadata:
   name: cloud-credential-operator-config
   namespace: openshift-cloud-credential-operator
+  annotations:
+    release.openshift.io/create-only: "true"
 data:
   disabled: "false"


### PR DESCRIPTION
In current form the CVO will undo anything a user tries to do as it
believes it owns this configmap. Adding this annotation will have the
CVO only create it and then leave it be.