### PR TITLE
pkg/azure: add the network resource group to the list of infra groups

### DIFF
--- a/pkg/azure/actuator_test.go
+++ b/pkg/azure/actuator_test.go
@@ -516,6 +516,7 @@ func defaultExistingObjects() []runtime.Object {
 		&clusterInfra,
 		&rootSecretMintAnnotation,
 		&clusterDNS,
+		&cloudProviderConfigMap,
 	}
 	return objs
 }

--- a/pkg/azure/cloudconfig.go
+++ b/pkg/azure/cloudconfig.go
@@ -1,0 +1,7 @@
+package azure
+
+// https://github.com/kubernetes/kubernetes/blob/v1.16.0/staging/src/k8s.io/legacy-cloud-providers/azure/azure.go#L90
+type cloudconfig struct {
+	// The name of the resource group that the Vnet is deployed in
+	VnetResourceGroup string `json:"vnetResourceGroup,omitempty" yaml:"vnetResourceGroup,omitempty"`
+}


### PR DESCRIPTION
Currently the list of infra groups is `cluster` and `public dns zone`. And because the network resources like Virtual Network and Subnets are created for each cluster today this list is enough.
but to support Openshift clusters that use pre-existing Virtual Network and Subnets, we need the cluster to have access to this resource group too.

the network and cluster resource group split means all the cluster resources stay in the same group, but some network resources are used from a separate group. An example of operator that needs this access
is the machine-api-controllers, as they need to attach the nics for the virtual machine to subnets from network group.

The infratructure object provides the field for CloudConfig [1], which provides reference to the configmap and key that stores the k8s cloud provider config for Azure.
The cloud provider config for Azure contains the `vnetresourcegroupname` that is the network group for the cluster.

Using the cloud provider config to fetch the network resourcegroup name is as it is a well-known api.

Existing clusters have the cluster resource group as the network resource group, therefore no change in credentials and permissions is required. And only new clusters that are created with shared Virtual Network operator
will have the network group different from cluster group as install-time.

So even if the existing clusters have their permission updating capacity taken away, this will not create any failure during upgrades.

This shared Virtual Network work is being done in https://github.com/openshift/installer/pull/2441

[1]: https://github.com/openshift/api/blob/9c3d92fbdc669baf068d5503f2f1b1e5076d40d3/config/v1/types_infrastructure.go#L31