### PR TITLE
Bug 1750338: improve permissions simulation by adding region info

### DIFF
--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -1453,6 +1453,11 @@ func testInfrastructure(infraName string) *configv1.Infrastructure {
 		Status: configv1.InfrastructureStatus{
 			Platform:           configv1.AWSPlatformType,
 			InfrastructureName: infraName,
+			PlatformStatus: &configv1.PlatformStatus{
+				AWS: &configv1.AWSPlatformStatus{
+					Region: "test-region-2",
+				},
+			},
 		},
 	}
 }

--- a/pkg/controller/secretannotator/aws/reconciler.go
+++ b/pkg/controller/secretannotator/aws/reconciler.go
@@ -156,7 +156,14 @@ func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secre
 	}
 
 	// Else, can we just pass through the current creds?
-	cloudCheckResult, err = ccaws.CheckCloudCredPassthrough(awsClient, r.Logger)
+	region, err := utils.LoadInfrastructureRegion(r.Client, r.Logger)
+	if err != nil {
+		return err
+	}
+	simParams := &ccaws.SimulateParams{
+		Region: region,
+	}
+	cloudCheckResult, err = ccaws.CheckCloudCredPassthrough(awsClient, simParams, r.Logger)
 	if err != nil {
 		r.updateSecretAnnotations(secret, constants.InsufficientAnnotation)
 		return fmt.Errorf("failed checking passthrough cloud creds: %v", err)

--- a/pkg/controller/secretannotator/aws/reconciler_test.go
+++ b/pkg/controller/secretannotator/aws/reconciler_test.go
@@ -56,6 +56,7 @@ const (
 	testAWSAccessKeyID     = "FAKEAWSACCESSKEYID"
 	testInfraName          = "testcluster-abc123"
 	testAWSSecretAccessKey = "KEEPITSECRET"
+	testAWSRegion          = "test-region-2"
 )
 
 var (
@@ -132,11 +133,26 @@ func TestSecretAnnotatorReconcile(t *testing.T) {
 				mockSimulatePrincipalPolicyCredMinterFail(mockAWSClient)
 
 				mockGetUser(mockAWSClient)
-				mockSimulatePrincipalPolicyCredPassthroughSuccess(mockAWSClient)
+				mockSimulatePrincipalPolicyCredPassthrough(mockAWSClient, testAWSRegion)
 
 				return mockAWSClient
 			},
 			validateAnnotationValue: constants.PassthroughAnnotation,
+		},
+		{
+			name:     "cred passthrough mode wrong region permission",
+			existing: []runtime.Object{testSecret()},
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetUser(mockAWSClient)
+				mockSimulatePrincipalPolicyCredMinterFail(mockAWSClient)
+
+				mockGetUser(mockAWSClient)
+				mockSimulatePrincipalPolicyCredPassthrough(mockAWSClient, "expect-this-region")
+
+				return mockAWSClient
+			},
+			validateAnnotationValue: constants.InsufficientAnnotation,
 		},
 		{
 			name:     "useless creds",
@@ -185,6 +201,11 @@ func TestSecretAnnotatorReconcile(t *testing.T) {
 				Status: configv1.InfrastructureStatus{
 					Platform:           configv1.AWSPlatformType,
 					InfrastructureName: testInfraName,
+					PlatformStatus: &configv1.PlatformStatus{
+						AWS: &configv1.AWSPlatformStatus{
+							Region: testAWSRegion,
+						},
+					},
 				},
 			}
 
@@ -286,11 +307,28 @@ func mockSimulatePrincipalPolicyCredMinterFail(mockAWSClient *mockaws.MockClient
 		})
 }
 
-func mockSimulatePrincipalPolicyCredPassthroughSuccess(mockAWSClient *mockaws.MockClient) {
+func mockSimulatePrincipalPolicyCredPassthrough(mockAWSClient *mockaws.MockClient, expectedRegion string) {
 	mockAWSClient.EXPECT().SimulatePrincipalPolicyPages(gomock.Any(), gomock.Any()).Return(nil).
 		Do(func(input *iam.SimulatePrincipalPolicyInput, f func(*iam.SimulatePolicyResponse, bool) bool) {
-			f(successfulSimulateResponse, true)
+			if checkRegionParamSet(input, expectedRegion) {
+				f(successfulSimulateResponse, true)
+			} else {
+				f(failedSimulationResponse, true)
+			}
 		})
+}
+
+func checkRegionParamSet(input *iam.SimulatePrincipalPolicyInput, expectedRegion string) bool {
+	for _, ctx := range input.ContextEntries {
+		if *ctx.ContextKeyName == "aws:RequestedRegion" {
+			for _, value := range ctx.ContextKeyValues {
+				if *value == expectedRegion {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 func mockSimulatePrincipalPolicyCredPassthroughFail(mockAWSClient *mockaws.MockClient) {


### PR DESCRIPTION
Allow providing an aws region to be used when performing the simulations.

IAM permissions can be defined in a way where permissions are granted as long as the region is set to some specific region(s). Add region info when simulating permissions testing so that we avoid false failures (ie we claim permission denied when it would actually work with an acceptable region set).
