### PR TITLE
initial scaffolding for CCO metrics

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -74,6 +74,7 @@ func NewRootCommand() *cobra.Command {
 			// Create a new Cmd to provide shared dependencies and start components
 			log.Info("setting up manager")
 			mgr, err := manager.New(cfg, manager.Options{
+				MetricsBindAddress:      ":2112",
 				LeaderElection:          true,
 				LeaderElectionNamespace: minterv1.CloudCredOperatorNamespace,
 				LeaderElectionID:        leaderElectionConfigMap,

--- a/pkg/controller/add_metrics.go
+++ b/pkg/controller/add_metrics.go
@@ -1,0 +1,10 @@
+package controller
+
+import (
+	"github.com/openshift/cloud-credential-operator/pkg/controller/metrics"
+)
+
+func init() {
+	// AddToManagerFUncs is a list of functions to create controller for and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, metrics.Add)
+}

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -1,0 +1,148 @@
+package metrics
+
+import (
+	"context"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	log "github.com/sirupsen/logrus"
+
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/metrics"
+
+	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
+)
+
+const (
+	controllerName = "metrics"
+)
+
+var (
+	metricCredentialsRequestTotal = prometheus.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "cco_credentials_requests",
+		Help: "Total number of credentials requests.",
+	}, []string{"cloud_type"})
+
+	// MetricControllerReconcileTime tracks the length of time our reconcile loops take. controller-runtime
+	// technically tracks this for us, but due to bugs currently also includes time in the queue, which leads to
+	// extremely strange results. For now, track our own metric.
+	MetricControllerReconcileTime = prometheus.NewHistogramVec(
+		prometheus.HistogramOpts{
+			Name:    "cco_controller_reconcile_seconds",
+			Help:    "Distribution of the length of time each controllers reconcile loop takes.",
+			Buckets: []float64{0.001, 0.01, 0.1, 1, 10, 30, 60, 120},
+		},
+		[]string{"controller"},
+	)
+)
+
+func init() {
+	metrics.Registry.MustRegister(metricCredentialsRequestTotal)
+
+	metrics.Registry.MustRegister(MetricControllerReconcileTime)
+}
+
+// Add creates a new metrics Calculator and adds it to the Manager.
+func Add(mgr manager.Manager, kubeConfig string) error {
+	mc := &Calculator{
+		Client:   mgr.GetClient(),
+		Interval: 2 * time.Minute,
+	}
+	err := mgr.Add(mc)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Calculator runs in a goroutine and periodically calculates and publishes
+// Prometheus metrics which will be exposed at our /metrics endpoint. Note that this is not
+// a standard controller watching Kube resources, it runs periodically and then goes to sleep.
+//
+// This should be used for metrics which do not fit well into controller reconcile loops,
+// things that are calculated globally rather than metrics releated to specific reconciliations.
+type Calculator struct {
+	Client client.Client
+
+	// Interval is the length of time we sleep between metrics calculations.
+	Interval time.Duration
+}
+
+// Start begins the metrics calculation loop.
+func (mc *Calculator) Start(stopCh <-chan struct{}) error {
+	log.Info("started metrics calculator goroutine")
+
+	// Run forever, sleep at the end:
+	wait.Until(func() {
+		start := time.Now()
+		mcLog := log.WithField("controller", controllerName)
+		defer func() {
+			dur := time.Since(start)
+			MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
+			mcLog.WithField("elapsed", dur).Info("reconcile complete")
+		}()
+
+		mcLog.Info("calculating metrics for all CredentialsRequests")
+
+		credRequests := &credreqv1.CredentialsRequestList{}
+		if err := mc.Client.List(context.TODO(), credRequests); err != nil {
+			mcLog.WithError(err).Error("error listing CredentialsRequests")
+		} else {
+			accumulator := newAccumulator(mcLog)
+			for _, cr := range credRequests.Items {
+				accumulator.processCR(&cr)
+			}
+
+			accumulator.setMetrics()
+		}
+	}, mc.Interval, stopCh)
+
+	return nil
+}
+
+func cloudProviderSpecToMetricsKey(cloud string) string {
+	switch cloud {
+	case "AWSProviderSpec":
+		return "aws"
+	case "AzureProviderSpec":
+		return "azure"
+	case "GCPProviderSpec":
+		return "gcp"
+	case "OpenStackProviderSpec":
+		return "openstack"
+	default:
+		return "unknown"
+	}
+}
+
+type credRequestAccumulator struct {
+	logger log.FieldLogger
+
+	crTotals map[string]int
+}
+
+func newAccumulator(logger log.FieldLogger) *credRequestAccumulator {
+	return &credRequestAccumulator{
+		logger:   logger,
+		crTotals: map[string]int{},
+	}
+}
+
+func (a *credRequestAccumulator) processCR(cr *credreqv1.CredentialsRequest) {
+	cloudType, err := utils.GetCredentialsRequestCloudType(cr.Spec.ProviderSpec)
+	if err != nil {
+		a.logger.WithError(err).Warningf("unable to determine cloud type for CredentialsRequest: %v", cr.Name)
+	}
+	cloudKey := cloudProviderSpecToMetricsKey(cloudType)
+	a.crTotals[cloudKey]++
+}
+
+func (a *credRequestAccumulator) setMetrics() {
+	for k, v := range a.crTotals {
+		metricCredentialsRequestTotal.WithLabelValues(k).Set(float64(v))
+	}
+}

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -1,0 +1,87 @@
+package metrics
+
+import (
+	"testing"
+
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+)
+
+var (
+	codec *credreqv1.ProviderCodec
+)
+
+func TestCredentialsRequests(t *testing.T) {
+	var err error
+	codec, err = credreqv1.NewCodec()
+	if err != nil {
+		t.Fatalf("failed to create codec: %v", err)
+	}
+
+	logger := log.WithField("controller", "metricscontrollertest")
+
+	awsCredRequests := []credreqv1.CredentialsRequest{
+		testAWSCredRequest("a1"),
+	}
+
+	gcpCredRequests := []credreqv1.CredentialsRequest{
+		testGCPCredRequest("g1"),
+	}
+
+	credRequests := []credreqv1.CredentialsRequest{}
+	credRequests = append(credRequests, awsCredRequests...)
+	credRequests = append(credRequests, gcpCredRequests...)
+
+	accumulator := newAccumulator(logger)
+
+	for _, cr := range credRequests {
+		accumulator.processCR(&cr)
+	}
+
+	assert.Equal(t, len(awsCredRequests), accumulator.crTotals["aws"])
+	assert.Equal(t, len(gcpCredRequests), accumulator.crTotals["gcp"])
+}
+
+func testAWSCredRequest(name string) credreqv1.CredentialsRequest {
+	cr := credreqv1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-cloud-credential-operator",
+		},
+		Spec: credreqv1.CredentialsRequestSpec{},
+	}
+
+	awsProviderSpec, err := codec.EncodeProviderSpec(
+		&credreqv1.AWSProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "AWSProviderSpec",
+			},
+		},
+	)
+	if err != nil {
+		panic("failed to encode AWSProviderSpec for test")
+	}
+	cr.Spec.ProviderSpec = awsProviderSpec
+	return cr
+}
+
+func testGCPCredRequest(name string) credreqv1.CredentialsRequest {
+	gcpProviderSpec, err := codec.EncodeProviderSpec(
+		&credreqv1.GCPProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "GCPProviderSpec",
+			},
+		},
+	)
+	if err != nil {
+		panic("failed to encode GCPProviderSpec for test")
+	}
+	cr := testAWSCredRequest(name)
+	cr.Spec.ProviderSpec = gcpProviderSpec
+
+	return cr
+}


### PR DESCRIPTION
Add the bare minimum of metrics reporting. Report total number of cred requests, and the reconcile times for the various controllers.

Note: when running the controller locally, you can view the metrics at http://localhost:2112/metrics