### PR TITLE
enable prometheus to scrape metrics

### DIFF
--- a/config/kustomization.yaml
+++ b/config/kustomization.yaml
@@ -13,8 +13,12 @@ namespace: openshift-cloud-credential-operator
 resources:
 - rbac/cloud-credential-operator_role.yaml
 - rbac/cloud-credential-operator_role_binding.yaml
+- rbac/prometheus_role.yaml
+- rbac/prometheus_role_binding.yaml
 - manager/namespace.yaml
 - manager/service.yaml
 - manager/deployment.yaml
+- manager/servicemonitor.yaml
+- manager/metrics-service.yaml
 
 

--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -18,6 +18,7 @@ spec:
   template:
     metadata:
       labels:
+        app: cloud-credential-operator
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:

--- a/config/manager/metrics-service.yaml
+++ b/config/manager/metrics-service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: cco-metrics
+  namespace: openshift-cloud-credential-operator
+spec:
+  ports:
+  - name: cco-metrics
+    port: 2112
+    protocol: TCP
+    targetPort: 2112
+  selector:
+    app: cloud-credential-operator
+  sessionAffinity: None
+  type: ClusterIP

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -6,4 +6,5 @@ metadata:
   labels:
     controller-tools.k8s.io: "1.0"
     openshift.io/run-level: "1"
+    openshift.io/cluster-monitoring: "true"
   name: openshift-cloud-credential-operator

--- a/config/manager/servicemonitor.yaml
+++ b/config/manager/servicemonitor.yaml
@@ -1,0 +1,18 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cloud-credential-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: cco-metrics
+    scheme: http
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: cco.openshift-cloud-credential-operator.svc
+  namespaceSelector:
+    matchNames:
+    - openshift-cloud-credential-operator
+  selector: {}

--- a/config/rbac/prometheus_role.yaml
+++ b/config/rbac/prometheus_role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/rbac/prometheus_role_binding.yaml
+++ b/config/rbac/prometheus_role_binding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -5,8 +5,26 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     controller-tools.k8s.io: "1.0"
+    openshift.io/cluster-monitoring: "true"
     openshift.io/run-level: "1"
   name: openshift-cloud-credential-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
@@ -98,6 +116,20 @@ rules:
   - update
 ---
 apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: prometheus-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   creationTimestamp: null
@@ -118,6 +150,22 @@ metadata:
     config.openshift.io/inject-trusted-cabundle: "true"
   name: cco-trusted-ca
   namespace: openshift-cloud-credential-operator
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cco-metrics
+  namespace: openshift-cloud-credential-operator
+spec:
+  ports:
+  - name: cco-metrics
+    port: 2112
+    protocol: TCP
+    targetPort: 2112
+  selector:
+    app: cloud-credential-operator
+  sessionAffinity: None
+  type: ClusterIP
 ---
 apiVersion: v1
 kind: Service
@@ -154,6 +202,7 @@ spec:
   template:
     metadata:
       labels:
+        app: cloud-credential-operator
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
@@ -210,3 +259,22 @@ spec:
           name: cco-trusted-ca
           optional: true
         name: cco-trusted-ca
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cloud-credential-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: cco-metrics
+    scheme: http
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: cco.openshift-cloud-credential-operator.svc
+  namespaceSelector:
+    matchNames:
+    - openshift-cloud-credential-operator
+  selector: {}


### PR DESCRIPTION
this involves:
- [x] labeling the namespace with openshift.io/cluster-monitoring: "true"
- [x] creating a Service to point to the pods metrics port (2112)
- [x] creating a ServiceMonitor to tell prometheus where to scrape
- [x] creating a Role that allows get/list/watch on endpoints/service/pods (for prometheus to use)
- [x] a RoleBinding to grant the prometheus ServiceAccount the permissions defined in the above Role

update the kustomize pieces to use these new files when generating manifests.