### PR TITLE
alert on insufficient cluster cloud creds

### DIFF
--- a/config/manager/prometheusrule.yaml
+++ b/config/manager/prometheusrule.yaml
@@ -7,24 +7,31 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: TargetNamespaceMissing
+    - alert: CCOTargetNamespaceMissing
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) pointing to non-existant namespace
-    - alert: ProvisioningFailed
+    - alert: CCOProvisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be fulfilled
-    - alert: DeprovisioningFailed
+    - alert: CCODeprovisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be cleaned up
+    - alert: CCOInsufficientCloudCreds
+      expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"} > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: Cluster's cloud credentials insufficient for minting or passthrough

--- a/manifests/01_deployment.yaml
+++ b/manifests/01_deployment.yaml
@@ -269,7 +269,7 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: TargetNamespaceMissing
+    - alert: CCOTargetNamespaceMissing
       annotations:
         summary: CredentialsRequest(s) pointing to non-existant namespace
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
@@ -277,7 +277,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: ProvisioningFailed
+    - alert: CCOProvisioningFailed
       annotations:
         summary: CredentialsRequest(s) unable to be fulfilled
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
@@ -285,10 +285,18 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: DeprovisioningFailed
+    - alert: CCODeprovisioningFailed
       annotations:
         summary: CredentialsRequest(s) unable to be cleaned up
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
+        > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CCOInsufficientCloudCreds
+      annotations:
+        summary: Cluster's cloud credentials insufficient for minting or passthrough
+      expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
         > 0
       for: 5m
       labels:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -256,27 +256,34 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: TargetNamespaceMissing
+    - alert: CCOTargetNamespaceMissing
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) pointing to non-existant namespace
-    - alert: ProvisioningFailed
+    - alert: CCOProvisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be fulfilled
-    - alert: DeprovisioningFailed
+    - alert: CCODeprovisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be cleaned up
+    - alert: CCOInsufficientCloudCreds
+      expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"} > 0
+      for: 5m
+      labels:
+        severity: warning
+      annotations:
+        summary: Cluster's cloud credentials insufficient for minting or passthrough
 `)
 
 func config_manager_prometheusrule_yaml() ([]byte, error) {


### PR DESCRIPTION
also, rename the alerts in Prometheus so that all the CCO-specific credentials will be grouped by name