### PR TITLE
Bug 1717255: add alert for when operator is down

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,7 @@ manifests:
 	go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go rbac --name cloud-credential-operator
 	# kustomize and move to manifests dir for release image:
 	kustomize build config > manifests/05_deployment.yaml
+	cp config/manager/namespace.yaml manifests/00_namespace.yaml
 	cp config/crds/cloudcredential_v1_credentialsrequest.yaml manifests/00_v1_crd.yaml
 
 # Run go fmt against code

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    openshift.io/node-selector: ""
+  labels:
+    controller-tools.k8s.io: "1.0"
+    openshift.io/run-level: "1"
+    openshift.io/cluster-monitoring: "true"
+  name: openshift-cloud-credential-operator

--- a/config/manager/prometheusrule.yaml
+++ b/config/manager/prometheusrule.yaml
@@ -35,3 +35,10 @@ spec:
         severity: warning
       annotations:
         summary: Cluster's cloud credentials insufficient for minting or passthrough
+    - alert: CCOperatorDown
+      annotations:
+        summary: cloud-credential-operator pod not running
+      expr: absent(up{job="cco-metrics"} == 1)
+      for: 5m
+      labels:
+        severity: critical

--- a/config/rbac/prometheus_role.yaml
+++ b/config/rbac/prometheus_role.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -1,10 +1,10 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  name: prometheus-k8s
-  namespace: openshift-cloud-credential-operator
   annotations:
     exclude.release.openshift.io/internal-openshift-hosted: "true"
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
 rules:
 - apiGroups:
   - ""

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -292,6 +292,13 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: CCOperatorDown
+      annotations:
+        summary: cloud-credential-operator pod not running
+      expr: absent(up{job="cco-metrics"} == 1)
+      for: 5m
+      labels:
+        severity: critical
 ---
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -247,21 +247,6 @@ func config_manager_namespace_yaml() ([]byte, error) {
 	return _config_manager_namespace_yaml, nil
 }
 
-var _config_manager_operator_configmap_yaml = []byte(`apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: cloud-credential-operator-config
-  namespace: openshift-cloud-credential-operator
-  annotations:
-    release.openshift.io/create-only: "true"
-data:
-  disabled: "true"
-`)
-
-func config_manager_operator_configmap_yaml() ([]byte, error) {
-	return _config_manager_operator_configmap_yaml, nil
-}
-
 var _config_manager_prometheusrule_yaml = []byte(`apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
@@ -467,6 +452,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""
@@ -529,7 +516,6 @@ var _bindata = map[string]func() ([]byte, error){
 	"config/manager/deployment.yaml":                          config_manager_deployment_yaml,
 	"config/manager/metrics-service.yaml":                     config_manager_metrics_service_yaml,
 	"config/manager/namespace.yaml":                           config_manager_namespace_yaml,
-	"config/manager/operator-configmap.yaml":                  config_manager_operator_configmap_yaml,
 	"config/manager/prometheusrule.yaml":                      config_manager_prometheusrule_yaml,
 	"config/manager/service.yaml":                             config_manager_service_yaml,
 	"config/manager/servicemonitor.yaml":                      config_manager_servicemonitor_yaml,
@@ -585,13 +571,12 @@ var _bintree = &_bintree_t{nil, map[string]*_bintree_t{
 			"cloudcredential_v1_credentialsrequest.yaml": {config_crds_cloudcredential_v1_credentialsrequest_yaml, map[string]*_bintree_t{}},
 		}},
 		"manager": {nil, map[string]*_bintree_t{
-			"deployment.yaml":         {config_manager_deployment_yaml, map[string]*_bintree_t{}},
-			"metrics-service.yaml":    {config_manager_metrics_service_yaml, map[string]*_bintree_t{}},
-			"namespace.yaml":          {config_manager_namespace_yaml, map[string]*_bintree_t{}},
-			"operator-configmap.yaml": {config_manager_operator_configmap_yaml, map[string]*_bintree_t{}},
-			"prometheusrule.yaml":     {config_manager_prometheusrule_yaml, map[string]*_bintree_t{}},
-			"service.yaml":            {config_manager_service_yaml, map[string]*_bintree_t{}},
-			"servicemonitor.yaml":     {config_manager_servicemonitor_yaml, map[string]*_bintree_t{}},
+			"deployment.yaml":      {config_manager_deployment_yaml, map[string]*_bintree_t{}},
+			"metrics-service.yaml": {config_manager_metrics_service_yaml, map[string]*_bintree_t{}},
+			"namespace.yaml":       {config_manager_namespace_yaml, map[string]*_bintree_t{}},
+			"prometheusrule.yaml":  {config_manager_prometheusrule_yaml, map[string]*_bintree_t{}},
+			"service.yaml":         {config_manager_service_yaml, map[string]*_bintree_t{}},
+			"servicemonitor.yaml":  {config_manager_servicemonitor_yaml, map[string]*_bintree_t{}},
 		}},
 		"rbac": {nil, map[string]*_bintree_t{
 			"cloud-credential-operator_role.yaml":         {config_rbac_cloud_credential_operator_role_yaml, map[string]*_bintree_t{}},

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -284,6 +284,13 @@ spec:
         severity: warning
       annotations:
         summary: Cluster's cloud credentials insufficient for minting or passthrough
+    - alert: CCOperatorDown
+      annotations:
+        summary: cloud-credential-operator pod not running
+      expr: absent(up{job="cco-metrics"} == 1)
+      for: 5m
+      labels:
+        severity: critical
 `)
 
 func config_manager_prometheusrule_yaml() ([]byte, error) {


### PR DESCRIPTION
use the 'up' metric to detect when the CCO pod is down (ie Promtheus cannot scrape metrics).