### PR TITLE
Add manifest annotations for hosted deployment exclusions

### DIFF
--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -3,6 +3,8 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/07_cred-iam-ro.yaml
+++ b/manifests/07_cred-iam-ro.yaml
@@ -5,6 +5,8 @@ metadata:
     controller-tools.k8s.io: "1.0"
   name: cloud-credential-operator-iam-ro
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   secretRef:
     name: cloud-credential-operator-iam-ro-creds

--- a/manifests/10_cluster-operator.yaml
+++ b/manifests/10_cluster-operator.yaml
@@ -2,6 +2,8 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: cloud-credential
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 status:
   versions:
   - name: operator


### PR DESCRIPTION
Enables the CVO to exclude manifests in an externally hosted control plane deployment
See https://github.com/openshift/cluster-version-operator/pull/252