### PR TITLE
Bug 1776079: Azure: check existing role assignments before creating a new one

### DIFF
--- a/pkg/azure/passthrough_test.go
+++ b/pkg/azure/passthrough_test.go
@@ -132,13 +132,14 @@ var (
 		},
 	}
 
-	clusterDNS = openshiftapiv1.DNS{
+	testDNSResourceGroupName = "os4-common"
+	clusterDNS               = openshiftapiv1.DNS{
 		ObjectMeta: metav1.ObjectMeta{
 			Name: "cluster",
 		},
 		Spec: openshiftapiv1.DNSSpec{
 			PublicZone: &openshiftapiv1.DNSZone{
-				ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/os4-common/providers/Microsoft.Network/dnszones/devcluster.openshift.com",
+				ID: "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/" + testDNSResourceGroupName + "/providers/Microsoft.Network/dnszones/devcluster.openshift.com",
 			},
 		},
 	}


### PR DESCRIPTION
Currently when re-reconciling an already-provisioned CredentialsRequest in Azure, the actuator will just always attempt to create a role assignment even if it already exists. There is error handling to catch the "RoleAssignmentExists" error, and it just moves along to the next task.

This results in the Resource Group where the cluster is installed having periodic entries in the Azure console Activity Log for the Resource Group recording these (non-critical) errors:

```
{
    "authorization": {
        "action": "Microsoft.Authorization/roleAssignments/write",
        "scope": "/subscriptions/SUBSCRIPTION_ID/resourceGroups/jdiaz-az-gpqgx-rg/providers/Microsoft.Authorization/roleAssignments/94025186-5e7b-4e18-88de-4625cac3ed19"
    },
    "level": "Error",
    "operationName": {
        "value": "Microsoft.Authorization/roleAssignments/write",
        "localizedValue": "Create role assignment"
    },
    "resourceGroupName": "jdiaz-az-gpqgx-rg",
    "subStatus": {
        "value": "Conflict",
        "localizedValue": "Conflict (HTTP Status Code: 409)"
    },
    "properties": {
        "statusCode": "Conflict",
        "serviceRequestId": "931445cc-fbc6-469a-a6f4-2f7750788255",
        "statusMessage": "{\"error\":{\"code\":\"RoleAssignmentExists\",\"message\":\"The role assignment already exists.\"}}"
    },
}
```

Change the logic to pull the current list of Role Assignments so that we can avoid making unnecessary CreateRoleAssignment calls.