### PR TITLE
Bug 1776394: fix up ServiceMonitor CR

### DIFF
--- a/config/manager/servicemonitor.yaml
+++ b/config/manager/servicemonitor.yaml
@@ -5,13 +5,9 @@ metadata:
   namespace: openshift-cloud-credential-operator
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: cco-metrics
     scheme: http
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: cco.openshift-cloud-credential-operator.svc
   namespaceSelector:
     matchNames:
     - openshift-cloud-credential-operator

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -307,13 +307,9 @@ metadata:
   namespace: openshift-cloud-credential-operator
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: cco-metrics
     scheme: http
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: cco.openshift-cloud-credential-operator.svc
   namespaceSelector:
     matchNames:
     - openshift-cloud-credential-operator

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -324,13 +324,9 @@ metadata:
   namespace: openshift-cloud-credential-operator
 spec:
   endpoints:
-  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-    interval: 30s
+  - interval: 30s
     port: cco-metrics
     scheme: http
-    tlsConfig:
-      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
-      serverName: cco.openshift-cloud-credential-operator.svc
   namespaceSelector:
     matchNames:
     - openshift-cloud-credential-operator


### PR DESCRIPTION
CCO exposes metrics through HTTP, so no need to fill out HTTPS-specific fields in the ServiceMonitor CR.