### PR TITLE
Use `CloudCredentialOperator` as alert prefix for humans

### DIFF
--- a/config/manager/prometheusrule.yaml
+++ b/config/manager/prometheusrule.yaml
@@ -7,35 +7,35 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: CCOTargetNamespaceMissing
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: CredentialsRequest(s) pointing to non-existant namespace
-    - alert: CCOProvisioningFailed
+    - alert: CloudCredentialOperatorProvisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: CredentialsRequest(s) unable to be fulfilled
-    - alert: CCODeprovisioningFailed
+    - alert: CloudCredentialOperatorDeprovisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: CredentialsRequest(s) unable to be cleaned up
-    - alert: CCOInsufficientCloudCreds
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: Cluster's cloud credentials insufficient for minting or passthrough
-    - alert: CCOperatorDown
+    - alert: CloudCredentialOperatorDown
       expr: absent(up{job="cco-metrics"} == 1)
       for: 5m
       labels:

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -260,7 +260,7 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: CCOTargetNamespaceMissing
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
       annotations:
         message: CredentialsRequest(s) pointing to non-existant namespace
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
@@ -268,7 +268,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCOProvisioningFailed
+    - alert: CloudCredentialOperatorProvisioningFailed
       annotations:
         message: CredentialsRequest(s) unable to be fulfilled
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
@@ -276,7 +276,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCODeprovisioningFailed
+    - alert: CloudCredentialOperatorDeprovisioningFailed
       annotations:
         message: CredentialsRequest(s) unable to be cleaned up
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
@@ -284,7 +284,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCOInsufficientCloudCreds
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
       annotations:
         message: Cluster's cloud credentials insufficient for minting or passthrough
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
@@ -292,7 +292,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCOperatorDown
+    - alert: CloudCredentialOperatorDown
       annotations:
         message: cloud-credential-operator pod not running
       expr: absent(up{job="cco-metrics"} == 1)

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -256,35 +256,35 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: CCOTargetNamespaceMissing
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: CredentialsRequest(s) pointing to non-existant namespace
-    - alert: CCOProvisioningFailed
+    - alert: CloudCredentialOperatorProvisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: CredentialsRequest(s) unable to be fulfilled
-    - alert: CCODeprovisioningFailed
+    - alert: CloudCredentialOperatorDeprovisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: CredentialsRequest(s) unable to be cleaned up
-    - alert: CCOInsufficientCloudCreds
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         message: Cluster's cloud credentials insufficient for minting or passthrough
-    - alert: CCOperatorDown
+    - alert: CloudCredentialOperatorDown
       expr: absent(up{job="cco-metrics"} == 1)
       for: 5m
       labels:


### PR DESCRIPTION
CC is far too generic to be an alert name and confused an
admin (me) when looking at clusters.

Thank you for adding alerts