### PR TITLE
Bug 1781798: Use `CloudCredentialOperator` as alert prefix for humans

### DIFF
--- a/config/manager/prometheusrule.yaml
+++ b/config/manager/prometheusrule.yaml
@@ -7,38 +7,38 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: CCOTargetNamespaceMissing
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) pointing to non-existant namespace
-    - alert: CCOProvisioningFailed
+    - alert: CloudCredentialOperatorProvisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be fulfilled
-    - alert: CCODeprovisioningFailed
+    - alert: CloudCredentialOperatorDeprovisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be cleaned up
-    - alert: CCOInsufficientCloudCreds
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: Cluster's cloud credentials insufficient for minting or passthrough
-    - alert: CCOperatorDown
-      annotations:
-        summary: cloud-credential-operator pod not running
+    - alert: CloudCredentialOperatorDown
       expr: absent(up{job="cco-metrics"} == 1)
       for: 5m
       labels:
         severity: critical
+      annotations:
+        summary: cloud-credential-operator pod not running

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -260,7 +260,7 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: CCOTargetNamespaceMissing
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
       annotations:
         summary: CredentialsRequest(s) pointing to non-existant namespace
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
@@ -268,7 +268,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCOProvisioningFailed
+    - alert: CloudCredentialOperatorProvisioningFailed
       annotations:
         summary: CredentialsRequest(s) unable to be fulfilled
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
@@ -276,7 +276,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCODeprovisioningFailed
+    - alert: CloudCredentialOperatorDeprovisioningFailed
       annotations:
         summary: CredentialsRequest(s) unable to be cleaned up
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
@@ -284,7 +284,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCOInsufficientCloudCreds
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
       annotations:
         summary: Cluster's cloud credentials insufficient for minting or passthrough
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
@@ -292,7 +292,7 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CCOperatorDown
+    - alert: CloudCredentialOperatorDown
       annotations:
         summary: cloud-credential-operator pod not running
       expr: absent(up{job="cco-metrics"} == 1)

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -256,41 +256,41 @@ spec:
   groups:
   - name: CloudCredentialOperator
     rules:
-    - alert: CCOTargetNamespaceMissing
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) pointing to non-existant namespace
-    - alert: CCOProvisioningFailed
+    - alert: CloudCredentialOperatorProvisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be fulfilled
-    - alert: CCODeprovisioningFailed
+    - alert: CloudCredentialOperatorDeprovisioningFailed
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: CredentialsRequest(s) unable to be cleaned up
-    - alert: CCOInsufficientCloudCreds
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"} > 0
       for: 5m
       labels:
         severity: warning
       annotations:
         summary: Cluster's cloud credentials insufficient for minting or passthrough
-    - alert: CCOperatorDown
-      annotations:
-        summary: cloud-credential-operator pod not running
+    - alert: CloudCredentialOperatorDown
       expr: absent(up{job="cco-metrics"} == 1)
       for: 5m
       labels:
         severity: critical
+      annotations:
+        summary: cloud-credential-operator pod not running
 `)
 
 func config_manager_prometheusrule_yaml() ([]byte, error) {


### PR DESCRIPTION
CC is far too generic to be an alert name.

manual cherry-pick into release-4.3 to resolve the conflicts.

Backports #144 