### PR TITLE
Bug 1781109: pre-populate conditions with count of zero

### DIFF
--- a/pkg/controller/credentialsrequest/constants/constants.go
+++ b/pkg/controller/credentialsrequest/constants/constants.go
@@ -1,0 +1,16 @@
+package constants
+
+import (
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+)
+
+var (
+	// FailureConditionTypes is a list of all conditions where the overall controller status would not
+	// be healthy.
+	FailureConditionTypes = []minterv1.CredentialsRequestConditionType{
+		minterv1.InsufficientCloudCredentials,
+		minterv1.MissingTargetNamespace,
+		minterv1.CredentialsProvisionFailure,
+		minterv1.CredentialsDeprovisionFailure,
+	}
+)

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller.go
@@ -27,6 +27,7 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/internalcontroller"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/metrics"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
@@ -600,7 +601,7 @@ func setIgnoredCondition(cr *minterv1.CredentialsRequest, clusterPlatform config
 
 	// Also clear any other conditions since we are ignoring this cred request,
 	// and we don't want to be in a degraded state b/c of cred requests that we're ignoring.
-	for _, cond := range failureConditionTypes {
+	for _, cond := range constants.FailureConditionTypes {
 		cr.Status.Conditions = utils.SetCredentialsRequestCondition(cr.Status.Conditions, cond,
 			corev1.ConditionFalse, reason, msg, updateCheck)
 	}

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -44,6 +44,7 @@ import (
 	minteraws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/aws/actuator"
 	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/constants"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/controller/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 
@@ -840,7 +841,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 			existing: []runtime.Object{
 				func() runtime.Object {
 					cr := testGCPCredentialsRequest(t)
-					for _, cond := range failureConditionTypes {
+					for _, cond := range constants.FailureConditionTypes {
 						cr.Status.Conditions = append(cr.Status.Conditions, minterv1.CredentialsRequestCondition{
 							Type:   cond,
 							Status: corev1.ConditionTrue,

--- a/pkg/controller/credentialsrequest/status.go
+++ b/pkg/controller/credentialsrequest/status.go
@@ -12,6 +12,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 	"github.com/openshift/cloud-credential-operator/pkg/util/clusteroperator"
 
@@ -32,16 +33,6 @@ const (
 	reasonReconcilingComplete       = "ReconcilingComplete"
 	reasonCredentialsNotProvisioned = "CredentialsNotProvisioned"
 	reasonOperatorDisabled          = "OperatorDisabledByAdmin"
-)
-
-var (
-	// If any of these conditions are present and true, we consider it a failing credential:
-	failureConditionTypes = []minterv1.CredentialsRequestConditionType{
-		minterv1.InsufficientCloudCredentials,
-		minterv1.MissingTargetNamespace,
-		minterv1.CredentialsProvisionFailure,
-		minterv1.CredentialsDeprovisionFailure,
-	}
 )
 
 // syncOperatorStatus computes the operator's current status and
@@ -180,7 +171,7 @@ func computeStatusConditions(
 	for _, cr := range validCredRequests {
 		// Check for provision failure conditions:
 		foundFailure := false
-		for _, t := range failureConditionTypes {
+		for _, t := range constants.FailureConditionTypes {
 			failureCond := utils.FindCredentialsRequestCondition(cr.Status.Conditions, t)
 			if failureCond != nil && failureCond.Status == corev1.ConditionTrue {
 				foundFailure = true

--- a/pkg/controller/metrics/metrics.go
+++ b/pkg/controller/metrics/metrics.go
@@ -15,6 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/metrics"
 
 	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/controller/utils"
 )
 
@@ -135,11 +136,19 @@ type credRequestAccumulator struct {
 }
 
 func newAccumulator(logger log.FieldLogger) *credRequestAccumulator {
-	return &credRequestAccumulator{
+	acc := &credRequestAccumulator{
 		logger:       logger,
 		crTotals:     map[string]int{},
 		crConditions: map[credreqv1.CredentialsRequestConditionType]int{},
 	}
+
+	// make entries with '0' so we make sure to send updated metrics for any
+	// condititons that may have cleared
+	for _, c := range constants.FailureConditionTypes {
+		acc.crConditions[c] = 0
+	}
+
+	return acc
 }
 
 func (a *credRequestAccumulator) processCR(cr *credreqv1.CredentialsRequest) {

--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -10,6 +10,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/controller/credentialsrequest/constants"
 )
 
 var (
@@ -86,6 +87,18 @@ func TestCredentialsRequests(t *testing.T) {
 	assert.Equal(t, 1, accumulator.crConditions[credreqv1.CredentialsProvisionFailure])
 	assert.Equal(t, 1, accumulator.crConditions[credreqv1.Ignored])
 	assert.Equal(t, 1, accumulator.crConditions[credreqv1.InsufficientCloudCredentials])
+}
+
+func TestMetricsInitialization(t *testing.T) {
+	logger := log.WithField("controller", "metricscontrollertest")
+
+	accumulator := newAccumulator(logger)
+
+	// Assert that all possible conditions have explicit '0' values
+	// after initializing the accumulator.
+	for _, c := range constants.FailureConditionTypes {
+		assert.Zero(t, accumulator.crConditions[c])
+	}
 }
 
 func testCredReqWithConditions(cr credreqv1.CredentialsRequest, conditions []credreqv1.CredentialsRequestCondition) credreqv1.CredentialsRequest {


### PR DESCRIPTION
If a condition has previously been firing and later clears, the metrics calucation logic would not have any CredentialsRequests with the condition firing so there would be no updates to the metrics capturing that condition. This means the condition would never clear.

When initializtion a run for calculating current metrics, pre-populate all the failure condition types to '0' so that we ensure metrics are sent/cleared.