### PR TITLE
Fix exclusion annotation for hosted use case

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -8,6 +8,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   annotations:
     config.openshift.io/inject-proxy: "manager"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   selector:
     matchLabels:

--- a/config/manager/prometheusrule.yaml
+++ b/config/manager/prometheusrule.yaml
@@ -3,6 +3,8 @@ kind: PrometheusRule
 metadata:
   name: cloud-credential-operator-alerts
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
   - name: CloudCredentialOperator

--- a/config/rbac/prometheus_role.yaml
+++ b/config/rbac/prometheus_role.yaml
@@ -3,8 +3,6 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
-  annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -1,8 +1,6 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
 rules:
@@ -178,6 +176,7 @@ kind: Deployment
 metadata:
   annotations:
     config.openshift.io/inject-proxy: manager
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
@@ -254,6 +253,8 @@ spec:
 apiVersion: monitoring.coreos.com/v1
 kind: PrometheusRule
 metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
   name: cloud-credential-operator-alerts
   namespace: openshift-cloud-credential-operator
 spec:

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -129,6 +129,7 @@ metadata:
     controller-tools.k8s.io: "1.0"
   annotations:
     config.openshift.io/inject-proxy: "manager"
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   selector:
     matchLabels:
@@ -252,6 +253,8 @@ kind: PrometheusRule
 metadata:
   name: cloud-credential-operator-alerts
   namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
 spec:
   groups:
   - name: CloudCredentialOperator
@@ -455,8 +458,6 @@ kind: Role
 metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
-  annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
The annotation was in the wrong resource. It needs to be applied to both the deployment and the prometheus rule.