### PR TITLE
Bug 1794536: don't report conditions when CCO is disabled

### DIFF
--- a/pkg/controller/metrics/metrics_test.go
+++ b/pkg/controller/metrics/metrics_test.go
@@ -46,47 +46,86 @@ func TestCredentialsRequests(t *testing.T) {
 
 	logger := log.WithField("controller", "metricscontrollertest")
 
-	awsCredRequests := []credreqv1.CredentialsRequest{
-		// just a regular cred request
-		testAWSCredRequest("aregular"),
-		// missing namespace condition
-		testCredReqWithConditions(testAWSCredRequest("amissingnamespace"), []credreqv1.CredentialsRequestCondition{missingTargetNamespaceCond}),
-		// provision failed condition
-		testCredReqWithConditions(testAWSCredRequest("aprovisionfailed"), []credreqv1.CredentialsRequestCondition{provisionFailedCond}),
-		// provision failed false condition
-		func() credreqv1.CredentialsRequest {
-			cr := testCredReqWithConditions(testAWSCredRequest("aprovisionnotfailed"), []credreqv1.CredentialsRequestCondition{provisionFailedCond})
-			cr.Status.Conditions[0].Status = corev1.ConditionFalse
-			return cr
-		}(),
-		// insufficient cloud creds condition
-		testCredReqWithConditions(testAWSCredRequest("ainsufficientcreds"), []credreqv1.CredentialsRequestCondition{insufficientCredsCond}),
+	tests := []struct {
+		name        string
+		credReqs    []credreqv1.CredentialsRequest
+		ccoDisabled bool
+		validate    func(*credRequestAccumulator, *testing.T)
+	}{
+		{
+			name: "mixed credentials",
+			credReqs: []credreqv1.CredentialsRequest{
+				// just a regular cred request
+				testAWSCredRequest("aregular"),
+				// missing namespace condition
+				testCredReqWithConditions(testAWSCredRequest("amissingnamespace"), []credreqv1.CredentialsRequestCondition{missingTargetNamespaceCond}),
+				// provision failed condition
+				testCredReqWithConditions(testAWSCredRequest("aprovisionfailed"), []credreqv1.CredentialsRequestCondition{provisionFailedCond}),
+				// provision failed false condition
+				func() credreqv1.CredentialsRequest {
+					cr := testCredReqWithConditions(testAWSCredRequest("aprovisionnotfailed"), []credreqv1.CredentialsRequestCondition{provisionFailedCond})
+					cr.Status.Conditions[0].Status = corev1.ConditionFalse
+					return cr
+				}(),
+				// insufficient cloud creds condition
+				testCredReqWithConditions(testAWSCredRequest("ainsufficientcreds"), []credreqv1.CredentialsRequestCondition{insufficientCredsCond}),
+
+				// regular GCP credreq
+				testGCPCredRequest("gregular"),
+				// GCP credreq with condition set
+				testCredReqWithConditions(testGCPCredRequest("gignored"), []credreqv1.CredentialsRequestCondition{ignoredCond}),
+			},
+			validate: func(accumulator *credRequestAccumulator, t *testing.T) {
+				// total cred requests
+				assert.Equal(t, 5, accumulator.crTotals["aws"])
+				assert.Equal(t, 2, accumulator.crTotals["gcp"])
+
+				// conditions
+				assert.Equal(t, 1, accumulator.crConditions[credreqv1.MissingTargetNamespace])
+				assert.Equal(t, 1, accumulator.crConditions[credreqv1.CredentialsProvisionFailure])
+				assert.Equal(t, 1, accumulator.crConditions[credreqv1.Ignored])
+				assert.Equal(t, 1, accumulator.crConditions[credreqv1.InsufficientCloudCredentials])
+			},
+		},
+		{
+			name:        "cco disabled report no conditions",
+			ccoDisabled: true,
+			credReqs: []credreqv1.CredentialsRequest{
+				// missing namespace condition
+				testCredReqWithConditions(testAWSCredRequest("amissingnamespace"), []credreqv1.CredentialsRequestCondition{missingTargetNamespaceCond}),
+				// provision failed condition
+				testCredReqWithConditions(testAWSCredRequest("aprovisionfailed"), []credreqv1.CredentialsRequestCondition{provisionFailedCond}),
+				// insufficient cloud creds condition
+				testCredReqWithConditions(testAWSCredRequest("ainsufficientcreds"), []credreqv1.CredentialsRequestCondition{insufficientCredsCond}),
+
+				// GCP credreq with condition set
+				testCredReqWithConditions(testGCPCredRequest("gignored"), []credreqv1.CredentialsRequestCondition{ignoredCond}),
+			},
+			validate: func(accumulator *credRequestAccumulator, t *testing.T) {
+				// total cred requests
+				assert.Equal(t, 3, accumulator.crTotals["aws"])
+				assert.Equal(t, 1, accumulator.crTotals["gcp"])
+
+				// failure conditions should all be zero as CCO is disabled
+				for _, cond := range constants.FailureConditionTypes {
+					assert.Equal(t, 0, accumulator.crConditions[cond])
+				}
+			},
+		},
 	}
 
-	gcpCredRequests := []credreqv1.CredentialsRequest{
-		testGCPCredRequest("gregular"),
-		testCredReqWithConditions(testGCPCredRequest("gignored"), []credreqv1.CredentialsRequestCondition{ignoredCond}),
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			accumulator := newAccumulator(logger)
+
+			for _, cr := range test.credReqs {
+				accumulator.processCR(&cr, test.ccoDisabled)
+			}
+
+			test.validate(accumulator, t)
+		})
 	}
 
-	credRequests := []credreqv1.CredentialsRequest{}
-	credRequests = append(credRequests, awsCredRequests...)
-	credRequests = append(credRequests, gcpCredRequests...)
-
-	accumulator := newAccumulator(logger)
-
-	for _, cr := range credRequests {
-		accumulator.processCR(&cr)
-	}
-
-	// total cred requests
-	assert.Equal(t, len(awsCredRequests), accumulator.crTotals["aws"])
-	assert.Equal(t, len(gcpCredRequests), accumulator.crTotals["gcp"])
-
-	// conditions
-	assert.Equal(t, 1, accumulator.crConditions[credreqv1.MissingTargetNamespace])
-	assert.Equal(t, 1, accumulator.crConditions[credreqv1.CredentialsProvisionFailure])
-	assert.Equal(t, 1, accumulator.crConditions[credreqv1.Ignored])
-	assert.Equal(t, 1, accumulator.crConditions[credreqv1.InsufficientCloudCredentials])
 }
 
 func TestMetricsInitialization(t *testing.T) {


### PR DESCRIPTION
If CCO is disabled it should not be triggering Prometheus alerts. Skip reporting condition metrics if CCO has been disabled.