### PR TITLE
provide region when setting up an AWS client

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -102,8 +102,12 @@ func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error)
 }
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
-func NewClient(accessKeyID, secretAccessKey []byte, infraName string) (Client, error) {
+func NewClient(accessKeyID, secretAccessKey []byte, region, infraName string) (Client, error) {
 	awsConfig := &awssdk.Config{}
+
+	if region != "" {
+		awsConfig.Region = &region
+	}
 
 	awsConfig.Credentials = credentials.NewStaticCredentials(
 		string(accessKeyID), string(secretAccessKey), "")

--- a/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/controller/credentialsrequest/credentialsrequest_controller_test.go
@@ -1024,7 +1024,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 					Client: fakeClient,
 					Codec:  codec,
 					Scheme: scheme.Scheme,
-					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, infraName string) (minteraws.Client, error) {
+					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, region, infraName string) (minteraws.Client, error) {
 						if string(accessKeyID) == testRootAWSAccessKeyID {
 							return mockRootAWSClient, nil
 						} else if string(accessKeyID) == testAWSAccessKeyID {

--- a/pkg/controller/secretannotator/aws/reconciler_test.go
+++ b/pkg/controller/secretannotator/aws/reconciler_test.go
@@ -221,7 +221,7 @@ func TestSecretAnnotatorReconcile(t *testing.T) {
 			rcc := &annaws.ReconcileCloudCredSecret{
 				Client: fakeClient,
 				Logger: log.WithField("controller", "testController"),
-				AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, infraName string) (ccaws.Client, error) {
+				AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, region, infraName string) (ccaws.Client, error) {
 					return fakeAWSClient, nil
 				},
 			}


### PR DESCRIPTION
this allows the client setup code to insert the region info, which in turn allows the AWS SDK to use the alternative API endpoints when connecting to the AWS China regions.

also reorder parameters so we are consistently using region before infraName.