### PR TITLE
Bug 1806892: no need to run CCO as privileged pod

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,8 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 WORKDIR /root/
 COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/manager .
 ADD manifests/ /manifests
+# Update perms so we can copy updated CA if needed
+RUN chmod -R g+w /etc/pki/ca-trust/extracted/pem/
 
 LABEL io.openshift.release.operator=true
 ENTRYPOINT ["./manager"]

--- a/config/manager/namespace.yaml
+++ b/config/manager/namespace.yaml
@@ -5,6 +5,5 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     controller-tools.k8s.io: "1.0"
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
   name: openshift-cloud-credential-operator

--- a/manifests/00_namespace.yaml
+++ b/manifests/00_namespace.yaml
@@ -5,6 +5,5 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     controller-tools.k8s.io: "1.0"
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
   name: openshift-cloud-credential-operator

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -239,7 +239,6 @@ metadata:
     openshift.io/node-selector: ""
   labels:
     controller-tools.k8s.io: "1.0"
-    openshift.io/run-level: "1"
     openshift.io/cluster-monitoring: "true"
   name: openshift-cloud-credential-operator
 `)


### PR DESCRIPTION
Remove the label that was running CCO as a privileged pod. It is unnecessary for the kinds of operations that CCO needs to perform in cluster.
    
Removing the label makes the file copy of any provided certificate bundles fail (used for things like global proxy settings). Fix up the permissions at container build time to allow the Pod startup to continue to be able to copy over any certificate bundle mounted into the pod.
    
The label appears to have no effect when CCO is running on the bootstrap node, so there is no need to maintain a Namespace definition for use only during bootstrap (like we must do for the bootstrap-only Pod definition).

