### PR TITLE
Bug 1838718: do not special-case handling read-only credentialsRequest

### DIFF
--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -17,11 +17,197 @@ limitations under the License.
 package actuator
 
 import (
-	"github.com/stretchr/testify/assert"
+	"fmt"
 	"strings"
 	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/openshift/cloud-credential-operator/pkg/apis"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
+	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
 )
 
+const (
+	testROAccessKeyID     = "TestROAccessKeyID"
+	testROSecretAccessKey = "TestROSecretAccessKey"
+
+	testRootAccessKeyID     = "TestRootAccessKeyID"
+	testRootSecretAccessKey = "TestRootSecretAccessKey"
+)
+
+type awsClientBuilderRecorder struct {
+	accessKeyID     []byte
+	secretAccessKey []byte
+
+	fakeAWSClient      *mockaws.MockClient
+	fakeAWSClientError error
+}
+
+func (a *awsClientBuilderRecorder) ClientBuilder(accessKeyID, secretAccessKey []byte, region, infra string) (ccaws.Client, error) {
+	a.accessKeyID = accessKeyID
+	a.secretAccessKey = secretAccessKey
+
+	return a.fakeAWSClient, a.fakeAWSClientError
+}
+
+func TestCredentialsFetching(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		t.Fatalf("failed to set up codec for tests: %v", err)
+	}
+
+	tests := []struct {
+		name                  string
+		existing              []runtime.Object
+		credentialsRequest    *minterv1.CredentialsRequest
+		expectedError         bool
+		validate              func(*testing.T, *awsClientBuilderRecorder)
+		clientBuilderRecorder func(*gomock.Controller) *awsClientBuilderRecorder
+	}{
+		{
+			name: "read only secret exists",
+			existing: []runtime.Object{
+				testReadOnlySecret(),
+			},
+			clientBuilderRecorder: func(mockCtrl *gomock.Controller) *awsClientBuilderRecorder {
+				r := &awsClientBuilderRecorder{}
+
+				awsClient := mockaws.NewMockClient(mockCtrl)
+				awsClient.EXPECT().GetUser(gomock.Any()).Return(nil, nil)
+
+				r.fakeAWSClient = awsClient
+
+				return r
+			},
+			validate: func(t *testing.T, clientRecorder *awsClientBuilderRecorder) {
+				assert.Equal(t, testROAccessKeyID, string(clientRecorder.accessKeyID))
+				assert.Equal(t, testROSecretAccessKey, string(clientRecorder.secretAccessKey))
+			},
+		},
+		{
+			name: "no read only secret",
+			existing: []runtime.Object{
+				testRootSecret(),
+			},
+			clientBuilderRecorder: func(mockCtrl *gomock.Controller) *awsClientBuilderRecorder {
+				r := &awsClientBuilderRecorder{}
+
+				awsClient := mockaws.NewMockClient(mockCtrl)
+				r.fakeAWSClient = awsClient
+
+				return r
+			},
+			validate: func(t *testing.T, clientRecorder *awsClientBuilderRecorder) {
+				assert.Equal(t, testRootAccessKeyID, string(clientRecorder.accessKeyID))
+				assert.Equal(t, testRootSecretAccessKey, string(clientRecorder.secretAccessKey))
+			},
+		},
+		{
+			name: "read only creds not ready",
+			existing: []runtime.Object{
+				testReadOnlySecret(),
+				testRootSecret(),
+			},
+			clientBuilderRecorder: func(mockCtrl *gomock.Controller) *awsClientBuilderRecorder {
+				r := &awsClientBuilderRecorder{}
+
+				awsClient := mockaws.NewMockClient(mockCtrl)
+				awsClient.EXPECT().GetUser(gomock.Any()).Return(nil, &testAWSError{
+					code: "InvalidClientTokenId",
+				})
+				r.fakeAWSClient = awsClient
+
+				return r
+			},
+			validate: func(t *testing.T, clientRecorder *awsClientBuilderRecorder) {
+				assert.Equal(t, testRootAccessKeyID, string(clientRecorder.accessKeyID))
+				assert.Equal(t, testRootSecretAccessKey, string(clientRecorder.secretAccessKey))
+			},
+		},
+		{
+			name:          "error creating client",
+			expectedError: true,
+			existing: []runtime.Object{
+				testReadOnlySecret(),
+			},
+			clientBuilderRecorder: func(mockCtrl *gomock.Controller) *awsClientBuilderRecorder {
+				r := &awsClientBuilderRecorder{
+					fakeAWSClientError: fmt.Errorf("test error"),
+				}
+
+				return r
+			},
+		},
+		{
+			name:          "bad credentials request",
+			expectedError: true,
+			existing: []runtime.Object{
+				testReadOnlySecret(),
+			},
+			credentialsRequest: func() *minterv1.CredentialsRequest {
+				cr := testCredentialsRequest()
+				cr.Status.ProviderStatus = &runtime.RawExtension{
+					Raw: []byte("garbage data"),
+				}
+
+				return cr
+			}(),
+			clientBuilderRecorder: func(mockCtrl *gomock.Controller) *awsClientBuilderRecorder {
+				r := &awsClientBuilderRecorder{}
+
+				fakeAWSClient := mockaws.NewMockClient(mockCtrl)
+				r.fakeAWSClient = fakeAWSClient
+
+				return r
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if test.credentialsRequest == nil {
+				test.credentialsRequest = testCredentialsRequest()
+			}
+
+			test.existing = append(test.existing, test.credentialsRequest)
+			fakeClient := fake.NewFakeClient(test.existing...)
+
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			clientRecorder := test.clientBuilderRecorder(mockCtrl)
+
+			a := &AWSActuator{
+				Client:           fakeClient,
+				Codec:            codec,
+				AWSClientBuilder: clientRecorder.ClientBuilder,
+			}
+
+			aClient, err := a.buildReadAWSClient(test.credentialsRequest, "testregion", "testinfra")
+
+			if test.expectedError {
+				assert.Error(t, err, "expected error for test case")
+			} else {
+				assert.NotNil(t, aClient)
+				if test.validate != nil {
+					test.validate(t, clientRecorder)
+				}
+			}
+		})
+	}
+}
 func TestGenerateUserName(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -81,4 +267,59 @@ func TestGenerateUserName(t *testing.T) {
 			}
 		})
 	}
+}
+
+func testReadOnlySecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      roAWSCredsSecret,
+			Namespace: roAWSCredsSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"aws_access_key_id":     []byte(testROAccessKeyID),
+			"aws_secret_access_key": []byte(testROSecretAccessKey),
+		},
+	}
+}
+
+func testRootSecret() *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      rootAWSCredsSecret,
+			Namespace: rootAWSCredsSecretNamespace,
+		},
+		Data: map[string][]byte{
+			"aws_access_key_id":     []byte(testRootAccessKeyID),
+			"aws_secret_access_key": []byte(testRootSecretAccessKey),
+		},
+	}
+}
+
+func testCredentialsRequest() *minterv1.CredentialsRequest {
+	return &minterv1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "testcr",
+			Namespace: "testnamespace",
+		},
+	}
+}
+
+type testAWSError struct {
+	code string
+}
+
+func (a *testAWSError) Code() string {
+	return a.code
+}
+
+func (a *testAWSError) Message() string {
+	panic("not implemented")
+}
+
+func (a *testAWSError) OrigErr() error {
+	panic("not implemented")
+}
+
+func (a *testAWSError) Error() string {
+	panic("not implemented")
 }


### PR DESCRIPTION
In the event that the install-time creds secret is removed (kube-system/aws-creds), reconciling the read-only CredentialsRequest would fail.

It is okay to just use the read-only credentials to make sure that no updates are needed to the read-only CredentialsRequest.

Also, update the function for handling whether a CredentialsRequest already exists so that it covers the passthrough credentials case where the AWS user fields are empty.