### PR TITLE
Bug 1813343: handle old Infrastructure objects without PlatformStatus

### DIFF
--- a/pkg/controller/utils/utils.go
+++ b/pkg/controller/utils/utils.go
@@ -70,6 +70,12 @@ func LoadInfrastructureRegion(c client.Client, logger log.FieldLogger) (string, 
 		logger.WithError(err).Error("error loading Infrastructure region")
 		return "", err
 	}
+	if infra.Status.PlatformStatus == nil {
+		// Older clusters may have an Infrastructure object without the PlatformStatus fields.
+		// Send back an empty region and the AWS client will use default settings.
+		// The permissions simulation will also simply not fill out the region for simulations.
+		return "", nil
+	}
 	return infra.Status.PlatformStatus.AWS.Region, nil
 }
 


### PR DESCRIPTION
Older clusters that have been upgraded over time will have a correspondingly old version of the Infrastructure CR where Status.PlatformStatus did not exist.

Detect that case, and return an empty region string. The AWS client code will just use the defaults, and the permissions simulations will simply not include the region as part of the simulation.