### PR TITLE
pkg/aws: allow users to create a client from IAM client

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -121,7 +121,12 @@ func NewClient(accessKeyID, secretAccessKey []byte, region, infraName string) (C
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io cloud-credential-operator", version.Version, infraName),
 	})
 
+	return NewClientFromIAMClient(iam.New(s))
+}
+
+// NewClientFromIAMClient create a client from AWS IAM client.
+func NewClientFromIAMClient(client iamiface.IAMAPI) (Client, error) {
 	return &awsClient{
-		iamClient: iam.New(s),
+		iamClient: client,
 	}, nil
 }


### PR DESCRIPTION
users like openshift installer configure AWS clients with properties like
- configure the max retires for the client to wait longer for throttle errors.
- configure the service endpoint resolver in larger ecosystem of other AWS APIs
- configure and control the user agent sent with AWS requests.

The existing method doesn't allow the freedom mentioned above and is too restrictive to use as lib.