### PR TITLE
add aws-pod-identity-webhook to image refs and deployment

### DIFF
--- a/config/manager/deployment.yaml
+++ b/config/manager/deployment.yaml
@@ -42,6 +42,8 @@ spec:
       - env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
+        - name: AWS_POD_IDENTITY_WEBHOOK_IMAGE
+          value: quay.io/openshift/aws-pod-identity-webhook:latest
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -210,6 +210,8 @@ spec:
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
+        - name: AWS_POD_IDENTITY_WEBHOOK_IMAGE
+          value: quay.io/openshift/aws-pod-identity-webhook:latest
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
         name: manager

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -6,3 +6,7 @@ spec:
     from:
       kind: DockerImage
       Name: quay.io/openshift/origin-cloud-credential-operator
+  - name: aws-pod-identity-webhook
+    from:
+      kind: DockerImage
+      Name: quay.io/openshift/aws-pod-identity-webhook

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -163,6 +163,8 @@ spec:
       - env:
         - name: RELEASE_VERSION
           value: "0.0.1-snapshot"
+        - name: AWS_POD_IDENTITY_WEBHOOK_IMAGE
+          value: quay.io/openshift/aws-pod-identity-webhook:latest
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
         name: manager


### PR DESCRIPTION
This gets the payload image for `aws-pod-identity-webhook` into the operator.  After this, we can start adding code to this operator to manage this admission webhook and other AWS pod identity bits.

fyi @derekwaynecarr