### PR TITLE
add verify-deps target and rename containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	golang.mk \
 	targets/openshift/bindata.mk \
 	targets/openshift/crd-schema-gen.mk \
+	targets/openshift/deps.mk \
 )
 
 # adapted from https://github.com/openshift/build-machinery-go/blob/master/make/targets/openshift/images.mk

--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -214,7 +214,7 @@ spec:
           value: quay.io/openshift/aws-pod-identity-webhook:latest
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
-        name: manager
+        name: cloud-credential-operator
         ports:
         - containerPort: 9876
           name: webhook-server

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -49,7 +49,7 @@ spec:
     - --kubeconfig=/etc/kubernetes/secrets/kubeconfig
     image: %s
     imagePullPolicy: IfNotPresent
-    name: manager
+    name: cloud-credential-operator
     volumeMounts:
     - mountPath: /etc/kubernetes/secrets
       name: secrets


### PR DESCRIPTION
Two small commits adding a `make verify-deps` target for ensuring the integrity of the `vendor` tree and follow-on to #177 renaming the containers from `manager` to `cloud-credential-operator`.

After this, I'll open a PR against openshift/release to run the new build-machinery make targets (`test`, `verify`, and `verify-deps`) and we can remove the old ones.