### PR TITLE
Bug 1815219: CO-876: allow defining Conditions in AWS CredentialsRequest

### DIFF
--- a/pkg/apis/cloudcredential/v1/aws_types.go
+++ b/pkg/apis/cloudcredential/v1/aws_types.go
@@ -38,6 +38,8 @@ type StatementEntry struct {
 	Action []string `json:"action"`
 	// Resource specifies the object(s) this statement should apply to. (or "*" for all)
 	Resource string `json:"resource"`
+	// PolicyCondition specifies under which condition StatementEntry will apply
+	PolicyCondition IAMPolicyCondition `json:"policyCondition,omitempty"`
 }
 
 // AWSStatus containes the status of the credentials request in AWS.
@@ -49,3 +51,9 @@ type AWSProviderStatus struct {
 	// Policy is the name of the policy attached to the user in AWS.
 	Policy string `json:"policy"`
 }
+
+// IAMPolicyCondition - map of condition types, with associated key - value mapping
+type IAMPolicyCondition map[string]IAMPolicyConditionKeyValue
+
+// IAMPolicyConditionKeyValue - mapping of values for the chosen type
+type IAMPolicyConditionKeyValue map[string]interface{}

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -901,9 +901,10 @@ func (a *AWSActuator) getDesiredUserPolicy(entries []minterv1.StatementEntry, us
 	}
 	for _, se := range entries {
 		policyDoc.Statement = append(policyDoc.Statement, StatementEntry{
-			Effect:   se.Effect,
-			Action:   se.Action,
-			Resource: se.Resource,
+			Effect:    se.Effect,
+			Action:    se.Action,
+			Resource:  se.Resource,
+			Condition: se.PolicyCondition,
 		})
 	}
 
@@ -1154,9 +1155,10 @@ type PolicyDocument struct {
 // StatementEntry is a simple type used to serialize to AWS' PolicyDocument format. We cannot
 // re-use minterv1.StatementEntry due to different conventions for the serialization keys. (caps)
 type StatementEntry struct {
-	Effect   string
-	Action   []string
-	Resource string
+	Effect    string
+	Action    []string
+	Resource  string
+	Condition minterv1.IAMPolicyCondition `json:",omitempty"`
 }
 
 func (a *AWSActuator) loadClusterUUID(logger log.FieldLogger) (configv1.ClusterID, error) {


### PR DESCRIPTION
Added support for conditions in AWS provider

Allows to use the same form as JSON conditions to specify rules to apply - https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition_operators.html

```yaml
apiVersion: cloudcredential.openshift.io/v1
kind: CredentialsRequest
.....
      - iam:PassRole
      condition:
        "Null":
          key: "true"
      effect: Allow
      resource: '*'
```
