### PR TITLE
use alternate IAM endpoints if specified

### DIFF
--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/openshift/cloud-credential-operator/pkg/apis"
@@ -53,7 +54,7 @@ type awsClientBuilderRecorder struct {
 	fakeAWSClientError error
 }
 
-func (a *awsClientBuilderRecorder) ClientBuilder(accessKeyID, secretAccessKey []byte, region, infra string) (ccaws.Client, error) {
+func (a *awsClientBuilderRecorder) ClientBuilder(accessKeyID, secretAccessKey []byte, client client.Client) (ccaws.Client, error) {
 	a.accessKeyID = accessKeyID
 	a.secretAccessKey = secretAccessKey
 
@@ -195,7 +196,7 @@ func TestCredentialsFetching(t *testing.T) {
 				AWSClientBuilder: clientRecorder.ClientBuilder,
 			}
 
-			aClient, err := a.buildReadAWSClient(test.credentialsRequest, "testregion", "testinfra")
+			aClient, err := a.buildReadAWSClient(test.credentialsRequest)
 
 			if test.expectedError {
 				assert.Error(t, err, "expected error for test case")

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -1025,7 +1025,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 					Client: fakeClient,
 					Codec:  codec,
 					Scheme: scheme.Scheme,
-					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, region, infraName string) (minteraws.Client, error) {
+					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, c client.Client) (minteraws.Client, error) {
 						if string(accessKeyID) == testRootAWSAccessKeyID {
 							return mockRootAWSClient, nil
 						} else if string(accessKeyID) == testAWSAccessKeyID {

--- a/pkg/operator/secretannotator/aws/reconciler_test.go
+++ b/pkg/operator/secretannotator/aws/reconciler_test.go
@@ -222,7 +222,7 @@ func TestSecretAnnotatorReconcile(t *testing.T) {
 			rcc := &annaws.ReconcileCloudCredSecret{
 				Client: fakeClient,
 				Logger: log.WithField("controller", "testController"),
-				AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, region, infraName string) (ccaws.Client, error) {
+				AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, c client.Client) (ccaws.Client, error) {
 					return fakeAWSClient, nil
 				},
 			}

--- a/pkg/operator/utils/aws/utils.go
+++ b/pkg/operator/utils/aws/utils.go
@@ -1,0 +1,71 @@
+package aws
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+)
+
+// ClientBuilder handles creating an AWS client using the details found in the cluster's
+// Infrastructure object.
+func ClientBuilder(accessKeyID, secretAccessKey []byte, c client.Client) (ccaws.Client, error) {
+	infra, err := utils.GetInfrastructure(c)
+	if err != nil {
+		return nil, err
+	}
+
+	params := setupClientParams(infra)
+
+	return ccaws.NewClient(accessKeyID, secretAccessKey, params)
+}
+
+func setupClientParams(infra *configv1.Infrastructure) *ccaws.ClientParams {
+	region := ""
+	endpoint := ""
+	if infra.Status.PlatformStatus != nil {
+		// If PlatformStatus isn't nil, then we can at least assume Region is provided
+		region = infra.Status.PlatformStatus.AWS.Region
+
+		endpoint = getIAMEndpoint(infra)
+	}
+
+	params := &ccaws.ClientParams{
+		InfraName: infra.Status.InfrastructureName,
+		Region:    region,
+		Endpoint:  endpoint,
+	}
+
+	return params
+}
+
+// LoadInfrastructureRegion loads the AWS region the cluster is installed to.
+func LoadInfrastructureRegion(c client.Client, logger log.FieldLogger) (string, error) {
+	infra, err := utils.GetInfrastructure(c)
+	if err != nil {
+		logger.WithError(err).Error("error loading Infrastructure region")
+		return "", err
+	}
+	if infra.Status.PlatformStatus == nil {
+		// Older clusters may have an Infrastructure object without the PlatformStatus fields.
+		// Send back an empty region and the AWS client will use default settings.
+		// The permissions simulation will also simply not fill out the region for simulations.
+		return "", nil
+	}
+	return infra.Status.PlatformStatus.AWS.Region, nil
+}
+
+func getIAMEndpoint(infra *configv1.Infrastructure) string {
+	for _, ep := range infra.Status.PlatformStatus.AWS.ServiceEndpoints {
+		if ep.Name == iam.ServiceName {
+			return ep.URL
+		}
+	}
+	return ""
+}

--- a/pkg/operator/utils/aws/utils_test.go
+++ b/pkg/operator/utils/aws/utils_test.go
@@ -1,0 +1,115 @@
+package aws
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
+)
+
+const (
+	testInfraName = "test-cluster-abcde"
+	testRegion    = "regionA"
+	testIAMURL    = "http://some.endpoint.com"
+)
+
+func TestClientSetup(t *testing.T) {
+	tests := []struct {
+		name           string
+		infrastructure *configv1.Infrastructure
+		expectedParams *ccaws.ClientParams
+	}{
+		{
+			name: "only infraname",
+			infrastructure: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: testInfraName,
+				},
+			},
+			expectedParams: &ccaws.ClientParams{
+				InfraName: testInfraName,
+			},
+		},
+		{
+			name: "use region for client",
+			infrastructure: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: testInfraName,
+					PlatformStatus: &configv1.PlatformStatus{
+						AWS: &configv1.AWSPlatformStatus{
+							Region: testRegion,
+						},
+					},
+				},
+			},
+			expectedParams: &ccaws.ClientParams{
+				InfraName: testInfraName,
+				Region:    testRegion,
+			},
+		},
+		{
+			name: "use provided IAM endpoint",
+			infrastructure: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: testInfraName,
+					PlatformStatus: &configv1.PlatformStatus{
+						AWS: &configv1.AWSPlatformStatus{
+							Region: testRegion,
+							ServiceEndpoints: []configv1.AWSServiceEndpoint{
+								{
+									Name: iam.ServiceName,
+									URL:  testIAMURL,
+								},
+								{
+									Name: "EC2",
+									URL:  "http://ignore.this.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedParams: &ccaws.ClientParams{
+				InfraName: testInfraName,
+				Region:    testRegion,
+				Endpoint:  testIAMURL,
+			},
+		},
+		{
+			name: "endpoint not provided",
+			infrastructure: &configv1.Infrastructure{
+				Status: configv1.InfrastructureStatus{
+					InfrastructureName: testInfraName,
+					PlatformStatus: &configv1.PlatformStatus{
+						AWS: &configv1.AWSPlatformStatus{
+							Region: testRegion,
+							ServiceEndpoints: []configv1.AWSServiceEndpoint{
+								{
+									Name: "EC2",
+									URL:  "http://ignore.this.com",
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedParams: &ccaws.ClientParams{
+				InfraName: testInfraName,
+				Region:    testRegion,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			params := setupClientParams(test.infrastructure)
+
+			assert.Equal(t, test.expectedParams, params)
+		})
+	}
+}

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -59,7 +59,7 @@ func LoadCredsFromSecret(kubeClient client.Client, namespace, secretName string)
 // LoadInfrastructureName loads the cluster Infrastructure config and returns the infra name
 // used to identify this cluster, and tag some cloud objects.
 func LoadInfrastructureName(c client.Client, logger log.FieldLogger) (string, error) {
-	infra, err := getInfrastructure(c)
+	infra, err := GetInfrastructure(c)
 	if err != nil {
 		logger.WithError(err).Error("error loading Infrastructure config 'cluster'")
 		return "", err
@@ -70,7 +70,7 @@ func LoadInfrastructureName(c client.Client, logger log.FieldLogger) (string, er
 
 // LoadInfrastructureRegion loads the AWS region the cluster is installed to.
 func LoadInfrastructureRegion(c client.Client, logger log.FieldLogger) (string, error) {
-	infra, err := getInfrastructure(c)
+	infra, err := GetInfrastructure(c)
 	if err != nil {
 		logger.WithError(err).Error("error loading Infrastructure region")
 		return "", err
@@ -87,7 +87,8 @@ func LoadInfrastructureRegion(c client.Client, logger log.FieldLogger) (string, 
 	return infra.Status.PlatformStatus.AWS.Region, nil
 }
 
-func getInfrastructure(c client.Client) (*configv1.Infrastructure, error) {
+// GetInfrastructure will return the cluster's Infrastructure object.
+func GetInfrastructure(c client.Client) (*configv1.Infrastructure, error) {
 	infra := &configv1.Infrastructure{}
 	if err := c.Get(context.TODO(), types.NamespacedName{Name: "cluster"}, infra); err != nil {
 		return nil, err


### PR DESCRIPTION
Search through the cluster's Infrastructure object to see if an alternate IAM endpoint is specified, and use it when creating the AWS client.