### PR TITLE
Fix failing make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ run: build
 
 # Install CRDs into a cluster
 install: update-codegen
-	kubectl apply -f manifests/00_v1_crd.yaml
+	kubectl apply -f manifests/00-crd.yaml
 
 # TODO targets for backward compatibility while we make the shift in CI
 test-no-gen: test


### PR DESCRIPTION
Currently 'make install' is failing because the name of the CCO CRD file has
changed from '00_v1_crd.yaml' to '00-crd.yaml'. This PR fixes it.