### PR TITLE
internalize location of CCO configmap

### DIFF
--- a/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
+++ b/pkg/apis/cloudcredential/v1/credentialsrequest_types.go
@@ -39,9 +39,6 @@ const (
 
 	// CloudCredOperatorNamespace is the namespace where the credentials operator runs.
 	CloudCredOperatorNamespace = "openshift-cloud-credential-operator"
-
-	// CloudCredOperatorConfigMap is an optional ConfigMap that can be used to alter behavior of the operator.
-	CloudCredOperatorConfigMap = "cloud-credential-operator-config"
 )
 
 // NOTE: Run "make" to regenerate code after modifying this file

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -30,6 +30,7 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	assets "github.com/openshift/cloud-credential-operator/pkg/assets/bootstrap"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
@@ -189,7 +190,7 @@ func isDisabled() bool {
 			continue
 		}
 
-		if configMap.Namespace == minterv1.CloudCredOperatorNamespace && configMap.Name == minterv1.CloudCredOperatorConfigMap {
+		if configMap.Namespace == minterv1.CloudCredOperatorNamespace && configMap.Name == constants.CloudCredOperatorConfigMap {
 			logger := log.New()
 			logger.SetLevel(log.GetLevel())
 			disabled, err := utils.CCODisabledCheck(configMap, logger)

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -1,0 +1,6 @@
+package constants
+
+const (
+	// CloudCredOperatorConfigMap is an optional ConfigMap that can be used to alter behavior of the operator.
+	CloudCredOperatorConfigMap = "cloud-credential-operator-config"
+)

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -26,6 +26,7 @@ import (
 	"golang.org/x/time/rate"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	operatorconstants "github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/internalcontroller"
@@ -285,7 +286,7 @@ func (r *ReconcileCredentialsRequest) Reconcile(request reconcile.Request) (reco
 		logger.WithError(err).Error("error checking if operator is disabled")
 		return reconcile.Result{}, err
 	} else if operatorIsDisabled {
-		logger.Infof("operator disabled in %s ConfigMap", minterv1.CloudCredOperatorConfigMap)
+		logger.Infof("operator disabled in %s ConfigMap", operatorconstants.CloudCredOperatorConfigMap)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -44,6 +44,7 @@ import (
 	minteraws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/aws/actuator"
 	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
+	operatorconstants "github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
@@ -1465,7 +1466,7 @@ func testInfrastructure(infraName string) *configv1.Infrastructure {
 func testOperatorConfigMap(disabled string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      minterv1.CloudCredOperatorConfigMap,
+			Name:      operatorconstants.CloudCredOperatorConfigMap,
 			Namespace: minterv1.CloudCredOperatorNamespace,
 		},
 		Data: map[string]string{

--- a/pkg/operator/secretannotator/aws/reconciler_test.go
+++ b/pkg/operator/secretannotator/aws/reconciler_test.go
@@ -44,6 +44,7 @@ import (
 	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
 
+	operatorconstants "github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	annaws "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 )
@@ -261,7 +262,7 @@ func testSecret() *corev1.Secret {
 func testOperatorConfigMap(disabled string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      minterv1.CloudCredOperatorConfigMap,
+			Name:      operatorconstants.CloudCredOperatorConfigMap,
 			Namespace: minterv1.CloudCredOperatorNamespace,
 		},
 		Data: map[string]string{

--- a/pkg/operator/secretannotator/gcp/reconciler_test.go
+++ b/pkg/operator/secretannotator/gcp/reconciler_test.go
@@ -43,6 +43,7 @@ import (
 
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 
+	operatorconstants "github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	anngcp "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/gcp"
 
@@ -240,7 +241,7 @@ func testSecret() *corev1.Secret {
 func testOperatorConfigMap(disabled string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      minterv1.CloudCredOperatorConfigMap,
+			Name:      operatorconstants.CloudCredOperatorConfigMap,
 			Namespace: minterv1.CloudCredOperatorNamespace,
 		},
 		Data: map[string]string{

--- a/pkg/operator/secretannotator/vsphere/reconciler.go
+++ b/pkg/operator/secretannotator/vsphere/reconciler.go
@@ -31,9 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 
-	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/metrics"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
+	secretconstants "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 	log "github.com/sirupsen/logrus"
 )
@@ -58,14 +58,14 @@ type ReconcileCloudCredSecret struct {
 func NewReconciler(mgr manager.Manager) reconcile.Reconciler {
 	return &ReconcileCloudCredSecret{
 		Client: mgr.GetClient(),
-		Logger: log.WithField("controller", constants.ControllerName),
+		Logger: log.WithField("controller", secretconstants.ControllerName),
 	}
 }
 
 // Add sets up a controller for watching the cloud cred secret.
 func Add(mgr manager.Manager, r reconcile.Reconciler) error {
 	// Create a new controller
-	c, err := controller.New(constants.ControllerName, mgr, controller.Options{Reconciler: r})
+	c, err := controller.New(secretconstants.ControllerName, mgr, controller.Options{Reconciler: r})
 	if err != nil {
 		return err
 	}
@@ -90,7 +90,7 @@ func Add(mgr manager.Manager, r reconcile.Reconciler) error {
 }
 
 func cloudCredSecretObjectCheck(secret metav1.Object) bool {
-	return secret.GetNamespace() == constants.CloudCredSecretNamespace && secret.GetName() == VSphereCloudCredSecretName
+	return secret.GetNamespace() == secretconstants.CloudCredSecretNamespace && secret.GetName() == VSphereCloudCredSecretName
 }
 
 // Reconcile handles annotating the cloud cred secret.
@@ -104,7 +104,7 @@ func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (reconci
 		r.Logger.WithError(err).Error("error checking if operator is disabled")
 		return reconcile.Result{}, err
 	} else if operatorIsDisabled {
-		r.Logger.Infof("operator disabled in %s ConfigMap", minterv1.CloudCredOperatorConfigMap)
+		r.Logger.Infof("operator disabled in %s ConfigMap", constants.CloudCredOperatorConfigMap)
 		return reconcile.Result{}, err
 	}
 
@@ -136,7 +136,7 @@ func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secre
 
 	// Assume passthrough
 	r.Logger.Info("Cloud creds will be used as-is (passthrough)")
-	return r.updateSecretAnnotations(secret, constants.PassthroughAnnotation)
+	return r.updateSecretAnnotations(secret, secretconstants.PassthroughAnnotation)
 }
 
 func (r *ReconcileCloudCredSecret) updateSecretAnnotations(secret *corev1.Secret, value string) error {
@@ -145,7 +145,7 @@ func (r *ReconcileCloudCredSecret) updateSecretAnnotations(secret *corev1.Secret
 		secretAnnotations = map[string]string{}
 	}
 
-	secretAnnotations[constants.AnnotationKey] = value
+	secretAnnotations[secretconstants.AnnotationKey] = value
 	secret.SetAnnotations(secretAnnotations)
 
 	return r.Update(context.Background(), secret)

--- a/pkg/operator/secretannotator/vsphere/reconciler_test.go
+++ b/pkg/operator/secretannotator/vsphere/reconciler_test.go
@@ -39,6 +39,7 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/apis"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 
+	operatorconstants "github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 )
 
@@ -141,7 +142,7 @@ func testSecret() *corev1.Secret {
 func testOperatorConfigMap(disabled string) *corev1.ConfigMap {
 	return &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      minterv1.CloudCredOperatorConfigMap,
+			Name:      operatorconstants.CloudCredOperatorConfigMap,
 			Namespace: minterv1.CloudCredOperatorNamespace,
 		},
 		Data: map[string]string{

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -18,6 +18,7 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 )
 
 const (
@@ -154,11 +155,11 @@ func IsOperatorDisabled(kubeClient client.Client, logger log.FieldLogger) (bool,
 	err := kubeClient.Get(context.TODO(),
 		types.NamespacedName{
 			Namespace: minterv1.CloudCredOperatorNamespace,
-			Name:      minterv1.CloudCredOperatorConfigMap,
+			Name:      constants.CloudCredOperatorConfigMap,
 		}, cm)
 	if err != nil {
 		if errors.IsNotFound(err) {
-			logger.Debugf("%s ConfigMap does not exist, assuming default behavior", minterv1.CloudCredOperatorConfigMap)
+			logger.Debugf("%s ConfigMap does not exist, assuming default behavior", constants.CloudCredOperatorConfigMap)
 			return OperatorDisabledDefault, nil
 		}
 		return OperatorDisabledDefault, err
@@ -172,7 +173,7 @@ func IsOperatorDisabled(kubeClient client.Client, logger log.FieldLogger) (bool,
 func CCODisabledCheck(cm *corev1.ConfigMap, logger log.FieldLogger) (bool, error) {
 	disabled, ok := cm.Data[operatorConfigMapDisabledKey]
 	if !ok {
-		logger.Debugf("%s ConfigMap has no %s key, assuming default behavior", minterv1.CloudCredOperatorConfigMap, operatorConfigMapDisabledKey)
+		logger.Debugf("%s ConfigMap has no %s key, assuming default behavior", constants.CloudCredOperatorConfigMap, operatorConfigMapDisabledKey)
 		return OperatorDisabledDefault, nil
 	}
 	return strconv.ParseBool(disabled)


### PR DESCRIPTION
don't want to make it part of the published info into openshift/api as we have plans to make a more formal config object