### PR TITLE
Upgradable false when parent creds removed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,13 +19,15 @@ instance roles)
 
 Currently the operator supports AWS, GCP, Azure, VMWare, OpenStack and oVirt.
 
-## Admin Credential Secret Formats
+## Credentials Root Secret Formats
 
-If running in-cluster, your credentials are expected to exist in kube-system
-namespace.  Credentials are stored in a Kubernetes Secret, and the format
-varies by cloud. The data in these format in these secrets is also the same
-used for each credentials secret the operator will create for a
-CredentialsRequest.
+Each cloud provider utilizes a credentials root secret in the kube-system
+namespace (by convention), which is then used to satisfy all
+CredentialsRequests and create their respective Secrets. (either by minting new
+credentials (mint mode), or by copying the credentials root secret (passthrough
+mode))
+
+The format for the secret varies by cloud, and is also used for each CredentialsRequest Secret.
 
 ### AWS
 

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -894,14 +894,14 @@ func (a *AWSActuator) getDesiredUserPolicy(entries []minterv1.StatementEntry, us
 	return string(b), nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *AWSActuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *AWSActuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AWSCloudCredSecretName}
 }
 
 func (a *AWSActuator) getCloudCredentialsSecret(ctx context.Context, logger log.FieldLogger) (*corev1.Secret, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
+	if err := a.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return nil, &actuatoriface.ActuatorError{

--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -36,6 +36,8 @@ import (
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	ccaws "github.com/openshift/cloud-credential-operator/pkg/aws"
 	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 )
 
 const (
@@ -286,8 +288,8 @@ func testReadOnlySecret() *corev1.Secret {
 func testRootSecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      rootAWSCredsSecret,
-			Namespace: rootAWSCredsSecretNamespace,
+			Name:      annotatorconst.AWSCloudCredSecretName,
+			Namespace: constants.KubeSystemNS,
 		},
 		Data: map[string][]byte{
 			"aws_access_key_id":     []byte(testRootAccessKeyID),

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -567,14 +567,14 @@ func (a *Actuator) syncCredentialSecrets(ctx context.Context, cr *minterv1.Crede
 	return nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *Actuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *Actuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AzureCloudCredSecretName}
 }
 
 func (a *Actuator) getRootCloudCredentialsSecret(ctx context.Context, logger log.FieldLogger) (*corev1.Secret, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.client.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
+	if err := a.client.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return nil, &actuatoriface.ActuatorError{

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -24,6 +24,8 @@ import (
 	"time"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
+
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -565,9 +567,14 @@ func (a *Actuator) syncCredentialSecrets(ctx context.Context, cr *minterv1.Crede
 	return nil
 }
 
+// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *Actuator) GetParentCredSecretLocation() types.NamespacedName {
+	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AzureCloudCredSecretName}
+}
+
 func (a *Actuator) getRootCloudCredentialsSecret(ctx context.Context, logger log.FieldLogger) (*corev1.Secret, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.client.Client.Get(ctx, types.NamespacedName{Name: RootSecretName, Namespace: RootSecretNamespace}, cloudCredSecret); err != nil {
+	if err := a.client.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return nil, &actuatoriface.ActuatorError{
@@ -577,7 +584,7 @@ func (a *Actuator) getRootCloudCredentialsSecret(ctx context.Context, logger log
 	}
 
 	if !isSecretAnnotated(cloudCredSecret) {
-		logger.WithField("secret", fmt.Sprintf("%s/%s", RootSecretNamespace, RootSecretName)).Error("cloud cred secret not yet annotated")
+		logger.WithField("secret", fmt.Sprintf("%s/%s", constants.KubeSystemNS, annotatorconst.AzureCloudCredSecretName)).Error("cloud cred secret not yet annotated")
 		return nil, &actuatoriface.ActuatorError{
 			ErrReason: minterv1.CredentialsProvisionFailure,
 			Message:   fmt.Sprintf("cannot proceed without cloud cred secret annotation"),

--- a/pkg/azure/actuator_test.go
+++ b/pkg/azure/actuator_test.go
@@ -31,6 +31,7 @@ import (
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/azure"
 	azuremock "github.com/openshift/cloud-credential-operator/pkg/azure/mock"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	log "github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/assert"
@@ -60,8 +61,8 @@ const (
 var (
 	rootSecretMintAnnotation = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      azure.RootSecretName,
-			Namespace: azure.RootSecretNamespace,
+			Name:      annotatorconst.AzureCloudCredSecretName,
+			Namespace: constants.KubeSystemNS,
 			Annotations: map[string]string{
 				annotatorconst.AnnotationKey: annotatorconst.MintAnnotation,
 			},

--- a/pkg/azure/client.go
+++ b/pkg/azure/client.go
@@ -22,16 +22,12 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-const (
-	RootSecretNamespace = "kube-system"
-	RootSecretName      = "azure-credentials"
-)
-
-var RootSecretKey = client.ObjectKey{Name: RootSecretName, Namespace: RootSecretNamespace}
+var RootSecretKey = client.ObjectKey{Name: annotatorconst.AzureCloudCredSecretName, Namespace: constants.KubeSystemNS}
 
 type clientWrapper struct {
 	client.Client

--- a/pkg/azure/passthrough.go
+++ b/pkg/azure/passthrough.go
@@ -77,8 +77,8 @@ func (a *passthrough) Update(ctx context.Context, cr *minterv1.CredentialsReques
 	return nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *passthrough) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *passthrough) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AzureCloudCredSecretName}
 }
 

--- a/pkg/azure/passthrough.go
+++ b/pkg/azure/passthrough.go
@@ -24,8 +24,12 @@ import (
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
+
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -71,6 +75,11 @@ func (a *passthrough) Update(ctx context.Context, cr *minterv1.CredentialsReques
 		}
 	}
 	return nil
+}
+
+// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *passthrough) GetParentCredSecretLocation() types.NamespacedName {
+	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AzureCloudCredSecretName}
 }
 
 func copySecret(cr *minterv1.CredentialsRequest, src *secret, dest *secret) {

--- a/pkg/azure/passthrough_test.go
+++ b/pkg/azure/passthrough_test.go
@@ -23,6 +23,7 @@ import (
 	openshiftapiv1 "github.com/openshift/api/config/v1"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/azure"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"github.com/stretchr/testify/assert"
 	corev1 "k8s.io/api/core/v1"
@@ -76,8 +77,8 @@ var (
 
 	validRootSecret = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      azure.RootSecretName,
-			Namespace: azure.RootSecretNamespace,
+			Name:      annotatorconst.AzureCloudCredSecretName,
+			Namespace: constants.KubeSystemNS,
 			Annotations: map[string]string{
 				annotatorconst.AnnotationKey: annotatorconst.PassthroughAnnotation,
 			},
@@ -95,8 +96,8 @@ var (
 
 	rootSecretBadAnnotation = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      azure.RootSecretName,
-			Namespace: azure.RootSecretNamespace,
+			Name:      annotatorconst.AzureCloudCredSecretName,
+			Namespace: constants.KubeSystemNS,
 			Annotations: map[string]string{
 				annotatorconst.AnnotationKey: "blah",
 			},
@@ -105,8 +106,8 @@ var (
 
 	rootSecretNoAnnotation = corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        azure.RootSecretName,
-			Namespace:   azure.RootSecretNamespace,
+			Name:        annotatorconst.AzureCloudCredSecretName,
+			Namespace:   constants.KubeSystemNS,
 			Annotations: map[string]string{},
 		},
 	}

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -554,15 +554,15 @@ func (a *Actuator) updateProviderStatus(ctx context.Context, logger log.FieldLog
 	return nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *Actuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *Actuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.GCPCloudCredSecretName}
 }
 
 // getRootCloudCredentialsSecret will return the cluster's root GCP cloud cred secret if it exists and is properly annotated
 func (a *Actuator) getRootCloudCredentialsSecret(ctx context.Context, logger log.FieldLogger) (*corev1.Secret, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
+	if err := a.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return nil, &actuatoriface.ActuatorError{

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -209,8 +209,8 @@ func (a *OpenStackActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) 
 	return existingSecret, nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *OpenStackActuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *OpenStackActuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: crconst.KubeSystemNS, Name: constants.OpenStackCloudCredsSecretName}
 }
 
@@ -218,7 +218,7 @@ func (a *OpenStackActuator) getRootCloudCredentialsSecretData(ctx context.Contex
 	var clouds string
 
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
+	if err := a.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return "", &actuatoriface.ActuatorError{

--- a/pkg/operator/awspodidentity/controller.go
+++ b/pkg/operator/awspodidentity/controller.go
@@ -2,15 +2,12 @@ package awspodidentity
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
-	"github.com/openshift/cloud-credential-operator/pkg/assets/v410_00_assets"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/platform"
 	"github.com/openshift/library-go/pkg/operator/events"
 	"github.com/openshift/library-go/pkg/operator/resource/resourceapply"
 	"github.com/openshift/library-go/pkg/operator/resource/resourcehelper"
@@ -34,6 +31,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	"github.com/openshift/cloud-credential-operator/pkg/assets/v410_00_assets"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/platform"
 )
 
 const (
@@ -109,7 +109,8 @@ func Add(mgr manager.Manager, kubeconfig string) error {
 	logger := log.WithFields(log.Fields{"controller": controllerName})
 	imagePullSpec := os.Getenv("AWS_POD_IDENTITY_WEBHOOK_IMAGE")
 	if len(imagePullSpec) == 0 {
-		return errors.New("AWS_POD_IDENTITY_WEBHOOK_IMAGE is not set")
+		logger.Warn("AWS_POD_IDENTITY_WEBHOOK_IMAGE is not set, skipping controller")
+		return nil
 	}
 
 	r := &staticResourceReconciler{

--- a/pkg/operator/credentialsrequest/actuator/actuator.go
+++ b/pkg/operator/credentialsrequest/actuator/actuator.go
@@ -36,8 +36,8 @@ type Actuator interface {
 	Update(context.Context, *minterv1.CredentialsRequest) error
 	// Exists checks if the credentials currently exist.
 	Exists(context.Context, *minterv1.CredentialsRequest) (bool, error)
-	// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-	GetParentCredSecretLocation() types.NamespacedName
+	// GetCredentialsRootSecretLocation returns the namespace and name where the credentials root secret is stored.
+	GetCredentialsRootSecretLocation() types.NamespacedName
 }
 
 type DummyActuator struct {
@@ -59,8 +59,8 @@ func (a *DummyActuator) Delete(ctx context.Context, cr *minterv1.CredentialsRequ
 	return nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *DummyActuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *DummyActuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AWSCloudCredSecretName}
 }
 

--- a/pkg/operator/credentialsrequest/actuator/actuator.go
+++ b/pkg/operator/credentialsrequest/actuator/actuator.go
@@ -18,7 +18,11 @@ package actuator
 import (
 	"context"
 
+	"k8s.io/apimachinery/pkg/types"
+
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 )
 
 // Actuator controls credentials on a specific infrastructure. All
@@ -30,8 +34,10 @@ type Actuator interface {
 	Delete(context.Context, *minterv1.CredentialsRequest) error
 	// Update the credentials to the provided definition.
 	Update(context.Context, *minterv1.CredentialsRequest) error
-	// Checks if the credentials currently exists.
+	// Exists checks if the credentials currently exist.
 	Exists(context.Context, *minterv1.CredentialsRequest) (bool, error)
+	// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
+	GetParentCredSecretLocation() types.NamespacedName
 }
 
 type DummyActuator struct {
@@ -51,6 +57,11 @@ func (a *DummyActuator) Update(ctx context.Context, cr *minterv1.CredentialsRequ
 
 func (a *DummyActuator) Delete(ctx context.Context, cr *minterv1.CredentialsRequest) error {
 	return nil
+}
+
+// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *DummyActuator) GetParentCredSecretLocation() types.NamespacedName {
+	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.AWSCloudCredSecretName}
 }
 
 type ActuatorError struct {

--- a/pkg/operator/credentialsrequest/constants/constants.go
+++ b/pkg/operator/credentialsrequest/constants/constants.go
@@ -54,4 +54,6 @@ var (
 		ModeDegraded,
 		ModeUnknown,
 	}
+
+	KubeSystemNS = "kube-system"
 )

--- a/pkg/operator/credentialsrequest/status_test.go
+++ b/pkg/operator/credentialsrequest/status_test.go
@@ -217,7 +217,7 @@ func TestClusterOperatorStatus(t *testing.T) {
 			credRequests:      []minterv1.CredentialsRequest{},
 			parentCredRemoved: true,
 			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, reasonParentCredRemoved),
+				testCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, reasonCredentialsRootSecretMissing),
 			},
 		},
 		{

--- a/pkg/operator/credentialsrequest/status_test.go
+++ b/pkg/operator/credentialsrequest/status_test.go
@@ -38,6 +38,8 @@ import (
 
 	"github.com/openshift/cloud-credential-operator/pkg/apis"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 )
 
 var (
@@ -79,6 +81,7 @@ func TestClusterOperatorStatus(t *testing.T) {
 		credRequests       []minterv1.CredentialsRequest
 		cloudPlatform      configv1.PlatformType
 		operatorDisabled   bool
+		parentCredRemoved  bool
 		expectedConditions []configv1.ClusterOperatorStatusCondition
 	}{
 		{
@@ -210,6 +213,14 @@ func TestClusterOperatorStatus(t *testing.T) {
 			},
 		},
 		{
+			name:              "upgradable false if parent cred removed",
+			credRequests:      []minterv1.CredentialsRequest{},
+			parentCredRemoved: true,
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{
+				testCondition(configv1.OperatorUpgradeable, configv1.ConditionFalse, reasonParentCredRemoved),
+			},
+		},
+		{
 			name: "operator disabled",
 			credRequests: []minterv1.CredentialsRequest{
 				testCredentialsRequestWithStatus("cred1", false, []minterv1.CredentialsRequestCondition{}, nil),
@@ -232,7 +243,11 @@ func TestClusterOperatorStatus(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
-			clusterOperatorConditions := computeStatusConditions(testUnknownConditions(), test.credRequests, test.cloudPlatform, test.operatorDisabled, log.WithField("test", test.name))
+			clusterOperatorConditions := computeStatusConditions(testUnknownConditions(), test.credRequests,
+				test.cloudPlatform, test.operatorDisabled,
+				!test.parentCredRemoved,
+				types.NamespacedName{Namespace: annotatorconst.CloudCredSecretNamespace, Name: annotatorconst.AWSCloudCredSecretName},
+				log.WithField("test", test.name))
 			for _, ec := range test.expectedConditions {
 				c := findClusterOperatorCondition(clusterOperatorConditions, ec.Type)
 				if assert.NotNil(t, c) {
@@ -287,7 +302,8 @@ func TestClusterOperatorVersion(t *testing.T) {
 			fakeClient := fake.NewFakeClient(existing...)
 
 			rcr := &ReconcileCredentialsRequest{
-				Client: fakeClient,
+				Client:   fakeClient,
+				Actuator: &actuator.DummyActuator{},
 			}
 
 			assert.NoError(t, os.Setenv("RELEASE_VERSION", test.releaseVersionEnv), "unable to set environment variable for testing")

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -236,14 +236,14 @@ func (a *OvirtActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) (*co
 	return loadedSecret, nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *OvirtActuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *OvirtActuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: crconst.KubeSystemNS, Name: annotatorconst.OvirtCloudCredsSecretName}
 }
 
 func (a *OvirtActuator) getCredentialsSecretData(ctx context.Context, logger log.FieldLogger) (OvirtCreds, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
+	if err := a.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return OvirtCreds{}, &actuatoriface.ActuatorError{

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -31,7 +31,8 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
+	crconst "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
+	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 )
 
 const (
@@ -235,9 +236,14 @@ func (a *OvirtActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) (*co
 	return loadedSecret, nil
 }
 
+// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *OvirtActuator) GetParentCredSecretLocation() types.NamespacedName {
+	return types.NamespacedName{Namespace: crconst.KubeSystemNS, Name: annotatorconst.OvirtCloudCredsSecretName}
+}
+
 func (a *OvirtActuator) getCredentialsSecretData(ctx context.Context, logger log.FieldLogger) (OvirtCreds, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, types.NamespacedName{Name: constants.OvirtCloudCredsSecretName, Namespace: constants.CloudCredSecretNamespace}, cloudCredSecret); err != nil {
+	if err := a.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return OvirtCreds{}, &actuatoriface.ActuatorError{
@@ -248,10 +254,10 @@ func (a *OvirtActuator) getCredentialsSecretData(ctx context.Context, logger log
 
 	out, err := secretToCreds(cloudCredSecret)
 	if err != nil {
-		logger.Warnf("secret did not have expected key: %s", constants.OvirtCloudCredsSecretName)
+		logger.Warnf("secret did not have expected key: %s", annotatorconst.OvirtCloudCredsSecretName)
 		return OvirtCreds{}, &actuatoriface.ActuatorError{
 			ErrReason: minterv1.InsufficientCloudCredentials,
-			Message:   fmt.Sprintf("secret did not have expected key: %v", constants.OvirtCloudCredsSecretName),
+			Message:   fmt.Sprintf("secret did not have expected key: %v", annotatorconst.OvirtCloudCredsSecretName),
 		}
 	}
 

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -330,14 +330,14 @@ func (a *VSphereActuator) syncTargetSecret(cr *minterv1.CredentialsRequest, secr
 	return nil
 }
 
-// GetParentCredSecretLocation returns the namespace and name where the parent credentials secret is stored.
-func (a *VSphereActuator) GetParentCredSecretLocation() types.NamespacedName {
+// GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
+func (a *VSphereActuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.KubeSystemNS, Name: annotatorconst.VSphereCloudCredSecretName}
 }
 
 func (a *VSphereActuator) getCloudCredentialsSecret(ctx context.Context, logger log.FieldLogger) (*corev1.Secret, error) {
 	cloudCredSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, a.GetParentCredSecretLocation(), cloudCredSecret); err != nil {
+	if err := a.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), cloudCredSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return nil, &actuatoriface.ActuatorError{


### PR DESCRIPTION
Enhance safety by making sure the recently documented root cred removal process marks upgradable false until the user restores the credentials.

We also now reconcile all cred requests on any change to a secret that looks like one of our supported cluster parent cred secrets.