### PR TITLE
Bug 1809194: expose metrics over https

### DIFF
--- a/manifests/0000_90_cloud-credential-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_cloud-credential-operator_01_prometheusrole.yaml
@@ -7,6 +7,12 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespace/metrics
+  verbs:
+  - get
+- apiGroups:
+  - ""
+  resources:
   - services
   - endpoints
   - pods

--- a/manifests/0000_90_cloud-credential-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_cloud-credential-operator_03_servicemonitor.yaml
@@ -5,61 +5,14 @@ metadata:
   namespace: openshift-cloud-credential-operator
 spec:
   endpoints:
-  - interval: 30s
-    port: cco-metrics
-    scheme: http
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: metrics
+    scheme: https
+    tlsConfig:
+      caFile: /etc/prometheus/configmaps/serving-certs-ca-bundle/service-ca.crt
+      serverName: cco-metrics.openshift-cloud-credential-operator.svc
   namespaceSelector:
     matchNames:
     - openshift-cloud-credential-operator
   selector: {}
----
-apiVersion: monitoring.coreos.com/v1
-kind: PrometheusRule
-metadata:
-  annotations:
-    exclude.release.openshift.io/internal-openshift-hosted: "true"
-  name: cloud-credential-operator-alerts
-  namespace: openshift-cloud-credential-operator
-spec:
-  groups:
-  - name: CloudCredentialOperator
-    rules:
-    - alert: CloudCredentialOperatorTargetNamespaceMissing
-      annotations:
-        message: CredentialsRequest(s) pointing to non-existant namespace
-      expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
-        > 0
-      for: 5m
-      labels:
-        severity: warning
-    - alert: CloudCredentialOperatorProvisioningFailed
-      annotations:
-        message: CredentialsRequest(s) unable to be fulfilled
-      expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
-        > 0
-      for: 5m
-      labels:
-        severity: warning
-    - alert: CloudCredentialOperatorDeprovisioningFailed
-      annotations:
-        message: CredentialsRequest(s) unable to be cleaned up
-      expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
-        > 0
-      for: 5m
-      labels:
-        severity: warning
-    - alert: CloudCredentialOperatorInsufficientCloudCreds
-      annotations:
-        message: Cluster's cloud credentials insufficient for minting or passthrough
-      expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
-        > 0
-      for: 5m
-      labels:
-        severity: warning
-    - alert: CloudCredentialOperatorDown
-      annotations:
-        message: cloud-credential-operator pod not running
-      expr: absent(up{job="cco-metrics"} == 1)
-      for: 5m
-      labels:
-        severity: critical

--- a/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
+++ b/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
@@ -1,0 +1,50 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+  name: cloud-credential-operator-alerts
+  namespace: openshift-cloud-credential-operator
+spec:
+  groups:
+  - name: CloudCredentialOperator
+    rules:
+    - alert: CloudCredentialOperatorTargetNamespaceMissing
+      annotations:
+        message: CredentialsRequest(s) pointing to non-existant namespace
+      expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
+        > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CloudCredentialOperatorProvisioningFailed
+      annotations:
+        message: CredentialsRequest(s) unable to be fulfilled
+      expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
+        > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CloudCredentialOperatorDeprovisioningFailed
+      annotations:
+        message: CredentialsRequest(s) unable to be cleaned up
+      expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
+        > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CloudCredentialOperatorInsufficientCloudCreds
+      annotations:
+        message: Cluster's cloud credentials insufficient for minting or passthrough
+      expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
+        > 0
+      for: 5m
+      labels:
+        severity: warning
+    - alert: CloudCredentialOperatorDown
+      annotations:
+        message: cloud-credential-operator pod not running
+      expr: absent(up{job="cco-metrics"} == 1)
+      for: 5m
+      labels:
+        severity: critical

--- a/manifests/01-cluster-role.yaml
+++ b/manifests/01-cluster-role.yaml
@@ -100,3 +100,15 @@ rules:
   - clusterrolebindings
   verbs:
   - "*"
+- apiGroups:
+  - authentication.k8s.io
+  resources:
+  - tokenreviews
+  verbs:
+  - create
+- apiGroups:
+  - authorization.k8s.io
+  resources:
+  - subjectaccessreviews
+  verbs:
+  - create

--- a/manifests/01-service.yaml
+++ b/manifests/01-service.yaml
@@ -1,14 +1,16 @@
 apiVersion: v1
 kind: Service
 metadata:
+  annotations:
+    service.alpha.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert
   name: cco-metrics
   namespace: openshift-cloud-credential-operator
 spec:
   ports:
-  - name: cco-metrics
-    port: 2112
+  - name: metrics
+    port: 8443
     protocol: TCP
-    targetPort: 2112
+    targetPort: metrics
   selector:
     app: cloud-credential-operator
   sessionAffinity: None

--- a/manifests/02-kube-rbac-proxy-config.yaml
+++ b/manifests/02-kube-rbac-proxy-config.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kube-rbac-proxy
+  namespace: openshift-cloud-credential-operator
+data:
+  config-file.yaml: |+
+    authorization:
+      resourceAttributes:
+        apiVersion: v1
+        resource: namespace
+        subresource: metrics
+        namespace: openshift-cloud-credential-operator

--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -22,6 +22,32 @@ spec:
     spec:
       containers:
       - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:2112/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --config-file=/etc/kube-rbac-proxy/config-file.yaml
+        - --logtostderr=true
+        - -v=10
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/kube-rbac-proxy
+          name: auth-proxy-config
+        - mountPath: /etc/tls/private
+          name: cloud-credential-operator-serving-cert
+      - args:
         - |
           if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
               echo "Copying system trust bundle"
@@ -39,10 +65,6 @@ spec:
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
         name: cloud-credential-operator
-        ports:
-        - containerPort: 9876
-          name: webhook-server
-          protocol: TCP
         resources:
           requests:
             cpu: 10m
@@ -76,3 +98,9 @@ spec:
           name: cco-trusted-ca
           optional: true
         name: cco-trusted-ca
+      - configMap:
+          name: kube-rbac-proxy
+        name: auth-proxy-config
+      - name: cloud-credential-operator-serving-cert
+        secret:
+          secretName: cloud-credential-operator-serving-cert

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -10,3 +10,7 @@ spec:
     from:
       kind: DockerImage
       Name: quay.io/openshift/aws-pod-identity-webhook
+  - name: kube-rbac-proxy
+    from:
+      kind: DockerImage
+      name: quay.io/openshift/origin-kube-rbac-proxy:latest


### PR DESCRIPTION
Add kube-rbac-proxy container to CCO deployment listening on :8443 and forwarding traffic to :2112 (the CCO container's metrics port).
New ConfigMap with configuration for the kube-rbac-proxy container.
Update cco-metrics service to request certs to be created (for use by kube-rbac-proxy container).
Update ServiceMonitor to tell Prometheus to scrape using https.
Grant Prometheus role permissions for fetching metrics.
Update role permissions so that kube-rbac-proxy container can perform its tasks.

Also, remove unused port definition in CCO container definition (webook-server port number 9876).