### PR TITLE
Bug 1846200: make AWS_POD_IDENTITY_WEBHOOK_IMAGE not set non-fatal

### DIFF
--- a/pkg/operator/awspodidentity/controller.go
+++ b/pkg/operator/awspodidentity/controller.go
@@ -109,7 +109,7 @@ func Add(mgr manager.Manager, kubeconfig string) error {
 	logger := log.WithFields(log.Fields{"controller": controllerName})
 	imagePullSpec := os.Getenv("AWS_POD_IDENTITY_WEBHOOK_IMAGE")
 	if len(imagePullSpec) == 0 {
-		logger.Warn("AWS_POD_IDENTITY_WEBHOOK_IMAGE is not set, skipping controller")
+		logger.Warn("AWS_POD_IDENTITY_WEBHOOK_IMAGE is not set, AWS pod identity webhook will not be deployed")
 		return nil
 	}
 


### PR DESCRIPTION
@dgoodwin @abhinavdahiya @wking 

fixes https://bugzilla.redhat.com/show_bug.cgi?id=1846200

This changes the behavior from fatal termination of the whole operator when `AWS_POD_IDENTITY_WEBHOOK_IMAGE` is not set, to just disabling the `podidentitywebhook` controller within the operator.