### PR TITLE
refactor ClusterOperator status updates

### DIFF
--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -33,6 +33,7 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/operator/metrics"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+	"github.com/openshift/cloud-credential-operator/pkg/util/clusteroperator"
 
 	configv1 "github.com/openshift/api/config/v1"
 
@@ -80,11 +81,13 @@ func AddWithActuator(mgr manager.Manager, actuator actuator.Actuator, platType c
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager, actuator actuator.Actuator, platType configv1.PlatformType) reconcile.Reconciler {
-	return &ReconcileCredentialsRequest{
+	r := &ReconcileCredentialsRequest{
 		Client:       mgr.GetClient(),
 		Actuator:     actuator,
 		platformType: platType,
 	}
+	clusteroperator.AddStatusHandler(r)
+	return r
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -45,6 +45,7 @@ import (
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	gcpconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/gcp"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+	"github.com/openshift/cloud-credential-operator/pkg/util/clusteroperator"
 
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
@@ -579,6 +580,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				},
 				platformType: configv1.GCPPlatformType,
 			}
+			clusteroperator.AddStatusHandler(rcr)
 
 			_, err := rcr.Reconcile(reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -48,6 +48,7 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/constants"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+	"github.com/openshift/cloud-credential-operator/pkg/util/clusteroperator"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
@@ -1037,6 +1038,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				},
 				platformType: configv1.AWSPlatformType,
 			}
+			clusteroperator.AddStatusHandler(rcr)
 
 			_, err = rcr.Reconcile(reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
@@ -40,6 +40,7 @@ import (
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	annotatorconst "github.com/openshift/cloud-credential-operator/pkg/operator/secretannotator/constants"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+	"github.com/openshift/cloud-credential-operator/pkg/util/clusteroperator"
 	"github.com/openshift/cloud-credential-operator/pkg/vsphere/actuator"
 )
 
@@ -206,6 +207,7 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				},
 				platformType: configv1.VSpherePlatformType,
 			}
+			clusteroperator.AddStatusHandler(rcr)
 
 			_, err := rcr.Reconcile(reconcile.Request{
 				NamespacedName: types.NamespacedName{

--- a/pkg/operator/credentialsrequest/status.go
+++ b/pkg/operator/credentialsrequest/status.go
@@ -4,10 +4,8 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"reflect"
-	"time"
 
-	errors "github.com/pkg/errors"
+	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -19,7 +17,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -29,11 +26,7 @@ const (
 	cloudCredClusterOperator           = "cloud-credential"
 	cloudCredOperatorNamespace         = "openshift-cloud-credential-operator"
 	reasonCredentialsFailing           = "CredentialsFailing"
-	reasonNoCredentialsFailing         = "NoCredentialsFailing"
 	reasonReconciling                  = "Reconciling"
-	reasonReconcilingComplete          = "ReconcilingComplete"
-	reasonCredentialsNotProvisioned    = "CredentialsNotProvisioned"
-	reasonOperatorDisabled             = "OperatorDisabledByAdmin"
 	reasonCredentialsRootSecretMissing = "CredentialsRootSecretMissing"
 )
 
@@ -41,63 +34,33 @@ const (
 // creates or updates the ClusterOperator resource for the operator accordingly.
 func (r *ReconcileCredentialsRequest) syncOperatorStatus() error {
 	logger := log.WithField("controller", "credreq_status")
-	logger.Debug("syncing cluster operator status")
-	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: cloudCredClusterOperator}}
-	err := r.Client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co)
-	isNotFound := apierrors.IsNotFound(err)
-	if err != nil && !isNotFound {
-		return fmt.Errorf("failed to get clusteroperator %s: %v", co.Name, err)
-	}
+	return clusteroperator.SyncStatus(r.Client, logger)
+}
 
+var _ clusteroperator.StatusHandler = &ReconcileCredentialsRequest{}
+
+func (r *ReconcileCredentialsRequest) GetConditions(logger log.FieldLogger) ([]configv1.ClusterOperatorStatusCondition, error) {
 	_, credRequests, operatorIsDisabled, err := r.getOperatorState(logger)
 	if err != nil {
-		return fmt.Errorf("failed to get operator state: %v", err)
+		return []configv1.ClusterOperatorStatusCondition{}, fmt.Errorf("failed to get operator state: %v", err)
 	}
-
-	oldConditions := co.Status.Conditions
-	oldVersions := co.Status.Versions
-	oldRelatedObjects := co.Status.RelatedObjects
 	parentSecretExists, err := r.parentSecretExists()
 	if err != nil {
-		return errors.Wrap(err, "error checking if parent secret exists")
+		return []configv1.ClusterOperatorStatusCondition{}, errors.Wrap(err, "error checking if parent secret exists")
 	}
-	co.Status.Conditions = computeStatusConditions(oldConditions, credRequests, r.platformType, operatorIsDisabled,
-		parentSecretExists, r.Actuator.GetCredentialsRootSecretLocation(), logger)
-	co.Status.Versions = computeClusterOperatorVersions()
-	co.Status.RelatedObjects = buildExpectedRelatedObjects(credRequests)
+	return computeStatusConditions(credRequests, r.platformType, operatorIsDisabled, parentSecretExists, r.Actuator.GetCredentialsRootSecretLocation(), logger), nil
+}
 
-	// ClusterOperator should already exist (from the manifests payload), but recreate it if needed
-	if isNotFound {
-		if err := r.Client.Create(context.TODO(), co); err != nil {
-			return fmt.Errorf("failed to create clusteroperator %s: %v", co.Name, err)
-		}
-		logger.Info("created clusteroperator")
+func (r *ReconcileCredentialsRequest) GetRelatedObjects(logger log.FieldLogger) ([]configv1.ObjectReference, error) {
+	_, credRequests, _, err := r.getOperatorState(logger)
+	if err != nil {
+		return []configv1.ObjectReference{}, fmt.Errorf("failed to get operator state: %v", err)
 	}
+	return buildExpectedRelatedObjects(credRequests), nil
+}
 
-	// Check if version changed, if so force a progressing last transition update:
-	if !reflect.DeepEqual(oldVersions, co.Status.Versions) {
-		logger.WithFields(log.Fields{
-			"old": oldVersions,
-			"new": co.Status.Versions,
-		}).Info("version has changed, updating progressing condition lastTransitionTime")
-		progressing := findClusterOperatorCondition(co.Status.Conditions, configv1.OperatorProgressing)
-		// We know this should be there.
-		progressing.LastTransitionTime = metav1.Time{Time: time.Now()}
-	}
-
-	// Update status fields if needed
-	if !clusteroperator.ConditionsEqual(oldConditions, co.Status.Conditions) ||
-		!reflect.DeepEqual(oldVersions, co.Status.Versions) ||
-		!reflect.DeepEqual(oldRelatedObjects, co.Status.RelatedObjects) {
-
-		err = r.Client.Status().Update(context.TODO(), co)
-		if err != nil {
-			return fmt.Errorf("failed to update clusteroperator %s: %v", co.Name, err)
-		}
-		logger.Debug("cluster operator status updated")
-	}
-
-	return nil
+func (r *ReconcileCredentialsRequest) Name() string {
+	return controllerName
 }
 
 func (r *ReconcileCredentialsRequest) parentSecretExists() (bool, error) {
@@ -156,17 +119,14 @@ func computeClusterOperatorVersions() []configv1.OperandVersion {
 
 // computeStatusConditions computes the operator's current state.
 func computeStatusConditions(
-	conditions []configv1.ClusterOperatorStatusCondition,
 	credRequests []minterv1.CredentialsRequest,
 	clusterCloudPlatform configv1.PlatformType,
 	operatorIsDisabled bool, parentCredExists bool, parentCredLocation types.NamespacedName,
 	logger log.FieldLogger) []configv1.ClusterOperatorStatusCondition {
 
-	// Degraded should be true if we are encountering errors. We consider any credentials request
-	// with either provision or deprovision failure conditions true, to be a degraded condition.
-	degradedCondition := &configv1.ClusterOperatorStatusCondition{
-		Type:   configv1.OperatorDegraded,
-		Status: configv1.ConditionFalse,
+	var conditions []configv1.ClusterOperatorStatusCondition
+	if operatorIsDisabled {
+		return conditions
 	}
 
 	failingCredRequests := 0
@@ -203,95 +163,51 @@ func computeStatusConditions(
 
 	}
 
-	if operatorIsDisabled {
-		degradedCondition.Status = configv1.ConditionFalse
-		degradedCondition.Reason = reasonOperatorDisabled
-	} else {
-		if failingCredRequests > 0 {
-			degradedCondition.Status = configv1.ConditionTrue
-			degradedCondition.Reason = reasonCredentialsFailing
-			degradedCondition.Message = fmt.Sprintf(
-				"%d of %d credentials requests are failing to sync.",
-				failingCredRequests, len(validCredRequests))
-		} else {
-			degradedCondition.Status = configv1.ConditionFalse
-			degradedCondition.Reason = reasonNoCredentialsFailing
-			degradedCondition.Message = "No credentials requests reporting errors."
-
-		}
+	if failingCredRequests > 0 {
+		var degradedCondition configv1.ClusterOperatorStatusCondition
+		degradedCondition.Type = configv1.OperatorDegraded
+		degradedCondition.Status = configv1.ConditionTrue
+		degradedCondition.Reason = reasonCredentialsFailing
+		degradedCondition.Message = fmt.Sprintf(
+			"%d of %d credentials requests are failing to sync.",
+			failingCredRequests, len(validCredRequests))
+		conditions = append(conditions, degradedCondition)
 	}
-	conditions = clusteroperator.SetStatusCondition(conditions,
-		degradedCondition)
 
 	// Progressing should be true if the operator is making changes to the operand. In this case
 	// we will set true if any CredentialsRequests are not provisioned, or have failure conditions,
 	// as this indicates the controllers have work they are trying to do.
-	progressingCondition := &configv1.ClusterOperatorStatusCondition{
-		Type:   configv1.OperatorProgressing,
-		Status: configv1.ConditionUnknown,
-	}
+	credRequestsNotProvisioned := 0
+	logger.Debugf("%d cred requests", len(validCredRequests))
 
-	if operatorIsDisabled {
-		progressingCondition.Status = configv1.ConditionFalse
-		progressingCondition.Reason = reasonOperatorDisabled
-	} else {
-		credRequestsNotProvisioned := 0
-		logger.Debugf("%d cred requests", len(validCredRequests))
-
-		for _, cr := range validCredRequests {
-			if !cr.Status.Provisioned {
-				credRequestsNotProvisioned = credRequestsNotProvisioned + 1
-			}
-		}
-		if credRequestsNotProvisioned > 0 || failingCredRequests > 0 {
-			progressingCondition.Status = configv1.ConditionTrue
-			progressingCondition.Reason = reasonReconciling
-			progressingCondition.Message = fmt.Sprintf(
-				"%d of %d credentials requests provisioned, %d reporting errors.",
-				len(validCredRequests)-credRequestsNotProvisioned, len(validCredRequests), failingCredRequests)
-		} else {
-			progressingCondition.Status = configv1.ConditionFalse
-			progressingCondition.Reason = reasonReconcilingComplete
-			progressingCondition.Message = fmt.Sprintf(
-				"%d of %d credentials requests provisioned and reconciled.",
-				len(validCredRequests), len(validCredRequests))
+	for _, cr := range validCredRequests {
+		if !cr.Status.Provisioned {
+			credRequestsNotProvisioned = credRequestsNotProvisioned + 1
 		}
 	}
-	conditions = clusteroperator.SetStatusCondition(conditions,
-		progressingCondition)
+	if credRequestsNotProvisioned > 0 || failingCredRequests > 0 {
+		var progressingCondition configv1.ClusterOperatorStatusCondition
+		progressingCondition.Type = configv1.OperatorProgressing
+		progressingCondition.Status = configv1.ConditionTrue
+		progressingCondition.Reason = reasonReconciling
+		progressingCondition.Message = fmt.Sprintf(
+			"%d of %d credentials requests provisioned, %d reporting errors.",
+			len(validCredRequests)-credRequestsNotProvisioned, len(validCredRequests), failingCredRequests)
+		conditions = append(conditions, progressingCondition)
+	}
 
-	// Available should be true if we've made our API available.
-	// (note: definition has fluctuated a lot) Our CO definition in release manifest will set to
-	// unknown, we will set to true indicating we're up and running.
-	// TODO: is there a better way to determine if we've made our API available? We wouldn't
-	// get this far in syncing on a CredentialsRequest if it wasn't available. Would probably need a separate controller syncing on some other type to formally check.
-	availableCondition := &configv1.ClusterOperatorStatusCondition{
-		Status: configv1.ConditionTrue,
-		Type:   configv1.OperatorAvailable,
-	}
-	if operatorIsDisabled {
-		availableCondition.Reason = reasonOperatorDisabled
-	}
-	conditions = clusteroperator.SetStatusCondition(conditions,
-		availableCondition)
-
-	// CCO doesn't have the idea of upgradeable vs not-upgradeable, but should report that condition nevertheless.
-	// Always be upgradeable.
-	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
-		Status: configv1.ConditionTrue,
-		Type:   configv1.OperatorUpgradeable,
-	}
 	// If the operator is not disabled, and we do not have a parent cred in kube-system, we are not
 	// upgradable. Admin cred removal is a valid mode to run in but it should be restored before
 	// you can upgrade.
 	if !operatorIsDisabled && !parentCredExists {
+		var upgradeableCondition configv1.ClusterOperatorStatusCondition
+		upgradeableCondition.Type = configv1.OperatorUpgradeable
 		upgradeableCondition.Status = configv1.ConditionFalse
 		upgradeableCondition.Reason = reasonCredentialsRootSecretMissing
 		upgradeableCondition.Message = fmt.Sprintf("Parent credential secret %s/%s must be restored prior to upgrade",
 			parentCredLocation.Namespace, parentCredLocation.Name)
+		conditions = append(conditions, upgradeableCondition)
 	}
-	conditions = clusteroperator.SetStatusCondition(conditions,
-		upgradeableCondition)
 
 	// Log all conditions we set:
 	for _, c := range conditions {

--- a/pkg/operator/credentialsrequest/status_test.go
+++ b/pkg/operator/credentialsrequest/status_test.go
@@ -85,14 +85,10 @@ func TestClusterOperatorStatus(t *testing.T) {
 		expectedConditions []configv1.ClusterOperatorStatusCondition
 	}{
 		{
-			name:          "no credentials requests",
-			credRequests:  []minterv1.CredentialsRequest{},
-			cloudPlatform: configv1.AWSPlatformType,
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
-				testCondition(configv1.OperatorProgressing, configv1.ConditionFalse, reasonReconcilingComplete),
-				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonNoCredentialsFailing),
-			},
+			name:               "no credentials requests",
+			credRequests:       []minterv1.CredentialsRequest{},
+			cloudPlatform:      configv1.AWSPlatformType,
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{},
 		},
 		{
 			name: "progressing no errors",
@@ -103,9 +99,7 @@ func TestClusterOperatorStatus(t *testing.T) {
 			},
 			cloudPlatform: configv1.AWSPlatformType,
 			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
 				testCondition(configv1.OperatorProgressing, configv1.ConditionTrue, reasonReconciling),
-				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonNoCredentialsFailing),
 			},
 		},
 		{
@@ -119,7 +113,6 @@ func TestClusterOperatorStatus(t *testing.T) {
 			},
 			cloudPlatform: configv1.AWSPlatformType,
 			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
 				testCondition(configv1.OperatorProgressing, configv1.ConditionTrue, reasonReconciling),
 				testCondition(configv1.OperatorDegraded, configv1.ConditionTrue, reasonCredentialsFailing),
 			},
@@ -139,7 +132,6 @@ func TestClusterOperatorStatus(t *testing.T) {
 			},
 			cloudPlatform: configv1.AWSPlatformType,
 			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
 				testCondition(configv1.OperatorProgressing, configv1.ConditionTrue, reasonReconciling),
 				testCondition(configv1.OperatorDegraded, configv1.ConditionTrue, reasonCredentialsFailing),
 			},
@@ -151,12 +143,8 @@ func TestClusterOperatorStatus(t *testing.T) {
 				testCredentialsRequestWithStatus("cred2", true, []minterv1.CredentialsRequestCondition{}, nil),
 				testCredentialsRequestWithStatus("cred3", true, []minterv1.CredentialsRequestCondition{}, nil),
 			},
-			cloudPlatform: configv1.AWSPlatformType,
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
-				testCondition(configv1.OperatorProgressing, configv1.ConditionFalse, reasonReconcilingComplete),
-				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonNoCredentialsFailing),
-			},
+			cloudPlatform:      configv1.AWSPlatformType,
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{},
 		},
 		{
 			// Implies the credential was initially provisioned but an update is needed and it's failing:
@@ -170,7 +158,6 @@ func TestClusterOperatorStatus(t *testing.T) {
 			},
 			cloudPlatform: configv1.AWSPlatformType,
 			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
 				testCondition(configv1.OperatorProgressing, configv1.ConditionTrue, reasonReconciling),
 				testCondition(configv1.OperatorDegraded, configv1.ConditionTrue, reasonCredentialsFailing),
 			},
@@ -183,12 +170,8 @@ func TestClusterOperatorStatus(t *testing.T) {
 				testCredentialsRequestWithStatus("azurecred", false, []minterv1.CredentialsRequestCondition{}, defaultAzureProviderConfig),
 				testCredentialsRequestWithStatus("gcpcred", false, []minterv1.CredentialsRequestCondition{}, defaultGCPProviderConfig),
 			},
-			cloudPlatform: configv1.AWSPlatformType,
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
-				testConditionWithMessage(configv1.OperatorProgressing, configv1.ConditionFalse, reasonReconcilingComplete, "2 of 2 credentials requests"),
-				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonNoCredentialsFailing),
-			},
+			cloudPlatform:      configv1.AWSPlatformType,
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{},
 		},
 		{
 			name: "ignore nonGCP credreqs",
@@ -198,19 +181,8 @@ func TestClusterOperatorStatus(t *testing.T) {
 				testCredentialsRequestWithStatus("awscred", false, []minterv1.CredentialsRequestCondition{}, defaultAWSProviderConfig),
 				testCredentialsRequestWithStatus("azurecred", false, []minterv1.CredentialsRequestCondition{}, defaultAzureProviderConfig),
 			},
-			cloudPlatform: configv1.GCPPlatformType,
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, ""),
-				testConditionWithMessage(configv1.OperatorProgressing, configv1.ConditionFalse, reasonReconcilingComplete, "2 of 2 credentials requests"),
-				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonNoCredentialsFailing),
-			},
-		},
-		{
-			name:         "set upgradeable condition",
-			credRequests: []minterv1.CredentialsRequest{},
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorUpgradeable, configv1.ConditionTrue, ""),
-			},
+			cloudPlatform:      configv1.GCPPlatformType,
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{},
 		},
 		{
 			name:              "upgradable false if parent cred removed",
@@ -228,13 +200,9 @@ func TestClusterOperatorStatus(t *testing.T) {
 					testCRCondition(minterv1.CredentialsProvisionFailure, corev1.ConditionTrue),
 				}, nil),
 			},
-			cloudPlatform:    configv1.AWSPlatformType,
-			operatorDisabled: true,
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorAvailable, configv1.ConditionTrue, reasonOperatorDisabled),
-				testCondition(configv1.OperatorProgressing, configv1.ConditionFalse, reasonOperatorDisabled),
-				testCondition(configv1.OperatorDegraded, configv1.ConditionFalse, reasonOperatorDisabled),
-			},
+			cloudPlatform:      configv1.AWSPlatformType,
+			operatorDisabled:   true,
+			expectedConditions: []configv1.ClusterOperatorStatusCondition{},
 		},
 	}
 
@@ -242,15 +210,14 @@ func TestClusterOperatorStatus(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
-
-			clusterOperatorConditions := computeStatusConditions(testUnknownConditions(), test.credRequests,
+			clusterOperatorConditions := computeStatusConditions(test.credRequests,
 				test.cloudPlatform, test.operatorDisabled,
 				!test.parentCredRemoved,
 				types.NamespacedName{Namespace: annotatorconst.CloudCredSecretNamespace, Name: annotatorconst.AWSCloudCredSecretName},
 				log.WithField("test", test.name))
 			for _, ec := range test.expectedConditions {
 				c := findClusterOperatorCondition(clusterOperatorConditions, ec.Type)
-				if assert.NotNil(t, c) {
+				if assert.NotNil(t, c, "unexpected nil for condition %s", ec.Type) {
 					assert.Equal(t, string(ec.Status), string(c.Status), "unexpected status for condition %s", ec.Type)
 					assert.Equal(t, ec.Reason, c.Reason, "unexpected reason for condition %s", ec.Type)
 
@@ -355,11 +322,8 @@ func testClusterOperator(version string, progressingLastTransition metav1.Time) 
 			},
 			Conditions: []configv1.ClusterOperatorStatusCondition{
 				{
-					Type:   configv1.OperatorProgressing,
-					Status: "False",
-					Reason: reasonReconcilingComplete,
-					// Warning: must match what the controller status would check, otherwise we might get a false positive on this test.
-					Message:            "0 of 0 credentials requests provisioned and reconciled.",
+					Type:               configv1.OperatorProgressing,
+					Status:             configv1.ConditionFalse,
 					LastTransitionTime: progressingLastTransition,
 				},
 			},
@@ -386,26 +350,6 @@ func testCRCondition(condType minterv1.CredentialsRequestConditionType, status c
 	return minterv1.CredentialsRequestCondition{
 		Type:   condType,
 		Status: status,
-	}
-}
-
-func testUnknownConditions() []configv1.ClusterOperatorStatusCondition {
-	return []configv1.ClusterOperatorStatusCondition{
-		{
-			Type:   configv1.OperatorAvailable,
-			Status: configv1.ConditionUnknown,
-			Reason: "",
-		},
-		{
-			Type:   configv1.OperatorProgressing,
-			Status: configv1.ConditionUnknown,
-			Reason: "",
-		},
-		{
-			Type:   configv1.OperatorDegraded,
-			Status: configv1.ConditionUnknown,
-			Reason: "",
-		},
 	}
 }
 

--- a/pkg/util/clusteroperator/status.go
+++ b/pkg/util/clusteroperator/status.go
@@ -1,65 +1,229 @@
 package clusteroperator
 
 import (
-	configv1 "github.com/openshift/api/config/v1"
+	"context"
+	"fmt"
+	"os"
+	"reflect"
 
+	log "github.com/sirupsen/logrus"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// SetStatusCondition returns the result of setting the specified condition in
-// the given slice of conditions.
-func SetStatusCondition(oldConditions []configv1.ClusterOperatorStatusCondition, condition *configv1.ClusterOperatorStatusCondition) []configv1.ClusterOperatorStatusCondition {
-	condition.LastTransitionTime = metav1.Now()
+const (
+	cloudCredClusterOperator = "cloud-credential"
+	reasonOperatorDisabled   = "OperatorDisabledByAdmin"
+	msgOperatorDisabled      = "Credential minting is disabled by cluster admin"
+)
 
-	newConditions := []configv1.ClusterOperatorStatusCondition{}
-
-	found := false
-	for _, c := range oldConditions {
-		if condition.Type == c.Type {
-			if condition.Status == c.Status &&
-				condition.Reason == c.Reason &&
-				condition.Message == c.Message {
-				return oldConditions
-			}
-
-			found = true
-			newConditions = append(newConditions, *condition)
-		} else {
-			newConditions = append(newConditions, c)
-		}
-	}
-	if !found {
-		newConditions = append(newConditions, *condition)
-	}
-
-	return newConditions
+// StatusHandler produces conditions and related objects to be reflected
+// in the cloud-credential-operator ClusterOperatorStatus
+type StatusHandler interface {
+	GetConditions(logger log.FieldLogger) ([]configv1.ClusterOperatorStatusCondition, error)
+	GetRelatedObjects(logger log.FieldLogger) ([]configv1.ObjectReference, error)
+	Name() string
 }
 
-// ConditionsEqual returns true if and only if the provided slices of conditions
-// (ignoring LastTransitionTime) are equal.
-func ConditionsEqual(oldConditions, newConditions []configv1.ClusterOperatorStatusCondition) bool {
-	if len(newConditions) != len(oldConditions) {
-		return false
+var (
+	statusHandlers = []StatusHandler{}
+)
+
+// AddStatusHandler registers a StatusHandler that will be called whenever
+// an update to the ClusterOperator status is requested
+func AddStatusHandler(handler StatusHandler) {
+	statusHandlers = append(statusHandlers, handler)
+}
+
+// SyncStatus syncs the ClusterOperator status by calling all registered
+// status handlers for conditions and related objects
+func SyncStatus(client client.Client, logger log.FieldLogger) error {
+	logger.Info("syncing cluster operator status")
+
+	co := &configv1.ClusterOperator{ObjectMeta: metav1.ObjectMeta{Name: cloudCredClusterOperator}}
+	err := client.Get(context.TODO(), types.NamespacedName{Name: co.Name}, co)
+	isNotFound := errors.IsNotFound(err)
+	if err != nil && !isNotFound {
+		return fmt.Errorf("failed to get clusteroperator %s: %v", co.Name, err)
 	}
 
-	for _, conditionA := range oldConditions {
-		foundMatchingCondition := false
+	oldConditions := co.Status.Conditions
+	oldVersions := co.Status.Versions
+	oldRelatedObjects := co.Status.RelatedObjects
 
-		for _, conditionB := range newConditions {
-			// Compare every field except LastTransitionTime.
-			if conditionA.Type == conditionB.Type &&
-				conditionA.Status == conditionB.Status &&
-				conditionA.Reason == conditionB.Reason &&
-				conditionA.Message == conditionB.Message {
-				foundMatchingCondition = true
-				break
+	// We rebuild the conditions from scratch each time.
+	// Handlers return abnormal (non-default) conditions they wish to set.
+	// if the controller is functioning normally, it should return an empty slice of conditions.
+	conditions := []configv1.ClusterOperatorStatusCondition{}
+	relatedObjects := []configv1.ObjectReference{}
+	for _, handler := range statusHandlers {
+		handlerConditions, err := handler.GetConditions(logger)
+		if err != nil {
+			logger.Errorf("failed to get conditions from handler %s", handler.Name())
+			continue
+		}
+		conditions = mergeConditions(conditions, handlerConditions, logger, handler.Name())
+		handlerRelatedObjects, err := handler.GetRelatedObjects(logger)
+		if err != nil {
+			logger.Errorf("failed to get related objects from handler %s", handler.Name())
+			continue
+		}
+		relatedObjects = append(relatedObjects, handlerRelatedObjects...)
+	}
+
+	// sets defaults for condition not set by any handler
+	conditions = defaultUnsetConditions(conditions)
+
+	// at this point we know all condition types exist in conditions
+
+	co.Status.Conditions = conditions
+	co.Status.RelatedObjects = relatedObjects
+	co.Status.Versions = computeClusterOperatorVersions()
+
+	// check if the operator is disabled and reflect that in the Available condition
+	operatorIsDisabled, err := utils.IsOperatorDisabled(client, logger)
+	if err != nil {
+		return fmt.Errorf("error checking if operator is disabled: %v", err)
+	}
+	if operatorIsDisabled {
+		available := findClusterOperatorCondition(co.Status.Conditions, configv1.OperatorAvailable)
+		if available.Status == configv1.ConditionTrue {
+			available.Reason = reasonOperatorDisabled
+			available.Message = msgOperatorDisabled
+		}
+	}
+
+	// Update transition time for any condition that has changed
+	setLastTransitionTime(oldConditions, co.Status.Conditions)
+
+	// Check if version changed, if so force a progressing last transition update:
+	if !reflect.DeepEqual(oldVersions, co.Status.Versions) {
+		logger.WithFields(log.Fields{
+			"old": oldVersions,
+			"new": co.Status.Versions,
+		}).Info("version has changed, updating progressing condition lastTransitionTime")
+		progressing := findClusterOperatorCondition(co.Status.Conditions, configv1.OperatorProgressing)
+		// We know this should be there.
+		progressing.LastTransitionTime = metav1.Now()
+	}
+
+	// ClusterOperator should already exist (from the manifests payload), but recreate it if needed
+	if isNotFound {
+		if err := client.Create(context.TODO(), co); err != nil {
+			return fmt.Errorf("failed to create clusteroperator %s: %v", co.Name, err)
+		}
+		logger.Info("created clusteroperator")
+		return nil
+	}
+
+	// Update status fields if needed
+	if !reflect.DeepEqual(oldConditions, co.Status.Conditions) ||
+		!reflect.DeepEqual(oldVersions, co.Status.Versions) ||
+		!reflect.DeepEqual(oldRelatedObjects, co.Status.RelatedObjects) {
+
+		err = client.Status().Update(context.TODO(), co)
+		if err != nil {
+			return fmt.Errorf("failed to update clusteroperator %s: %v", co.Name, err)
+		}
+		logger.Info("cluster operator status updated")
+	}
+
+	return nil
+}
+
+func mergeConditions(existing []configv1.ClusterOperatorStatusCondition, new []configv1.ClusterOperatorStatusCondition, logger log.FieldLogger, handlerName string) []configv1.ClusterOperatorStatusCondition {
+	conditions := []configv1.ClusterOperatorStatusCondition{}
+	for _, newCondition := range new {
+		existingCondition := findClusterOperatorCondition(existing, newCondition.Type)
+		if existingCondition == nil {
+			conditions = append(conditions, newCondition)
+		} else {
+			logger.Infof("condition already set for type %s by a previous handler, the following condition from handler %s will be dropped: %v", newCondition.Type, handlerName, newCondition)
+		}
+	}
+	return conditions
+}
+
+func defaultUnsetConditions(existing []configv1.ClusterOperatorStatusCondition) []configv1.ClusterOperatorStatusCondition {
+	var conditions []configv1.ClusterOperatorStatusCondition
+	for _, conditionType := range []configv1.ClusterStatusConditionType{
+		configv1.OperatorAvailable,
+		configv1.OperatorDegraded,
+		configv1.OperatorProgressing,
+		configv1.OperatorUpgradeable,
+	} {
+		existingCondition := findClusterOperatorCondition(existing, conditionType)
+		if existingCondition != nil {
+			conditions = append(conditions, *existingCondition)
+		} else {
+			// No handler set this condition type, set to defaults
+			defaultCondition := configv1.ClusterOperatorStatusCondition{
+				Type: conditionType,
 			}
-		}
-
-		if !foundMatchingCondition {
-			return false
+			switch conditionType {
+			case configv1.OperatorAvailable:
+				defaultCondition.Status = configv1.ConditionTrue
+			case configv1.OperatorDegraded:
+				defaultCondition.Status = configv1.ConditionFalse
+			case configv1.OperatorProgressing:
+				defaultCondition.Status = configv1.ConditionFalse
+			case configv1.OperatorUpgradeable:
+				defaultCondition.Status = configv1.ConditionTrue
+			}
+			conditions = append(conditions, defaultCondition)
 		}
 	}
+	return conditions
+}
 
-	return true
+func computeClusterOperatorVersions() []configv1.OperandVersion {
+	currentVersion := os.Getenv("RELEASE_VERSION")
+	versions := []configv1.OperandVersion{
+		{
+			Name:    "operator",
+			Version: currentVersion,
+		},
+	}
+	return versions
+}
+
+// findClusterOperatorCondition iterates all conditions on a ClusterOperator looking for the
+// specified condition type. If none exists nil will be returned.
+func findClusterOperatorCondition(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}
+
+func setLastTransitionTime(oldConditions []configv1.ClusterOperatorStatusCondition, newConditions []configv1.ClusterOperatorStatusCondition) {
+	for i := range newConditions {
+		newCondition := &newConditions[i]
+		oldCondition := findClusterOperatorCondition(oldConditions, newCondition.Type)
+		if oldCondition == nil || !conditionEqual(*oldCondition, *newCondition) {
+			newCondition.LastTransitionTime = metav1.Now()
+		} else {
+			newCondition.LastTransitionTime = oldCondition.LastTransitionTime
+		}
+	}
+}
+
+func conditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
+	// Compare every field except LastTransitionTime.
+	if a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message {
+		return true
+	}
+	return false
 }

--- a/pkg/util/clusteroperator/status_test.go
+++ b/pkg/util/clusteroperator/status_test.go
@@ -8,203 +8,66 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestSetStatusCondition(t *testing.T) {
-	testCases := []struct {
-		description   string
-		oldConditions []configv1.ClusterOperatorStatusCondition
-		newCondition  *configv1.ClusterOperatorStatusCondition
-		expected      []configv1.ClusterOperatorStatusCondition
-	}{
-		{
-			description: "new condition",
-			newCondition: &configv1.ClusterOperatorStatusCondition{
-				Type:   configv1.OperatorAvailable,
-				Status: configv1.ConditionTrue,
-			},
-			expected: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-			},
-		},
-		{
-			description: "existing condition, unchanged",
-			oldConditions: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-			},
-			newCondition: &configv1.ClusterOperatorStatusCondition{
-				Type:   configv1.OperatorAvailable,
-				Status: configv1.ConditionTrue,
-			},
-			expected: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-			},
-		},
-		{
-			description: "existing conditions, one changed",
-			oldConditions: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorDegraded,
-					Status: configv1.ConditionFalse,
-				},
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionFalse,
-				},
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionFalse,
-				},
-			},
-			newCondition: &configv1.ClusterOperatorStatusCondition{
-				Type:   configv1.OperatorAvailable,
-				Status: configv1.ConditionTrue,
-			},
-			expected: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorDegraded,
-					Status: configv1.ConditionFalse,
-				},
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionFalse,
-				},
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-			},
-		},
-	}
-
-	for _, tc := range testCases {
-		actual := SetStatusCondition(tc.oldConditions, tc.newCondition)
-		if !ConditionsEqual(actual, tc.expected) {
-			t.Fatalf("%q: expected %v, got %v", tc.description,
-				tc.expected, actual)
-		}
-	}
-}
-
 func TestConditionsEqual(t *testing.T) {
 	testCases := []struct {
 		description string
 		expected    bool
-		a, b        []configv1.ClusterOperatorStatusCondition
+		a, b        configv1.ClusterOperatorStatusCondition
 	}{
 		{
-			description: "empty statuses should be equal",
+			description: "empty conditions should be equal",
 			expected:    true,
 		},
 		{
 			description: "condition LastTransitionTime should be ignored",
 			expected:    true,
-			a: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:               configv1.OperatorAvailable,
-					Status:             configv1.ConditionTrue,
-					LastTransitionTime: metav1.Unix(0, 0),
-				},
+			a: configv1.ClusterOperatorStatusCondition{
+				Type:               configv1.OperatorAvailable,
+				Status:             configv1.ConditionTrue,
+				LastTransitionTime: metav1.Unix(0, 0),
 			},
-			b: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:               configv1.OperatorAvailable,
-					Status:             configv1.ConditionTrue,
-					LastTransitionTime: metav1.Unix(1, 0),
-				},
-			},
-		},
-		{
-			description: "order of conditions should not matter",
-			expected:    true,
-			a: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionTrue,
-				},
-			},
-			b: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionTrue,
-				},
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-			},
-		},
-		{
-			description: "check missing condition",
-			expected:    false,
-			a: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionTrue,
-				},
-			},
-			b: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionTrue,
-				},
-				{
-					Type:   configv1.OperatorProgressing,
-					Status: configv1.ConditionTrue,
-				},
+			b: configv1.ClusterOperatorStatusCondition{
+				Type:               configv1.OperatorAvailable,
+				Status:             configv1.ConditionTrue,
+				LastTransitionTime: metav1.Unix(1, 0),
 			},
 		},
 		{
 			description: "check condition reason differs",
 			expected:    false,
-			a: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionFalse,
-					Reason: "foo",
-				},
+			a: configv1.ClusterOperatorStatusCondition{
+				Type:   configv1.OperatorAvailable,
+				Status: configv1.ConditionFalse,
+				Reason: "foo",
 			},
-			b: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:   configv1.OperatorAvailable,
-					Status: configv1.ConditionFalse,
-					Reason: "bar",
-				},
+			b: configv1.ClusterOperatorStatusCondition{
+
+				Type:   configv1.OperatorAvailable,
+				Status: configv1.ConditionFalse,
+				Reason: "bar",
 			},
 		},
 		{
 			description: "check condition message differs",
 			expected:    false,
-			a: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:    configv1.OperatorAvailable,
-					Status:  configv1.ConditionFalse,
-					Message: "foo",
-				},
+			a: configv1.ClusterOperatorStatusCondition{
+
+				Type:    configv1.OperatorAvailable,
+				Status:  configv1.ConditionFalse,
+				Message: "foo",
 			},
-			b: []configv1.ClusterOperatorStatusCondition{
-				{
-					Type:    configv1.OperatorAvailable,
-					Status:  configv1.ConditionFalse,
-					Message: "bar",
-				},
+
+			b: configv1.ClusterOperatorStatusCondition{
+
+				Type:    configv1.OperatorAvailable,
+				Status:  configv1.ConditionFalse,
+				Message: "bar",
 			},
 		},
 	}
 
 	for _, tc := range testCases {
-		actual := ConditionsEqual(tc.a, tc.b)
+		actual := conditionEqual(tc.a, tc.b)
 		if actual != tc.expected {
 			t.Fatalf("%q: expected %v, got %v", tc.description,
 				tc.expected, actual)


### PR DESCRIPTION
@dgoodwin @joelddiaz @derekwaynecarr 

This PR refactors the code responsible for updating the `cloud-credential` `ClusterOperator` status.

Previous to the recent additions of the `awspodidentity` and `oidcdiscoveryendpoint` controllers, the only controller whose status effected the `ClusterOperator` status was the `credentialsrequest` controller and thus, the code to modify the status conditions was authoritatively controlled there.

However, with the new controllers, there are now 3 controllers whose state should be reflected in the status conditions.

The PR seeks to pull the code responsible for reconciling the `ClusterOperator` status out of the `credentialsrequest` controller so that other controllers can also register as `StatusHandlers` that can impact the status conditions and related objects.

This PR is largely as no-op, only seeking to separate the status reporting code, creating an interface that controllers can use, and switch the `credentialsrequest` controller to use that interface.  Because, with the new interface, controllers only report non-default conditions, the reasons for being in the expected steady state for the condition is no longer reported (i.e. `ReconcilingComplete` and `NoCredentialsFailing`)