### PR TITLE
let CCO use the default info log-level

### DIFF
--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -49,7 +49,7 @@ spec:
               echo "Copying system trust bundle"
               cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
           fi
-          exec /usr/bin/cloud-credential-operator operator --log-level=debug
+          exec /usr/bin/cloud-credential-operator operator
         command:
         - /bin/bash
         - -ec


### PR DESCRIPTION
instead of forcing debug.

This is to address openshift/cloud-credential-operator#207

But it doesn't address how to actually set it to debug mode if desired.