### PR TITLE
oidcdiscoveryendpoint: add status handler

### DIFF
--- a/pkg/util/clusteroperator/status.go
+++ b/pkg/util/clusteroperator/status.go
@@ -209,7 +209,7 @@ func setLastTransitionTime(oldConditions []configv1.ClusterOperatorStatusConditi
 	for i := range newConditions {
 		newCondition := &newConditions[i]
 		oldCondition := findClusterOperatorCondition(oldConditions, newCondition.Type)
-		if oldCondition == nil || !conditionEqual(*oldCondition, *newCondition) {
+		if oldCondition == nil || !ConditionEqual(*oldCondition, *newCondition) {
 			newCondition.LastTransitionTime = metav1.Now()
 		} else {
 			newCondition.LastTransitionTime = oldCondition.LastTransitionTime
@@ -217,7 +217,7 @@ func setLastTransitionTime(oldConditions []configv1.ClusterOperatorStatusConditi
 	}
 }
 
-func conditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
+func ConditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
 	// Compare every field except LastTransitionTime.
 	if a.Type == b.Type &&
 		a.Status == b.Status &&

--- a/pkg/util/clusteroperator/status_test.go
+++ b/pkg/util/clusteroperator/status_test.go
@@ -67,7 +67,7 @@ func TestConditionsEqual(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := conditionEqual(tc.a, tc.b)
+		actual := ConditionEqual(tc.a, tc.b)
 		if actual != tc.expected {
 			t.Fatalf("%q: expected %v, got %v", tc.description,
 				tc.expected, actual)


### PR DESCRIPTION
/cc @joelddiaz 
/assign @dgoodwin 

Following https://github.com/openshift/cloud-credential-operator/pull/213, this PR adds a status handler to the `oidcdiscoveryendpoint` controller so that if it is having problems, the overall OperatorStatus is Degraded with informative message why.

fyi @derekwaynecarr 