### PR TITLE
[OpenStack] Include cacert in the output

### DIFF
--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -70,6 +70,12 @@ const (
 	// CloudCredSecretNamespace is where the cloud credentials can be found
 	CloudCredSecretNamespace = "kube-system"
 
+	// OpenShiftConfigNamespace is where the OpenShift configuration can be found
+	OpenShiftConfigNamespace = "openshift-config"
+
+	// CloudProvderConfigMapName is the name of the configmap where cloudprovider config is stored
+	CloudProvderConfigMapName = "cloud-provider-config"
+
 	// GCPCloudCredSecretName is the name of the secret created by the installer containing cloud creds.
 	GCPCloudCredSecretName = "gcp-credentials"
 


### PR DESCRIPTION
If OpenStack cloud uses self-signed certificates, the installer stores the cacert file in the configmap that is mounted to kube-apiserver and and kube-controller-manager pods by library-go.

Unfortunately, for all other pods that communicates with OpenStack we have to introduce various mechanisms to obtain this configmap.
It will be more correct to distribute this file using CCO means.