### PR TITLE
Bug 1868328: Fix cases in cloud-credential's related objects

### DIFF
--- a/pkg/operator/awspodidentity/controller.go
+++ b/pkg/operator/awspodidentity/controller.go
@@ -68,12 +68,12 @@ var (
 		},
 		{
 			Group:    "rbac.authorization.k8s.io",
-			Resource: "clusteroles",
+			Resource: "clusterroles",
 			Name:     "pod-identity-webhook",
 		},
 		{
 			Group:    "rbac.authorization.k8s.io",
-			Resource: "clusterolebindings",
+			Resource: "clusterrolebindings",
 			Name:     "pod-identity-webhook",
 		},
 		{

--- a/pkg/operator/credentialsrequest/status.go
+++ b/pkg/operator/credentialsrequest/status.go
@@ -246,7 +246,7 @@ func buildExpectedRelatedObjects(credRequests []minterv1.CredentialsRequest) []c
 	for _, cr := range credRequests {
 		related = append(related, configv1.ObjectReference{
 			Group:     minterv1.SchemeGroupVersion.Group,
-			Resource:  "CredentialsRequest",
+			Resource:  "credentialsrequest",
 			Namespace: cr.Namespace,
 			Name:      cr.Name,
 		})

--- a/pkg/operator/secretannotator/status/status.go
+++ b/pkg/operator/secretannotator/status/status.go
@@ -68,7 +68,7 @@ func (s *SecretStatusHandler) GetRelatedObjects(logger log.FieldLogger) ([]confi
 	related := []configv1.ObjectReference{
 		{
 			Group:    operatorv1.GroupName,
-			Resource: "CloudCredentials",
+			Resource: "cloudcredentials",
 			Name:     constants.CloudCredOperatorConfig,
 		},
 	}
@@ -83,7 +83,7 @@ func (s *SecretStatusHandler) GetRelatedObjects(logger log.FieldLogger) ([]confi
 	// add the configmap if it exists
 	if !errors.IsNotFound(err) {
 		related = append(related, configv1.ObjectReference{
-			Resource:  "ConfigMap",
+			Resource:  "configmap",
 			Namespace: cm.Namespace,
 			Name:      cm.Name,
 		})


### PR DESCRIPTION
cloud-credential's related objects have wrong `resource` casing. Thats causing inability to create links in the console:
<img width="1181" alt="Screenshot 2020-08-12 at 17 07 26" src="https://user-images.githubusercontent.com/1668218/90032104-4d7a9e80-dcbe-11ea-9c51-34910593f080.png">

/assign dgoodwin csrwng