### PR TITLE
Bug 1873345: specify a serviceaccount in the deployment

### DIFF
--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -238,6 +238,8 @@ spec:
       nodeSelector:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
+      serviceAccount: default
+      serviceAccountName: default
       terminationGracePeriodSeconds: 10
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
allow downgrading from 4.6 (where we do specify a serviceaccount)