### PR TITLE
Bug 1871713: Mark Manual Clusters  Upgradeable=False If 4.6 Cred Request Secrets Are Not Provisioned

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1237,10 +1237,9 @@ func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv
 			upgradeableCondition.Status = configv1.ConditionFalse
 			upgradeableCondition.Reason = constants.MissingSecretsForUpgradeReason
 			upgradeableCondition.Message = fmt.Sprintf(
-				"Cannot upgrade manual mode cluster to %s due to missing secret(s): %v Please see documentation at: %s",
+				"Cannot upgrade manual mode cluster to %s due to missing secret(s): %v Please see the Manually Creating IAM for AWS OpenShift documentation.",
 				toRelease,
-				missingSecrets,
-				"https://docs.openshift.com/container-platform/4.5/installing/installing_aws/manually-creating-iam.html")
+				missingSecrets)
 		}
 	} else {
 		// If in mint or passthrough, make sure the root cred secret exists, if not it must be restored prior to upgrade.

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1198,3 +1198,84 @@ func isAWSCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 	}
 	return isAWS, nil
 }
+
+func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	toRelease := "4.6"
+	if mode == operatorv1.CloudCredentialsModeManual {
+		// Check for the existence of credentials we know are coming in 4.6. If any do not exist, then we consider
+		// ourselves upgradable=false and inform the user why.
+		missingSecrets := []types.NamespacedName{}
+		for _, nsSecret := range a.GetUpcomingCredSecrets() {
+
+			secLog := log.WithField("secret", nsSecret).WithField("toRelease", toRelease)
+			secLog.Debug("checking that secrets exist for manual mode cluster upgrade")
+			secret := &corev1.Secret{}
+
+			err := a.Client.Get(context.Background(), nsSecret, secret)
+			if err != nil {
+				if errors.IsNotFound(err) {
+					secLog.Info("identified missing secret for upgrade")
+					missingSecrets = append(missingSecrets, nsSecret)
+				} else {
+					// If we can't figure out if you're upgradeable, you're not upgradeable:
+					secLog.WithError(err).Error("unexpected error looking up secret, marking upgradeable=false")
+					upgradeableCondition.Status = configv1.ConditionFalse
+					upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
+					upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
+						toRelease, err)
+					return upgradeableCondition
+				}
+			}
+		}
+
+		if len(missingSecrets) > 0 {
+			log.Infof("%d secrets missing, marking upgradeable=false", len(missingSecrets))
+			upgradeableCondition.Status = configv1.ConditionFalse
+			upgradeableCondition.Reason = constants.MissingSecretsForUpgradeReason
+			upgradeableCondition.Message = fmt.Sprintf(
+				"Cannot upgrade manual mode cluster to %s due to missing secret(s): %v Please see documentation at: %s",
+				toRelease,
+				missingSecrets,
+				"https://docs.openshift.com/container-platform/4.5/installing/installing_aws/manually-creating-iam.html")
+		}
+	} else {
+		// If in mint or passthrough, make sure the root cred secret exists, if not it must be restored prior to upgrade.
+		rootCred := types.NamespacedName{Namespace: rootAWSCredsSecretNamespace, Name: rootAWSCredsSecret}
+		secret := &corev1.Secret{}
+
+		err := a.Client.Get(context.Background(), rootCred, secret)
+		if err != nil {
+
+			if errors.IsNotFound(err) {
+				log.WithField("secret", rootCred).Info("parent cred secret must be restored prior to upgrade, marking upgradeable=false")
+				upgradeableCondition.Status = configv1.ConditionFalse
+				upgradeableCondition.Reason = constants.MissingRootCredentialUpgradeableReason
+				upgradeableCondition.Message = fmt.Sprintf("Parent credential secret must be restored prior to upgrade: %s/%s",
+					rootCred.Namespace, rootCred.Name)
+				return upgradeableCondition
+			}
+
+			log.WithError(err).Error("unexpected error looking up parent secret, marking upgradeable=false")
+			// If we can't figure out if you're upgradeable, you're not upgradeable:
+			upgradeableCondition.Status = configv1.ConditionFalse
+			upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
+			upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
+				toRelease, err)
+			return upgradeableCondition
+		}
+	}
+
+	return upgradeableCondition
+}
+
+func (a *AWSActuator) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{
+		// New in 4.6:
+		{Namespace: "openshift-cloud-credential-operator", Name: "cloud-credential-operator-s3"},
+		{Namespace: "openshift-cluster-csi-drivers", Name: "ebs-cloud-credentials"},
+	}
+}

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -23,6 +23,7 @@ import (
 	"reflect"
 	"time"
 
+	operatorv1 "github.com/openshift/api/operator/v1"
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	corev1 "k8s.io/api/core/v1"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
@@ -645,4 +646,16 @@ func (a *Actuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldLogger {
 		"actuator": "azure",
 		"cr":       fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 	})
+}
+
+func (a *Actuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	return upgradeableCondition
+}
+
+func (a *Actuator) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{}
 }

--- a/pkg/azure/passthrough.go
+++ b/pkg/azure/passthrough.go
@@ -21,12 +21,18 @@ import (
 	"fmt"
 	"reflect"
 
+	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 var _ actuator.Actuator = (*passthrough)(nil)
@@ -90,4 +96,16 @@ func copySecret(cr *minterv1.CredentialsRequest, src *secret, dest *secret) {
 		AzureSubscriptionID: src.Data[AzureSubscriptionID],
 		AzureTenantID:       src.Data[AzureTenantID],
 	}
+}
+
+func (a *passthrough) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	return upgradeableCondition
+}
+
+func (a *passthrough) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{}
 }

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"reflect"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -763,4 +765,16 @@ func checkServicesEnabled(gcpClient ccgcp.Client, permList []string, logger log.
 	}
 
 	return serviceAPIsEnabled, nil
+}
+
+func (a *Actuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	return upgradeableCondition
+}
+
+func (a *Actuator) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{}
 }

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
 
 	corev1 "k8s.io/api/core/v1"
@@ -265,4 +267,16 @@ func (a *OpenStackActuator) getLogger(cr *minterv1.CredentialsRequest) log.Field
 		"actuator": "openstack",
 		"cr":       fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 	})
+}
+
+func (a *OpenStackActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	return upgradeableCondition
+}
+
+func (a *OpenStackActuator) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{}
 }

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -43,6 +43,18 @@ const (
 	// the operator config CR specifies an invalide mode
 	StatusModeInvalid = "ModeInvalid"
 
+	// MissingSecretsForUpgradeReason is used when a manual mode cluster is not upgradable due to missing
+	// secrets the operator knows will be required for the next minor release of OpenShift.
+	MissingSecretsForUpgradeReason = "ManualModeMissingSecrets"
+
+	// ErrorDeterminingUpgradeableReason is used when we encounter unexpected errors checking if a cluster can
+	// be updated.
+	ErrorDeterminingUpgradeableReason = "ErrorDeterminingUpgradeable"
+
+	// MissingRootCredentialUpgradeableReason is used when a cluster is in mint mode with the root credential removed.
+	// In this state the root credential must be restored before we can upgrade to the next minor release of OpenShift.
+	MissingRootCredentialUpgradeableReason = "MissingRootCredential"
+
 	// secret annoation vars
 
 	// AnnotationKey is the annotation the cloud credentials secret will be annotated with to indicate

--- a/pkg/operator/credentialsrequest/status_test.go
+++ b/pkg/operator/credentialsrequest/status_test.go
@@ -40,6 +40,7 @@ import (
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
 	schemeutils "github.com/openshift/cloud-credential-operator/pkg/util"
 )
 
@@ -261,7 +262,9 @@ func TestClusterOperatorStatus(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			defer mockCtrl.Finish()
 
-			clusterOperatorConditions := computeStatusConditions(testUnknownConditions(), test.credRequests,
+			schemeutils.SetupScheme(scheme.Scheme)
+			dummyActuator := &actuator.DummyActuator{}
+			clusterOperatorConditions := computeStatusConditions(dummyActuator, testUnknownConditions(), test.credRequests,
 				test.cloudPlatform, test.operatorMode, test.configConflict, log.WithField("test", test.name))
 			for _, ec := range test.expectedConditions {
 				c := findClusterOperatorCondition(clusterOperatorConditions, ec.Type)
@@ -317,7 +320,8 @@ func TestClusterOperatorVersion(t *testing.T) {
 			fakeClient := fake.NewFakeClient(existing...)
 
 			rcr := &ReconcileCredentialsRequest{
-				Client: fakeClient,
+				Client:   fakeClient,
+				Actuator: &actuator.DummyActuator{},
 			}
 
 			require.NoError(t, os.Setenv("RELEASE_VERSION", test.releaseVersionEnv), "unable to set environment variable for testing")

--- a/pkg/operator/secretannotator/aws/reconciler.go
+++ b/pkg/operator/secretannotator/aws/reconciler.go
@@ -10,6 +10,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
@@ -132,7 +133,11 @@ func (r *ReconcileCloudCredSecret) Reconcile(request reconcile.Request) (returnR
 	secret := &corev1.Secret{}
 	err = r.Get(context.Background(), request.NamespacedName, secret)
 	if err != nil {
-		r.Logger.WithError(err).Error("failed to fetch secret")
+		if errors.IsNotFound(err) {
+			r.Logger.Info("parent credential secret does not exist")
+			return reconcile.Result{}, nil
+		}
+		r.Logger.WithError(err).Error("failed to fetch parent credential secret")
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -21,6 +21,8 @@ import (
 	"reflect"
 	"strconv"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -340,4 +342,16 @@ func secretDataFrom(ovirtCreds *OvirtCreds) map[string][]byte {
 		insecureKey: []byte(strconv.FormatBool(ovirtCreds.Insecure)),
 		cabundleKey: []byte(ovirtCreds.CABundle),
 	}
+}
+
+func (a *OvirtActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	return upgradeableCondition
+}
+
+func (a *OvirtActuator) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{}
 }

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"reflect"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
@@ -383,4 +385,16 @@ func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 			Info("actuator handles only vsphere credentials")
 	}
 	return isVSphere, nil
+}
+
+func (a *VSphereActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Status: configv1.ConditionTrue,
+		Type:   configv1.OperatorUpgradeable,
+	}
+	return upgradeableCondition
+}
+
+func (a *VSphereActuator) GetUpcomingCredSecrets() []types.NamespacedName {
+	return []types.NamespacedName{}
 }


### PR DESCRIPTION
There are two new credentials coming in 4.6, but if a manual mode user attempts to upgrade without them, the upgrade will fail.

This change encodes the secret names we know are coming, we ensure they exist and if not you are upgradeable=false. This condition does not affect 4.5.x upgrades, only 4.5 to 4.6.

Additionally to improve user experience, we are doing a hacky reconcile to get the status update that would clear upgradeable false when these secrets are created. This involves reconciling a fake cred request NamespacedName which we watch for and return early. In 4.7 we hope to break status updating out into it's own controller for a number of reasons, at which point this hack can be removed.