### PR TITLE
Bug 1882505: Fix stalled leader election after Deployment updates.

### DIFF
--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -13,6 +13,8 @@ spec:
     matchLabels:
       control-plane: controller-manager
       controller-tools.k8s.io: "1.0"
+  strategy:
+    type: Recreate
   template:
     metadata:
       labels:


### PR DESCRIPTION
The revamped leader election in 4.6 is not working correctly if the
Deployment is modified. Under the default Deployment strategy of rolling
update, a new pod is brought up before the old is terminated. The new
pod leader election has already determined someone else is leader before
the old releases it's lock, and will wait the full renew interval of 270
seconds before checking again.

To fix we switch to the recreate strategy which will delete the old pod
first, then create the new. This seems the desired strategy for leader
election based operators.