### PR TITLE
Bug 1880785: Fix CredentialsRequest missing description in 'oc explain'

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ $(eval $(call build-image-internal,$(1),$(2),$(3),$(4)))
 endef
 
 # Set crd-schema-gen variables
-CONTROLLER_GEN_VERSION := v0.2.1
+CONTROLLER_GEN_VERSION := v0.2.5
 CRD_APIS :=./pkg/apis/cloudcredential/v1
 
 # Exclude e2e tests from unit testing

--- a/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
+++ b/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
@@ -42,6 +42,7 @@ spec:
               description: ProviderSpec contains the cloud provider specific credentials
                 specification.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             secretRef:
               description: SecretRef points to the secret where the credentials should
                 be stored once generated.
@@ -140,6 +141,7 @@ spec:
             providerStatus:
               description: ProviderStatus contains cloud provider specific status.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             provisioned:
               description: Provisioned is true once the credentials have been initially
                 provisioned.

--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -10,6 +10,7 @@ spec:
     plural: credentialsrequests
     singular: credentialsrequest
   scope: Namespaced
+  preserveUnknownFields: false
   subresources:
     status: {}
   version: v1
@@ -42,6 +43,7 @@ spec:
               description: ProviderSpec contains the cloud provider specific credentials
                 specification.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             secretRef:
               description: SecretRef points to the secret where the credentials should
                 be stored once generated.
@@ -140,6 +142,7 @@ spec:
             providerStatus:
               description: ProviderStatus contains cloud provider specific status.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             provisioned:
               description: Provisioned is true once the credentials have been initially
                 provisioned.

--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -51,6 +51,7 @@ type CredentialsRequestSpec struct {
 	SecretRef corev1.ObjectReference `json:"secretRef"`
 
 	// ProviderSpec contains the cloud provider specific credentials specification.
+	// +kubebuilder:pruning:PreserveUnknownFields
 	ProviderSpec *runtime.RawExtension `json:"providerSpec,omitempty"`
 }
 
@@ -79,6 +80,7 @@ type CredentialsRequestStatus struct {
 	LastSyncCloudCredsSecretResourceVersion string `json:"lastSyncCloudCredsSecretResourceVersion,omitempty"`
 
 	// ProviderStatus contains cloud provider specific status.
+	// +kubebuilder:pruning:PreserveUnknownFields
 	ProviderStatus *runtime.RawExtension `json:"providerStatus,omitempty"`
 
 	// Conditions includes detailed status for the CredentialsRequest

--- a/pkg/assets/bootstrap/bindata.go
+++ b/pkg/assets/bootstrap/bindata.go
@@ -100,6 +100,7 @@ spec:
               description: ProviderSpec contains the cloud provider specific credentials
                 specification.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             secretRef:
               description: SecretRef points to the secret where the credentials should
                 be stored once generated.
@@ -198,6 +199,7 @@ spec:
             providerStatus:
               description: ProviderStatus contains cloud provider specific status.
               type: object
+              x-kubernetes-preserve-unknown-fields: true
             provisioned:
               description: Provisioned is true once the credentials have been initially
                 provisioned.


### PR DESCRIPTION
In order to make 'oc explain' work we need to enable field pruning
by setting `preserveUnknownFields` to false