### PR TITLE
Stop reporting mode metrics for unused modes.

### DIFF
--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -250,7 +250,12 @@ func setCredentialsMode(ccoDisabled bool, secret *corev1.Secret, notFound bool, 
 	crMode[detectedMode] = 1
 
 	for k, v := range crMode {
-		metricCredentialsMode.WithLabelValues(string(k)).Set(float64(v))
+		if v > 0 {
+			metricCredentialsMode.WithLabelValues(string(k)).Set(float64(v))
+		} else {
+			// Ensure unused modes are cleared if we've recently changed mode:
+			metricCredentialsMode.Delete(map[string]string{"mode": string(k)})
+		}
 	}
 }
 


### PR DESCRIPTION
We now will report 1 for any modes in use, and anything not in use will
be explicitly cleared in case we transitioned modes since the pod was
started.

This is to make the metric easier to consume across the entire fleet.


/assign @joelddiaz 
/cc @akhil-rane 
