### PR TITLE
enable GCP read only creds to be used when root creds missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Cons:
   * Still requires admin credential in the cluster for brief periods of time.
   * Requires manually re-instating the Secret with admin credentials for each upgrade.
 
-Supported clouds: AWS
+Supported clouds: AWS, GCP
 
 ## 2. Passthrough Mode
 
@@ -200,7 +200,7 @@ Cloud | Mint | Mint + Remove Admin Cred | Passthrough | Manual | Token
 --- | --- | --- | --- | --- | ---
 AWS | Y | 4.4+ | Y | 4.3+ | 4.6+ (expected)
 Azure | Y | N | Y | unknown | N
-GCP | Y | N | Y | unknown | N
+GCP | Y | 4.7+ | Y | unknown | N
 OpenStack | N | N | Y | N | N
 oVirt | N | N | Y | N | N
 VMWare | N | N | Y | N | N

--- a/manifests/05-gcp-ro-credentialsrequest.yaml
+++ b/manifests/05-gcp-ro-credentialsrequest.yaml
@@ -1,0 +1,18 @@
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cloud-credential-operator-gcp-ro-creds
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/iam.securityReviewer
+    - roles/iam.roleViewer
+    skipServiceCheck: true
+  secretRef:
+    name: cloud-credential-operator-gcp-ro-creds
+    namespace: openshift-cloud-credential-operator

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -758,7 +758,7 @@ func (a *AWSActuator) buildRootAWSClient(cr *minterv1.CredentialsRequest) (minte
 	return a.AWSClientBuilder(accessKeyID, secretAccessKey, a.Client)
 }
 
-// buildReadAWSCreds will return an AWS client using the the scaled down read only AWS creds
+// buildReadAWSClient will return an AWS client using the the scaled down read only AWS creds
 // for cred minter, which are expected to live in openshift-cloud-credential-operator/cloud-credential-operator-iam-ro-creds.
 // These creds would normally be created by cred minter itself, via a CredentialsRequest created
 // by the cred minter operator.
@@ -780,6 +780,8 @@ func (a *AWSActuator) buildReadAWSClient(cr *minterv1.CredentialsRequest) (minte
 			logger.Warn("read-only creds not found, using root creds client")
 			return a.buildRootAWSClient(cr)
 		}
+		logger.WithError(err).Error("unexpected error while trying to load in read-only creds Secret")
+		return nil, err
 	}
 
 	logger.Debug("creating read AWS client")
@@ -1204,7 +1206,7 @@ func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv
 	}
 	toRelease := "4.7"
 	if mode == operatorv1.CloudCredentialsModeManual {
-		// Check for the existence of credentials we know are coming in 4.6. If any do not exist, then we consider
+		// Check for the existence of credentials we know are coming in the future. If any do not exist, then we consider
 		// ourselves upgradable=false and inform the user why.
 		missingSecrets := []types.NamespacedName{}
 		for _, nsSecret := range a.GetUpcomingCredSecrets() {


### PR DESCRIPTION
- [x] add new GCP read-only CredentialsRequest manifests
- [x] implement the ability to use the CCO's read-only GCP creds for verifying that creds need no updates
- [x] actually skip the service API checks when the CredReq says to skip the checking
- [x] add test case to cover the root creds missing but the read-only creds are available
- [x] update readme to mark GCP as supported for removing the root creds
- [x] (unrelated to GCP) return unexpected error in AWS actuator