### PR TITLE
Bug 1889540: manifests: Allow 'for: 20m' for CloudCredentialOperatorDown

### DIFF
--- a/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
+++ b/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
@@ -45,6 +45,6 @@ spec:
       annotations:
         message: cloud-credential-operator pod not running
       expr: absent(up{job="cco-metrics"} == 1)
-      for: 5m
+      for: 20m
       labels:
         severity: critical


### PR DESCRIPTION
The alert was born with a 5m `for` as CCOperatorDown in 63af2de417 (#132).  But folks are unlikely to be churning their creds so quickly that the occasional longer operator outage is worth waking an admin with a midnight alarm.  This is true in general, although folks have been revisiting this alert in the context of 4.5->4.6 updates, where a [shift in leader leasing][1] has lead to a risk of an 8 minute delay as a 4.6 operator waits patiently before picking up a lease abandoned by a 4.5 operator.  The new 20m threshold allows for two such delays with room to spare, and also ensures we aren't waking folks up if theres a brief network or registry outage while pods are being rescheduled or anything minor like that.  Some things are worth more agressive thresholds, but I don't think the cred operator is one of them.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1889540#c4