### PR TITLE
add new credentials field for AWS Secrets

### DIFF
--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -17,12 +17,14 @@ limitations under the License.
 package actuator
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	configv1 "github.com/openshift/api/config/v1"
 	v1 "github.com/openshift/api/operator/v1"
@@ -49,6 +51,9 @@ const (
 
 	testRootAccessKeyID     = "TestRootAccessKeyID"
 	testRootSecretAccessKey = "TestRootSecretAccessKey"
+
+	testTargetSecret    = "testTargetSecretName"
+	testTargetNamespace = "testTargetNamespace"
 )
 
 type awsClientBuilderRecorder struct {
@@ -372,6 +377,92 @@ func TestUpgradeable(t *testing.T) {
 		})
 	}
 }
+
+func TestSecretFormat(t *testing.T) {
+	apis.AddToScheme(scheme.Scheme)
+
+	tests := []struct {
+		name            string
+		accessKeyID     string
+		secretAccessKey string
+		existingSecret  *corev1.Secret
+	}{
+		{
+			name:            "new secret with credentials field",
+			accessKeyID:     "AKFIRSTKEY",
+			secretAccessKey: "FIRSTSECRET",
+		},
+		{
+			name:            "existing secret without credentials field",
+			accessKeyID:     "AKFIRSTKEY",
+			secretAccessKey: "FIRSTSECRET",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testTargetSecret,
+					Namespace: testTargetNamespace,
+				},
+				Data: map[string][]byte{
+					"aws_access_key_id":     []byte("SOMEACCESSKEY"),
+					"aws_secret_access_key": []byte("SOMESECRETKEY"),
+				},
+			},
+		},
+		{
+			name:            "existing secret with outdated credentials field",
+			accessKeyID:     "AKFIRSTKEY",
+			secretAccessKey: "FIRSTSECRET",
+			existingSecret: &corev1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      testTargetSecret,
+					Namespace: testTargetNamespace,
+				},
+				Data: map[string][]byte{
+					"aws_access_key_id":     []byte("SOMEACCESSKEY"),
+					"aws_secret_access_key": []byte("SOMESECRETKEY"),
+					"credentials":           []byte("OLD AWS CONFIG"),
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var fakeClient client.Client
+			if test.existingSecret != nil {
+				fakeClient = fake.NewFakeClient(test.existingSecret)
+			} else {
+				fakeClient = fake.NewFakeClient()
+			}
+
+			a := &AWSActuator{
+				Client: fakeClient,
+			}
+
+			cr := testCredentialsRequest()
+			logger := a.getLogger(cr)
+			err := a.syncAccessKeySecret(cr, test.accessKeyID, test.secretAccessKey, test.existingSecret, "exampleAWSPolicy", logger)
+
+			require.NoError(t, err, "unexpected error creating/updating Secret")
+
+			secret := &corev1.Secret{}
+			secretNSN := types.NamespacedName{Name: cr.Spec.SecretRef.Name, Namespace: cr.Spec.SecretRef.Namespace}
+
+			err = fakeClient.Get(context.TODO(), secretNSN, secret)
+			require.NoError(t, err, "unexpected error retriving Secret")
+
+			assert.Contains(t, secret.Data, "aws_access_key_id")
+			assert.Equal(t, string(secret.Data["aws_access_key_id"]), test.accessKeyID)
+			assert.Contains(t, secret.Data, "aws_secret_access_key")
+			assert.Equal(t, string(secret.Data["aws_secret_access_key"]), test.secretAccessKey)
+
+			require.Contains(t, secret.Data, "credentials")
+			credentialsConfig := string(secret.Data["credentials"])
+			assert.Contains(t, credentialsConfig, fmt.Sprintf("aws_access_key_id = %s", test.accessKeyID))
+			assert.Contains(t, credentialsConfig, fmt.Sprintf("aws_secret_access_key = %s", test.secretAccessKey))
+		})
+	}
+}
+
 func testReadOnlySecret() *corev1.Secret {
 	return &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -416,6 +507,12 @@ func testCredentialsRequest() *minterv1.CredentialsRequest {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "testcr",
 			Namespace: "testnamespace",
+		},
+		Spec: minterv1.CredentialsRequestSpec{
+			SecretRef: corev1.ObjectReference{
+				Name:      testTargetSecret,
+				Namespace: testTargetNamespace,
+			},
 		},
 	}
 }

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -71,6 +71,13 @@ const (
 	credentialsRequestInfraMismatch = "InfrastructureMismatch"
 )
 
+var (
+	syncPeriod = time.Hour
+	// Set some extra time when requeueing so we are guaranteed that the
+	// syncPeriod has elapsed when we re-reconcile an object.
+	defaultRequeueTime = syncPeriod + time.Minute*10
+)
+
 // AddWithActuator creates a new CredentialsRequest Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
@@ -537,12 +544,15 @@ func (r *ReconcileCredentialsRequest) Reconcile(request reconcile.Request) (reco
 	}
 	cloudCredsSecretUpdated := credentialsRootSecret != nil && credentialsRootSecret.ResourceVersion != cr.Status.LastSyncCloudCredsSecretResourceVersion
 	isStale := cr.Generation != cr.Status.LastSyncGeneration
-	hasRecentlySynced := cr.Status.LastSyncTimestamp != nil && cr.Status.LastSyncTimestamp.Add(time.Hour*1).After(time.Now())
+	hasRecentlySynced := cr.Status.LastSyncTimestamp != nil && cr.Status.LastSyncTimestamp.Add(syncPeriod).After(time.Now())
 	hasActiveFailureConditions := checkForFailureConditions(cr)
 
 	if !cloudCredsSecretUpdated && !isStale && hasRecentlySynced && crSecretExists && !hasActiveFailureConditions && cr.Status.Provisioned {
 		logger.Debug("lastsyncgeneration is current and lastsynctimestamp was less than an hour ago, so no need to sync")
-		return reconcile.Result{}, nil
+		// Since we get no events for changes made directly to the cloud/platform, set the requeueAfter so that we at
+		// least periodically check that nothing out in the cloud/platform was modified that would require us to fix up
+		// users/permissions/tags/etc.
+		return reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
 	}
 
 	credsExists, err := r.Actuator.Exists(context.TODO(), cr)
@@ -592,7 +602,10 @@ func (r *ReconcileCredentialsRequest) Reconcile(request reconcile.Request) (reco
 		return reconcile.Result{}, err
 	}
 
-	return reconcile.Result{}, syncErr
+	// Since we get no events for changes made directly to the cloud/platform, set the requeueAfter so that we at
+	// least periodically check that nothing out in the cloud/platform was modified that would require us to fix up
+	// users/permissions/tags/etc.
+	return reconcile.Result{RequeueAfter: defaultRequeueTime}, syncErr
 }
 
 func (r *ReconcileCredentialsRequest) updateActuatorConditions(cr *minterv1.CredentialsRequest, reason minterv1.CredentialsRequestConditionType, conditionError error) {


### PR DESCRIPTION
Start storing a usable AWS credentials config file in the 'credentials' field of the Secret. This should allow a consumer of the credentials to just point to the config stored in that field when setting up an AWS client.

Also make sure we are re-queuing CredentialsRequest objects every 1hr10min (so that we are at least periodically doing a full reconcile to restore any lost credentials).