### PR TITLE
Bug 1898199: manifests: Allow 'for: 20m' for CloudCredentialOperatorDown

### DIFF
--- a/manifests/05_deployment.yaml
+++ b/manifests/05_deployment.yaml
@@ -309,7 +309,7 @@ spec:
       annotations:
         message: cloud-credential-operator pod not running
       expr: absent(up{job="cco-metrics"} == 1)
-      for: 5m
+      for: 20m
       labels:
         severity: critical
 ---


### PR DESCRIPTION
Picking #267 back to 4.5.