### PR TITLE
Bug 1903226: exclude run-level 0 namespaces from MutatingWebhook for Pods

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml
@@ -13,6 +13,12 @@ webhooks:
       name: pod-identity-webhook
       namespace: openshift-cloud-credential-operator
       path: "/mutate"
+  namespaceSelector:
+    matchExpressions:
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -207,6 +207,12 @@ webhooks:
       name: pod-identity-webhook
       namespace: openshift-cloud-credential-operator
       path: "/mutate"
+  namespaceSelector:
+    matchExpressions:
+    - key: openshift.io/run-level
+      operator: NotIn
+      values:
+      - "0"
   rules:
   - operations: [ "CREATE" ]
     apiGroups: [""]


### PR DESCRIPTION
The pod-identity webhook should ignore the run-level 0 namespaces b/c there is a race where if the webhook is running before the non-bootstrap API server is running, the install will error out.