### PR TITLE
Bug 1916454: checking 4.7 creds

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1240,76 +1240,7 @@ func isAWSCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
-		Type: configv1.OperatorUpgradeable,
-	}
-	toRelease := "4.7"
-	if mode == operatorv1.CloudCredentialsModeManual {
-		// Check for the existence of credentials we know are coming in the future. If any do not exist, then we consider
-		// ourselves upgradable=false and inform the user why.
-		missingSecrets := []types.NamespacedName{}
-		for _, nsSecret := range a.getUpcomingCredSecrets() {
-
-			secLog := log.WithField("secret", nsSecret).WithField("toRelease", toRelease)
-			secLog.Debug("checking that secrets exist for manual mode cluster upgrade")
-			secret := &corev1.Secret{}
-
-			err := a.Client.Get(context.Background(), nsSecret, secret)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					secLog.Info("identified missing secret for upgrade")
-					missingSecrets = append(missingSecrets, nsSecret)
-				} else {
-					// If we can't figure out if you're upgradeable, you're not upgradeable:
-					secLog.WithError(err).Error("unexpected error looking up secret, marking upgradeable=false")
-					upgradeableCondition.Status = configv1.ConditionFalse
-					upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
-					upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
-						toRelease, err)
-					return upgradeableCondition
-				}
-			}
-		}
-
-		if len(missingSecrets) > 0 {
-			log.Infof("%d secrets missing, marking upgradeable=false", len(missingSecrets))
-			upgradeableCondition.Status = configv1.ConditionFalse
-			upgradeableCondition.Reason = constants.MissingSecretsForUpgradeReason
-			upgradeableCondition.Message = fmt.Sprintf(
-				"Cannot upgrade manual mode cluster to %s due to missing secret(s): %v Please see the Manually Creating IAM for AWS OpenShift documentation.",
-				toRelease,
-				missingSecrets)
-			return upgradeableCondition
-		}
-	} else {
-		// If in mint or passthrough, make sure the root cred secret exists, if not it must be restored prior to upgrade.
-		rootCred := a.GetCredentialsRootSecretLocation()
-		secret := &corev1.Secret{}
-
-		err := a.Client.Get(context.Background(), rootCred, secret)
-		if err != nil {
-
-			if errors.IsNotFound(err) {
-				log.WithField("secret", rootCred).Info("parent cred secret must be restored prior to upgrade, marking upgradeable=false")
-				upgradeableCondition.Status = configv1.ConditionFalse
-				upgradeableCondition.Reason = constants.MissingRootCredentialUpgradeableReason
-				upgradeableCondition.Message = fmt.Sprintf("Parent credential secret must be restored prior to upgrade: %s/%s",
-					rootCred.Namespace, rootCred.Name)
-				return upgradeableCondition
-			}
-
-			log.WithError(err).Error("unexpected error looking up parent secret, marking upgradeable=false")
-			// If we can't figure out if you're upgradeable, you're not upgradeable:
-			upgradeableCondition.Status = configv1.ConditionFalse
-			upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
-			upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
-				toRelease, err)
-			return upgradeableCondition
-		}
-	}
-
-	// Only return non-default conditions as the status controller will set defaults.
-	return nil
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.getUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
 }
 
 func (a *AWSActuator) getUpcomingCredSecrets() []types.NamespacedName {

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -20,10 +20,6 @@ import (
 	"fmt"
 	"reflect"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	log "github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,9 +27,14 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	log "github.com/sirupsen/logrus"
+
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
 const (
@@ -287,5 +288,9 @@ func (a *OpenStackActuator) getLogger(cr *minterv1.CredentialsRequest) log.Field
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *OpenStackActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return nil
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.getUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
+}
+
+func (a *OpenStackActuator) getUpcomingCredSecrets() []types.NamespacedName {
+	return constants.OpenStackUpcomingSecrets
 }

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -153,5 +153,10 @@ var (
 	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift
 	OvirtUpcomingSecrets = []types.NamespacedName{}
 	// VsphereUpcomingSecrets contains the list of known new vSphere credential secrets for the next version of OpenShift
-	VsphereUpcomingSecrets = []types.NamespacedName{}
+	VsphereUpcomingSecrets = []types.NamespacedName{
+		{
+			Namespace: "openshift-cluster-storage-operator",
+			Name:      "openshift-vsphere-problem-detector",
+		},
+	}
 )

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -138,7 +138,16 @@ var (
 	// AzureUpcomingSecrets contains the list of known new Azure credential secrets for the next version of OpenShift
 	AzureUpcomingSecrets = []types.NamespacedName{}
 	// GCPUpcomingSecrets contains the list of known new GCP credential secrets for the next version of OpenShift
-	GCPUpcomingSecrets = []types.NamespacedName{}
+	GCPUpcomingSecrets = []types.NamespacedName{
+		{
+			Namespace: "openshift-cluster-csi-drivers",
+			Name:      "gcp-pd-cloud-credentials",
+		},
+		{
+			Namespace: "openshift-cloud-credential-operator",
+			Name:      "cloud-credential-operator-gcp-ro-creds",
+		},
+	}
 	// OpenStackUpcomingSecrets contains the list of known new OpenStack credential secrets for the next version of OpenShift
 	OpenStackUpcomingSecrets = []types.NamespacedName{}
 	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -149,7 +149,12 @@ var (
 		},
 	}
 	// OpenStackUpcomingSecrets contains the list of known new OpenStack credential secrets for the next version of OpenShift
-	OpenStackUpcomingSecrets = []types.NamespacedName{}
+	OpenStackUpcomingSecrets = []types.NamespacedName{
+		{
+			Namespace: "openshift-cluster-csi-drivers",
+			Name:      "openstack-cloud-credentials",
+		},
+	}
 	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift
 	OvirtUpcomingSecrets = []types.NamespacedName{}
 	// VsphereUpcomingSecrets contains the list of known new vSphere credential secrets for the next version of OpenShift

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -287,3 +287,81 @@ func IsValidMode(operatorMode operatorv1.CloudCredentialsMode) bool {
 		return false
 	}
 }
+
+// UpgradeableCheck will take a list of expected secrets and the platform-specific root secret and
+// check the cluster to determine whether it is ready to perform an upgrade.
+// Note: the upgradeable flag can only stop upgrades from 4.x to 4.y, not 4.x.y to 4.x.z.
+func UpgradeableCheck(kubeClient client.Client,
+	mode operatorv1.CloudCredentialsMode,
+	toRelease string,
+	newSecrets []types.NamespacedName,
+	rootSecret types.NamespacedName) *configv1.ClusterOperatorStatusCondition {
+	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
+		Type: configv1.OperatorUpgradeable,
+	}
+
+	if mode == operatorv1.CloudCredentialsModeManual {
+		// Check for the existence of credentials we know are coming in the future. If any do not exist, then we cosider
+		// ourselves upgradeable=false and inform the user why.
+		missingSecrets := []types.NamespacedName{}
+		for _, nsSecret := range newSecrets {
+
+			secLog := log.WithField("secret", nsSecret).WithField("toRelease", toRelease)
+			secLog.Debug("checking that secrets exist for manual mode cluster upgrade")
+			secret := &corev1.Secret{}
+
+			if err := kubeClient.Get(context.Background(), nsSecret, secret); err != nil {
+				if errors.IsNotFound(err) {
+					secLog.Info("identified missing secret for upgrade")
+					missingSecrets = append(missingSecrets, nsSecret)
+				} else {
+					// If we can't figure out if you're upgradeable, you're not upgradeable:
+					secLog.WithError(err).Error("unexpected error looking up secret, marking upgradeable=false")
+					upgradeableCondition.Status = configv1.ConditionFalse
+					upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
+					upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgradead to %s: %s",
+						toRelease, err)
+					return upgradeableCondition
+				}
+			}
+
+		}
+
+		if len(missingSecrets) > 0 {
+			log.Infof("%d secrets missing, marking upgradeable=false", len(missingSecrets))
+			upgradeableCondition.Status = configv1.ConditionFalse
+			upgradeableCondition.Reason = constants.MissingSecretsForUpgradeReason
+			upgradeableCondition.Message = fmt.Sprintf(
+				"Cannot upgrade manual mode cluster to %s due to missing secret(s): %v Please see Manualy Creating IAM documentation for the cluster's platform.",
+				toRelease,
+				missingSecrets)
+			return upgradeableCondition
+		}
+	} else {
+		// if in mint or passthrough, make sure the root cred secret exists, if not it must be restored prior to upgrade.
+		secret := &corev1.Secret{}
+
+		err := kubeClient.Get(context.Background(), rootSecret, secret)
+		if err != nil {
+			if errors.IsNotFound(err) {
+				log.WithField("secret", rootSecret).Info("parent cred secret must be restored prior to upgrade, marking upgradeable=false")
+				upgradeableCondition.Status = configv1.ConditionFalse
+				upgradeableCondition.Reason = constants.MissingRootCredentialUpgradeableReason
+				upgradeableCondition.Message = fmt.Sprintf("Parent credentials secret must be restored prior to upgrade: %s/%s",
+					rootSecret.Namespace, rootSecret.Name)
+				return upgradeableCondition
+			}
+
+			log.WithError(err).Error("unexpected error looking up parent secret, marking upgradeable=false")
+			// If we can't figure out if you're upgradeable, you're not upgradeable:
+			upgradeableCondition.Status = configv1.ConditionFalse
+			upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
+			upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
+				toRelease, err)
+			return upgradeableCondition
+		}
+	}
+
+	// Only return non-default conditions as the status controller will set defaults
+	return nil
+}

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -20,20 +20,23 @@ import (
 	"fmt"
 	"reflect"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
-
-	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
-	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
 var _ actuatoriface.Actuator = (*VSphereActuator)(nil)
@@ -397,5 +400,9 @@ func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *VSphereActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return nil
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.getUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
+}
+
+func (a *VSphereActuator) getUpcomingCredSecrets() []types.NamespacedName {
+	return constants.VsphereUpcomingSecrets
 }


### PR DESCRIPTION
Refactor AWS upgradeable checking so that other platforms can use the logic.

Add new GCP, OpenStack, and vSphere secrets to check/set upgradeable on.