### PR TITLE
Add controller to cleanup stale credentials requests

### DIFF
--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -158,6 +158,8 @@ const (
 	// possible clouds/infrastructure, and cloud-credential-operator will only act on the
 	// CredentialsRequests where the cloud/infra matches.
 	Ignored CredentialsRequestConditionType = "Ignored"
+	// StaleCredentials is true when CredentialsRequest is no longer required and has to be cleaned ip
+	StaleCredentials CredentialsRequestConditionType = "StaleCredentials"
 )
 
 var (

--- a/pkg/operator/cleanup/cleanup_controller.go
+++ b/pkg/operator/cleanup/cleanup_controller.go
@@ -41,7 +41,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 			Client: mgr.GetClient(),
 		},
 	}
-	status.AddHandler(controllerName, &r.ReconcileCredentialsRequest)
+	status.AddHandler(controllerName, r)
 	return r
 }
 

--- a/pkg/operator/cleanup/cleanup_controller.go
+++ b/pkg/operator/cleanup/cleanup_controller.go
@@ -1,0 +1,179 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	log "github.com/sirupsen/logrus"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/metrics"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/status"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+)
+
+const (
+	controllerName       = "cleanup"
+	defaultRequeuePeriod = time.Minute * 5
+)
+
+// newReconciler returns a new reconcile.Reconciler
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	r := &ReconcileStaleCredentialsRequest{
+		ReconcileCredentialsRequest: credentialsrequest.ReconcileCredentialsRequest{
+			Client: mgr.GetClient(),
+		},
+	}
+	status.AddHandler(controllerName, &r.ReconcileCredentialsRequest)
+	return r
+}
+
+// Add creates a new Cleanup Controller and adds it to the Manager.
+func Add(mgr manager.Manager, kubeConfig string) error {
+	r := newReconciler(mgr)
+
+	// Create a new controller
+	c, err := controller.New(controllerName, mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	// trigger a sync only in case of an event for a stale credential request
+	stateCredentialRequestPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return isStaleCredentialsRequest(e.MetaNew.GetNamespace(), e.MetaNew.GetName())
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return isStaleCredentialsRequest(e.Meta.GetNamespace(), e.Meta.GetName())
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return isStaleCredentialsRequest(e.Meta.GetNamespace(), e.Meta.GetName())
+		},
+	}
+
+	// Watch for changes to CredentialsRequest and reconcile only the stale one
+	err = c.Watch(
+		&source.Kind{Type: &minterv1.CredentialsRequest{}},
+		&handler.EnqueueRequestForObject{},
+		stateCredentialRequestPredicate)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func isStaleCredentialsRequest(namespace, credentialRequestName string) bool {
+	cr := types.NamespacedName{Name: credentialRequestName, Namespace: namespace}
+
+	if contains(constants.StaleCredentialsRequests, cr) {
+		log.WithField("cr", credentialRequestName).WithField("namespace", namespace).Info("observed stale credential request event")
+		return true
+	}
+
+	return false
+}
+
+// contains checks if a given credential request is present in a slice of stale credential requests
+func contains(credentialRequests []types.NamespacedName, credentialRequest types.NamespacedName) bool {
+	for _, cr := range credentialRequests {
+		if cr == credentialRequest {
+			return true
+		}
+	}
+	return false
+}
+
+var _ reconcile.Reconciler = &ReconcileStaleCredentialsRequest{}
+
+// ReconcileStaleCredentialsRequest reconciles a stale CredentialsRequest object
+type ReconcileStaleCredentialsRequest struct {
+	ReconcileCredentialsRequest credentialsrequest.ReconcileCredentialsRequest
+}
+
+// Reconcile marks the stale CredentialsRequest object for deletion
+func (r *ReconcileStaleCredentialsRequest) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	start := time.Now()
+
+	logger := log.WithFields(log.Fields{
+		"controller": controllerName,
+		"cr":         fmt.Sprintf("%s/%s", request.NamespacedName.Namespace, request.NamespacedName.Name),
+	})
+
+	defer func() {
+		dur := time.Since(start)
+		metrics.MetricControllerReconcileTime.WithLabelValues(controllerName).Observe(dur.Seconds())
+	}()
+
+	mode, conflict, err := utils.GetOperatorConfiguration(r.ReconcileCredentialsRequest.Client, logger)
+	if err != nil {
+		logger.WithError(err).Error("error checking if operator is disabled")
+		return reconcile.Result{}, err
+	} else if conflict {
+		logger.Error("configuration conflict betwen legacy configmap and operator config")
+		return reconcile.Result{}, fmt.Errorf("configuration conflict")
+	}
+
+	logger.Info("syncing stale credentials request")
+	cr := &minterv1.CredentialsRequest{}
+	err = r.ReconcileCredentialsRequest.Get(context.TODO(), request.NamespacedName, cr)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debug("credentials request no longer exists")
+			return reconcile.Result{}, nil
+		}
+		logger.WithError(err).Error("error getting credentials request, requeuing")
+		return reconcile.Result{}, err
+	}
+	logger = logger.WithFields(log.Fields{
+		"secret": fmt.Sprintf("%s/%s", cr.Spec.SecretRef.Namespace, cr.Spec.SecretRef.Name),
+	})
+
+	origCR := cr
+	cr = cr.DeepCopy()
+
+	if mode == operatorv1.CloudCredentialsModeManual {
+		logger.Warnf("operator set to disabled / manual mode, user needs to delete stale credentials")
+
+		msg := fmt.Sprintf("CredentialsRequest is no longer required. Delete CR, Secret containing credentials, and associated platform/cloud resources")
+		reason := "CredentialsNoLongerRequired"
+		updateCheck := utils.UpdateConditionIfReasonOrMessageChange
+		status := corev1.ConditionTrue
+
+		cr.Status.Conditions = utils.SetCredentialsRequestCondition(cr.Status.Conditions, minterv1.StaleCredentials,
+			status, reason, msg, updateCheck)
+
+		err := r.ReconcileCredentialsRequest.UpdateStatus(origCR, cr, logger)
+		if err != nil {
+			logger.WithError(err).Error("failed to update conditions")
+		}
+
+		return reconcile.Result{}, err
+	}
+
+	// Delete stale credentials request
+	if cr.DeletionTimestamp == nil {
+		err = r.ReconcileCredentialsRequest.Client.Delete(context.TODO(), cr)
+	}
+
+	return reconcile.Result{
+		RequeueAfter: defaultRequeuePeriod,
+	}, err
+}

--- a/pkg/operator/cleanup/cleanup_controller_test.go
+++ b/pkg/operator/cleanup/cleanup_controller_test.go
@@ -1,0 +1,406 @@
+package cleanup
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	log "github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	minteraws "github.com/openshift/cloud-credential-operator/pkg/aws"
+	"github.com/openshift/cloud-credential-operator/pkg/aws/actuator"
+	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+	schemeutils "github.com/openshift/cloud-credential-operator/pkg/util"
+)
+
+const (
+	testStaleCRGeneration      = 1
+	testStaleCRName            = "openshift-component-a"
+	testNamespace              = "openshift-cloud-credential-operator"
+	testStaleSecretName        = "test-secret"
+	testStaleSecretNamespace   = "myproject"
+	testRootAWSAccessKeyID     = "rootaccesskey"
+	testRootAWSSecretAccessKey = "rootsecretkey"
+	testAWSAccessKeyID         = "FAKEAWSACCESSKEYID"
+	testAWSSecretAccessKey     = "KEEPITSECRET"
+	testInfraName              = "testcluster-abc123"
+	testAWSUser                = "mycluster-test-aws-user"
+	testClusterID              = "e415fe1c-f894-11e8-8eb2-f2801f1b9fd1"
+)
+
+type ExpectedCondition struct {
+	conditionType minterv1.CredentialsRequestConditionType
+	reason        string
+	status        corev1.ConditionStatus
+}
+
+type ExpectedCOCondition struct {
+	conditionType configv1.ClusterStatusConditionType
+	reason        string
+	status        corev1.ConditionStatus
+}
+
+func TestStaleCredentialsRequestReconcile(t *testing.T) {
+	schemeutils.SetupScheme(scheme.Scheme)
+
+	// Utility function to get the test credentials request from the fake client
+	getCR := func(c client.Client) *minterv1.CredentialsRequest {
+		cr := &minterv1.CredentialsRequest{}
+		err := c.Get(context.TODO(), client.ObjectKey{Name: testStaleCRName, Namespace: testNamespace}, cr)
+		if err == nil {
+			return cr
+		}
+		return nil
+	}
+
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		t.Fatalf("failed to set up codec for tests: %v", err)
+	}
+
+	tests := []struct {
+		name                 string
+		existing             []runtime.Object
+		expectErr            bool
+		expectDeletion       bool
+		mockRootAWSClient    func(mockCtrl *gomock.Controller) *mockaws.MockClient
+		expectedConditions   []ExpectedCondition
+		expectedCOConditions []ExpectedCOCondition
+	}{
+		{
+			name: "cleanup stale credentials request",
+			existing: []runtime.Object{
+				testOperatorConfig(""),
+				createTestNamespace(testNamespace),
+				createTestNamespace(testStaleSecretNamespace),
+				testStaleCredentialsRequest(t),
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
+				testAWSCredsSecret(testStaleSecretNamespace, testStaleSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
+				testClusterVersion(),
+				testInfrastructure(testInfraName),
+			},
+			expectDeletion: true,
+			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				return mockAWSClient
+			},
+		},
+		{
+			name: "cleanup stale credentials request in a manual mode",
+			existing: []runtime.Object{
+				testOperatorConfig("Manual"),
+				createTestNamespace(testNamespace),
+				createTestNamespace(testStaleSecretNamespace),
+				testStaleCredentialsRequest(t),
+				testAWSCredsSecret(testStaleSecretNamespace, testStaleSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
+				testClusterVersion(),
+				testInfrastructure(testInfraName),
+			},
+			expectDeletion: false,
+			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				return mockAWSClient
+			},
+			expectedConditions: []ExpectedCondition{
+				{
+					conditionType: minterv1.StaleCredentials,
+					reason:        "CredentialsNoLongerRequired",
+					status:        corev1.ConditionTrue,
+				},
+			},
+			expectedCOConditions: []ExpectedCOCondition{
+				{
+					conditionType: configv1.OperatorDegraded,
+					status:        corev1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockRootAWSClient := test.mockRootAWSClient(mockCtrl)
+
+			fakeClient := fake.NewFakeClient(test.existing...)
+			rscr := &ReconcileStaleCredentialsRequest{
+				ReconcileCredentialsRequest: credentialsrequest.ReconcileCredentialsRequest{
+					Client: fakeClient,
+					Actuator: &actuator.AWSActuator{
+						Client: fakeClient,
+						Codec:  codec,
+						Scheme: scheme.Scheme,
+						AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, c client.Client) (minteraws.Client, error) {
+							return mockRootAWSClient, nil
+						},
+					},
+					PlatformType: configv1.AWSPlatformType,
+				},
+			}
+
+			_, err = rscr.Reconcile(reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testStaleCRName,
+					Namespace: testNamespace,
+				},
+			})
+
+			if err != nil && !test.expectErr {
+				require.NoError(t, err, "Unexpected error: %v", err)
+			}
+			if err == nil && test.expectErr {
+				t.Errorf("Expected error but got none")
+			}
+
+			cr := getCR(fakeClient)
+			if test.expectDeletion {
+				assert.Nil(t, cr, "expected credentials request to be deleted")
+			} else {
+				require.NotNil(t, cr, "expected credentials request to exist")
+				for _, condition := range test.expectedConditions {
+					foundCondition := utils.FindCredentialsRequestCondition(cr.Status.Conditions, condition.conditionType)
+					require.NotNil(t, foundCondition, "unexpected unable to find condition")
+					assert.Exactly(t, condition.status, foundCondition.Status)
+					assert.Exactly(t, condition.reason, foundCondition.Reason)
+				}
+			}
+
+			if test.expectedCOConditions != nil {
+				logger := log.WithFields(log.Fields{"controller": controllerName})
+				currentConditions, err := rscr.ReconcileCredentialsRequest.GetConditions(logger)
+				require.NoError(t, err, "failed getting conditions")
+
+				for _, expectedCondition := range test.expectedCOConditions {
+					foundCondition := utils.FindClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
+					require.NotNil(t, foundCondition)
+					assert.Equal(t, string(expectedCondition.status), string(foundCondition.Status), "condition %s had unexpected status", expectedCondition.conditionType)
+					if expectedCondition.reason != "" {
+						assert.Exactly(t, expectedCondition.reason, foundCondition.Reason)
+					}
+				}
+			}
+		})
+	}
+}
+
+func testAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey string) *corev1.Secret {
+	s := testLegacyAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey)
+
+	s.Data["credentials"] = []byte(fmt.Sprintf(`[default]
+aws_access_key_id = %s
+aws_secret_access_key = %s`, accessKeyID, secretAccessKey))
+
+	return s
+}
+
+func testLegacyAWSCredsSecret(namespace, name, accessKeyID, secretAccessKey string) *corev1.Secret {
+	s := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+			Annotations: map[string]string{
+				constants.AnnotationKey: constants.MintAnnotation,
+			},
+		},
+		Data: map[string][]byte{
+			"aws_access_key_id":     []byte(accessKeyID),
+			"aws_secret_access_key": []byte(secretAccessKey),
+		},
+	}
+	return s
+}
+
+func testInfrastructure(infraName string) *configv1.Infrastructure {
+	return &configv1.Infrastructure{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "cluster",
+		},
+		Status: configv1.InfrastructureStatus{
+			Platform:           configv1.AWSPlatformType,
+			InfrastructureName: infraName,
+			PlatformStatus: &configv1.PlatformStatus{
+				AWS: &configv1.AWSPlatformStatus{
+					Region: "test-region-2",
+				},
+			},
+		},
+	}
+}
+
+func testClusterVersion() *configv1.ClusterVersion {
+	return &configv1.ClusterVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "version",
+		},
+		Spec: configv1.ClusterVersionSpec{
+			ClusterID: testClusterID,
+		},
+	}
+}
+
+func testOperatorConfig(mode operatorv1.CloudCredentialsMode) *operatorv1.CloudCredential {
+	conf := &operatorv1.CloudCredential{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: constants.CloudCredOperatorConfig,
+		},
+		Spec: operatorv1.CloudCredentialSpec{
+			CredentialsMode: mode,
+		},
+	}
+
+	return conf
+}
+
+func createTestNamespace(namespace string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: namespace,
+		},
+	}
+}
+
+func testStaleCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
+	cr := testPassthroughCredentialsRequest(t)
+
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		t.Logf("error creating new codec: %v", err)
+		t.FailNow()
+		return nil
+	}
+
+	awsStatus, err := codec.EncodeProviderStatus(
+		&minterv1.AWSProviderStatus{
+			User: testAWSUser,
+		})
+	if err != nil {
+		t.Logf("error encoding: %v", err)
+		t.FailNow()
+		return nil
+	}
+
+	cr.Status.ProviderStatus = awsStatus
+	return cr
+}
+
+func testPassthroughCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
+	codec, err := minterv1.NewCodec()
+	if err != nil {
+		t.Logf("error creating new codec: %v", err)
+		t.FailNow()
+		return nil
+	}
+	awsProvSpec, err := codec.EncodeProviderSpec(
+		&minterv1.AWSProviderSpec{
+			TypeMeta: metav1.TypeMeta{
+				Kind: "AWSProviderSpec",
+			},
+			StatementEntries: []minterv1.StatementEntry{
+				{
+					Effect: "Allow",
+					Action: []string{
+						"iam:GetUser",
+						"iam:GetUserPolicy",
+						"iam:ListAccessKeys",
+					},
+					Resource: "*",
+				},
+			},
+		})
+	if err != nil {
+		t.Logf("error encoding: %v", err)
+		t.FailNow()
+		return nil
+	}
+
+	return &minterv1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        testStaleCRName,
+			Namespace:   testNamespace,
+			Finalizers:  []string{minterv1.FinalizerDeprovision},
+			UID:         types.UID("1234"),
+			Annotations: map[string]string{},
+			Generation:  testStaleCRGeneration,
+		},
+		Spec: minterv1.CredentialsRequestSpec{
+			SecretRef:    corev1.ObjectReference{Name: testStaleSecretName, Namespace: testStaleSecretNamespace},
+			ProviderSpec: awsProvSpec,
+		},
+	}
+}
+
+func TestIsStaleCredentialsRequest(t *testing.T) {
+	tests := []struct {
+		name                               string
+		existingStaleCredentialsRequest    []types.NamespacedName
+		watchedCredentialsRequestName      string
+		watchedCredentialsRequestNamespace string
+		isStaleCredentialsRequest          bool
+	}{
+		{
+			name: "is a stale credentials request",
+			existingStaleCredentialsRequest: []types.NamespacedName{
+				{
+					Name:      "stale-credentials-request-name-1",
+					Namespace: "stale-credentials-request-namespace-1",
+				},
+				{
+					Name:      "stale-credentials-request-name-2",
+					Namespace: "stale-credentials-request-namespace-2",
+				},
+			},
+			watchedCredentialsRequestName:      "stale-credentials-request-name-1",
+			watchedCredentialsRequestNamespace: "stale-credentials-request-namespace-1",
+			isStaleCredentialsRequest:          true,
+		},
+		{
+			name: "is not a stale credentials request",
+			existingStaleCredentialsRequest: []types.NamespacedName{
+				{
+					Name:      "stale-credentials-request-name-1",
+					Namespace: "stale-credentials-request-namespace-1",
+				},
+				{
+					Name:      "stale-credentials-request-name-2",
+					Namespace: "stale-credentials-request-namespace-2",
+				},
+			},
+			watchedCredentialsRequestName:      "dummy-credentials-request-name-1",
+			watchedCredentialsRequestNamespace: "dummy-credentials-request-namespace-1",
+			isStaleCredentialsRequest:          false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			constants.StaleCredentialsRequests = test.existingStaleCredentialsRequest
+
+			assert.Equal(t, test.isStaleCredentialsRequest, isStaleCredentialsRequest(test.watchedCredentialsRequestNamespace, test.watchedCredentialsRequestName))
+		})
+	}
+}

--- a/pkg/operator/cleanup/status.go
+++ b/pkg/operator/cleanup/status.go
@@ -1,0 +1,22 @@
+package cleanup
+
+import (
+	log "github.com/sirupsen/logrus"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/status"
+)
+
+var _ status.Handler = &ReconcileStaleCredentialsRequest{}
+
+func (r *ReconcileStaleCredentialsRequest) GetConditions(logger log.FieldLogger) ([]configv1.ClusterOperatorStatusCondition, error) {
+	return []configv1.ClusterOperatorStatusCondition{}, nil
+}
+
+func (r *ReconcileStaleCredentialsRequest) GetRelatedObjects(logger log.FieldLogger) ([]configv1.ObjectReference, error) {
+	return []configv1.ObjectReference{}, nil
+}
+
+func (r *ReconcileStaleCredentialsRequest) Name() string {
+	return controllerName
+}

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -168,5 +168,10 @@ var (
 	// Add known stale credentials requests here
 
 	// StaleCredentialsRequests contains the list of known stale credentials requests for the next version of OpenShift
-	StaleCredentialsRequests = []types.NamespacedName{}
+	StaleCredentialsRequests = []types.NamespacedName{
+		{
+			Name:      "cloud-credential-operator-s3",
+			Namespace: "openshift-cloud-credential-operator",
+		},
+	}
 )

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -164,4 +164,9 @@ var (
 			Name:      "openshift-vsphere-problem-detector",
 		},
 	}
+
+	// Add known stale credentials requests here
+
+	// StaleCredentialsRequests contains the list of known stale credentials requests for the next version of OpenShift
+	StaleCredentialsRequests = []types.NamespacedName{}
 )

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -23,6 +23,7 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/kubevirt"
 	"github.com/openshift/cloud-credential-operator/pkg/openstack"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/awspodidentity"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/cleanup"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/configmap"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
@@ -52,6 +53,7 @@ func init() {
 	AddToManagerFuncs = append(AddToManagerFuncs, secretannotator.Add)
 	AddToManagerFuncs = append(AddToManagerFuncs, awspodidentity.Add)
 	AddToManagerFuncs = append(AddToManagerFuncs, status.Add)
+	AddToManagerFuncs = append(AddToManagerFuncs, cleanup.Add)
 	AddToManagerWithActuatorFuncs = append(AddToManagerWithActuatorFuncs, credentialsrequest.AddWithActuator)
 }
 

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -712,7 +712,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 						return nil, fmt.Errorf("unknown client to return for provided auth data")
 					},
 				},
-				PlatformType: configv1.GCPPlatformType,
+				platformType: configv1.GCPPlatformType,
 			}
 
 			_, err := rcr.Reconcile(reconcile.Request{

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -712,7 +712,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 						return nil, fmt.Errorf("unknown client to return for provided auth data")
 					},
 				},
-				platformType: configv1.GCPPlatformType,
+				PlatformType: configv1.GCPPlatformType,
 			}
 
 			_, err := rcr.Reconcile(reconcile.Request{
@@ -747,7 +747,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				require.NoError(t, err, "failed getting conditions")
 
 				for _, expectedCondition := range test.expectedCOConditions {
-					foundCondition := findClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
+					foundCondition := utils.FindClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
 					require.NotNil(t, foundCondition)
 					assert.Equal(t, string(expectedCondition.status), string(foundCondition.Status), "condition %s had unexpected status", expectedCondition.conditionType)
 					if expectedCondition.reason != "" {

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -1319,7 +1319,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 						}
 					},
 				},
-				platformType: configv1.AWSPlatformType,
+				PlatformType: configv1.AWSPlatformType,
 			}
 
 			_, err = rcr.Reconcile(reconcile.Request{
@@ -1354,7 +1354,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				require.NoError(t, err, "failed getting conditions")
 
 				for _, expectedCondition := range test.expectedCOConditions {
-					foundCondition := findClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
+					foundCondition := utils.FindClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
 					require.NotNil(t, foundCondition)
 					assert.Equal(t, string(expectedCondition.status), string(foundCondition.Status), "condition %s had unexpected status", expectedCondition.conditionType)
 					if expectedCondition.reason != "" {

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -1319,7 +1319,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 						}
 					},
 				},
-				PlatformType: configv1.AWSPlatformType,
+				platformType: configv1.AWSPlatformType,
 			}
 
 			_, err = rcr.Reconcile(reconcile.Request{

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
@@ -191,7 +191,7 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 					Client: fakeClient,
 					Codec:  codec,
 				},
-				PlatformType: configv1.VSpherePlatformType,
+				platformType: configv1.VSpherePlatformType,
 			}
 
 			_, err := rcr.Reconcile(reconcile.Request{

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
@@ -191,7 +191,7 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 					Client: fakeClient,
 					Codec:  codec,
 				},
-				platformType: configv1.VSpherePlatformType,
+				PlatformType: configv1.VSpherePlatformType,
 			}
 
 			_, err := rcr.Reconcile(reconcile.Request{
@@ -226,7 +226,7 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				require.NoError(t, err, "failed getting conditions")
 
 				for _, expectedCondition := range test.expectedCOConditions {
-					foundCondition := findClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
+					foundCondition := utils.FindClusterOperatorCondition(currentConditions, expectedCondition.conditionType)
 					require.NotNil(t, foundCondition)
 					assert.Equal(t, string(expectedCondition.status), string(foundCondition.Status), "condition %s had unexpected status", expectedCondition.conditionType)
 					if expectedCondition.reason != "" {

--- a/pkg/operator/credentialsrequest/status.go
+++ b/pkg/operator/credentialsrequest/status.go
@@ -38,7 +38,7 @@ func (r *ReconcileCredentialsRequest) GetConditions(logger log.FieldLogger) ([]c
 		r.Actuator,
 		mode,
 		credRequests,
-		r.PlatformType,
+		r.platformType,
 		logger), nil
 }
 
@@ -152,7 +152,7 @@ func computeStatusConditions(
 			degradedCondition.Reason = reasonStaleCredentials
 			degradedCondition.Message = fmt.Sprintf(
 				"%d of %d credentials requests are stale and should be deleted.",
-				failingCredRequests, len(validCredRequests))
+				staleCredRequests, len(validCredRequests))
 			conditions = append(conditions, degradedCondition)
 		}
 		return conditions

--- a/pkg/operator/credentialsrequest/status.go
+++ b/pkg/operator/credentialsrequest/status.go
@@ -24,6 +24,7 @@ import (
 const (
 	reasonCredentialsFailing = "CredentialsFailing"
 	reasonReconciling        = "Reconciling"
+	reasonStaleCredentials   = "StaleCredentials"
 )
 
 var _ status.Handler = &ReconcileCredentialsRequest{}
@@ -37,7 +38,7 @@ func (r *ReconcileCredentialsRequest) GetConditions(logger log.FieldLogger) ([]c
 		r.Actuator,
 		mode,
 		credRequests,
-		r.platformType,
+		r.PlatformType,
 		logger), nil
 }
 
@@ -103,11 +104,8 @@ func computeStatusConditions(
 		conditions = append(conditions, *upgradeableCondition)
 	}
 
-	if operatorIsDisabled {
-		return conditions
-	}
-
 	failingCredRequests := 0
+	staleCredRequests := 0
 
 	validCredRequests := []minterv1.CredentialsRequest{}
 	// Filter out credRequests that are for different clouds
@@ -139,6 +137,25 @@ func computeStatusConditions(
 			failingCredRequests = failingCredRequests + 1
 		}
 
+		// Check for stale credential request condition
+		staleCond := utils.FindCredentialsRequestCondition(cr.Status.Conditions, minterv1.StaleCredentials)
+		if staleCond != nil && staleCond.Status == corev1.ConditionTrue {
+			staleCredRequests = staleCredRequests + 1
+		}
+	}
+
+	if operatorIsDisabled {
+		if staleCredRequests > 0 {
+			var degradedCondition configv1.ClusterOperatorStatusCondition
+			degradedCondition.Type = configv1.OperatorDegraded
+			degradedCondition.Status = configv1.ConditionTrue
+			degradedCondition.Reason = reasonStaleCredentials
+			degradedCondition.Message = fmt.Sprintf(
+				"%d of %d credentials requests are stale and should be deleted.",
+				failingCredRequests, len(validCredRequests))
+			conditions = append(conditions, degradedCondition)
+		}
+		return conditions
 	}
 
 	if failingCredRequests > 0 {
@@ -186,17 +203,6 @@ func computeStatusConditions(
 	}
 
 	return conditions
-}
-
-// findClusterOperatorCondition iterates all conditions on a ClusterOperator looking for the
-// specified condition type. If none exists nil will be returned.
-func findClusterOperatorCondition(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
-	for i, condition := range conditions {
-		if condition.Type == conditionType {
-			return &conditions[i]
-		}
-	}
-	return nil
 }
 
 // buildExpectedRelatedObjects returns the list of expected related objects, used

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -365,3 +365,14 @@ func UpgradeableCheck(kubeClient client.Client,
 	// Only return non-default conditions as the status controller will set defaults
 	return nil
 }
+
+// FindClusterOperatorCondition iterates all conditions on a ClusterOperator looking for the
+// specified condition type. If none exists nil will be returned.
+func FindClusterOperatorCondition(conditions []configv1.ClusterOperatorStatusCondition, conditionType configv1.ClusterStatusConditionType) *configv1.ClusterOperatorStatusCondition {
+	for i, condition := range conditions {
+		if condition.Type == conditionType {
+			return &conditions[i]
+		}
+	}
+	return nil
+}

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"context"
 	"fmt"
+	"reflect"
 	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
@@ -374,5 +375,24 @@ func FindClusterOperatorCondition(conditions []configv1.ClusterOperatorStatusCon
 			return &conditions[i]
 		}
 	}
+	return nil
+}
+
+// UpdateStatus updates the status of the credentials request
+func UpdateStatus(client client.Client, origCR, newCR *minterv1.CredentialsRequest, logger log.FieldLogger) error {
+	logger.Debug("updating credentials request status")
+
+	// Update Credentials Request status if changed:
+	if !reflect.DeepEqual(newCR.Status, origCR.Status) {
+		logger.Infof("status has changed, updating")
+		err := client.Status().Update(context.TODO(), newCR)
+		if err != nil {
+			logger.WithError(err).Error("error updating credentials request")
+			return err
+		}
+	} else {
+		logger.Debugf("status unchanged")
+	}
+
 	return nil
 }


### PR DESCRIPTION
This PR adds a controller to remove the credentials requests no longer required by the CCO