### PR TITLE
require annotation before upgrade when in manual mode

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -35,6 +35,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.0
 	go.uber.org/zap v1.15.0 // indirect
+	golang.org/x/mod v0.3.0
 	golang.org/x/oauth2 v0.0.0-20200107190931-bf48bf16ab8d
 	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	gomodules.xyz/jsonpatch/v2 v2.1.0 // indirect
@@ -48,5 +49,6 @@ require (
 	k8s.io/apimachinery v0.19.2
 	k8s.io/client-go v0.19.2
 	k8s.io/code-generator v0.19.2
+	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/controller-runtime v0.6.2
 )

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -63,11 +63,10 @@ var _ actuatoriface.Actuator = (*AWSActuator)(nil)
 
 // AWSActuator implements the CredentialsRequest Actuator interface to create credentials in AWS.
 type AWSActuator struct {
-	Client              client.Client
-	Codec               *minterv1.ProviderCodec
-	AWSClientBuilder    func(accessKeyID, secretAccessKey []byte, c client.Client) (ccaws.Client, error)
-	Scheme              *runtime.Scheme
-	testUpcomingSecrets []types.NamespacedName
+	Client           client.Client
+	Codec            *minterv1.ProviderCodec
+	AWSClientBuilder func(accessKeyID, secretAccessKey []byte, c client.Client) (ccaws.Client, error)
+	Scheme           *runtime.Scheme
 }
 
 // NewAWSActuator creates a new AWSActuator.
@@ -1239,15 +1238,7 @@ func isAWSCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.getUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
-}
-
-func (a *AWSActuator) getUpcomingCredSecrets() []types.NamespacedName {
-	// For unit testing only, otherwise we want these to be a static list.
-	if a.testUpcomingSecrets != nil {
-		return a.testUpcomingSecrets
-	}
-	return constants.AWSUpcomingSecrets
+	return utils.UpgradeableCheck(a.Client, mode, a.GetCredentialsRootSecretLocation())
 }
 
 func generateAWSCredentialsConfig(accessKeyID, secretAccessKey string) []byte {

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -789,9 +789,5 @@ func checkServicesEnabled(gcpClient ccgcp.Client, permList []string, logger log.
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *Actuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.GetUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
-}
-
-func (a *Actuator) GetUpcomingCredSecrets() []types.NamespacedName {
-	return constants.GCPUpcomingSecrets
+	return utils.UpgradeableCheck(a.Client, mode, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -288,9 +288,5 @@ func (a *OpenStackActuator) getLogger(cr *minterv1.CredentialsRequest) log.Field
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *OpenStackActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.getUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
-}
-
-func (a *OpenStackActuator) getUpcomingCredSecrets() []types.NamespacedName {
-	return constants.OpenStackUpcomingSecrets
+	return utils.UpgradeableCheck(a.Client, mode, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -47,9 +47,9 @@ const (
 	// the operator config CR specifies an invalide mode
 	StatusModeInvalid = "ModeInvalid"
 
-	// MissingSecretsForUpgradeReason is used when a manual mode cluster is not upgradable due to missing
-	// secrets the operator knows will be required for the next minor release of OpenShift.
-	MissingSecretsForUpgradeReason = "ManualModeMissingSecrets"
+	// MissingUpgradeableAnnotationReason is used when the cluster is not upgradeable due to
+	// the CCO's config object missing the appropriate annotation.
+	MissingUpgradeableAnnotationReason = "MissingUpgradeableAnnotation"
 
 	// ErrorDeterminingUpgradeableReason is used when we encounter unexpected errors checking if a cluster can
 	// be updated.
@@ -126,6 +126,10 @@ const (
 	// KubevirtCloudCredSecretName is the name of the secret where credentials
 	// for Kubevirt are stored.
 	KubevirtCloudCredSecretName = "kubevirt-credentials"
+
+	// UpgradeableAnnotation is the annotation CCO will check for on the cloudcredential.operator.openshift.io
+	// CR when determining upgradeability.
+	UpgradeableAnnotation = "cloudcredential.openshift.io/upgradeable-to"
 )
 
 var (
@@ -138,40 +142,6 @@ var (
 		ModeDegraded,
 		ModeUnknown,
 		ModeManualPodIdentity,
-	}
-
-	// Add known new credentials for next version upgrade
-
-	// AWSUpcomingSecrets contains the list of known new AWS credential secrets for the next version of OpenShift
-	AWSUpcomingSecrets = []types.NamespacedName{}
-	// AzureUpcomingSecrets contains the list of known new Azure credential secrets for the next version of OpenShift
-	AzureUpcomingSecrets = []types.NamespacedName{}
-	// GCPUpcomingSecrets contains the list of known new GCP credential secrets for the next version of OpenShift
-	GCPUpcomingSecrets = []types.NamespacedName{
-		{
-			Namespace: "openshift-cluster-csi-drivers",
-			Name:      "gcp-pd-cloud-credentials",
-		},
-		{
-			Namespace: "openshift-cloud-credential-operator",
-			Name:      "cloud-credential-operator-gcp-ro-creds",
-		},
-	}
-	// OpenStackUpcomingSecrets contains the list of known new OpenStack credential secrets for the next version of OpenShift
-	OpenStackUpcomingSecrets = []types.NamespacedName{
-		{
-			Namespace: "openshift-cluster-csi-drivers",
-			Name:      "openstack-cloud-credentials",
-		},
-	}
-	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift
-	OvirtUpcomingSecrets = []types.NamespacedName{}
-	// VsphereUpcomingSecrets contains the list of known new vSphere credential secrets for the next version of OpenShift
-	VsphereUpcomingSecrets = []types.NamespacedName{
-		{
-			Namespace: "openshift-cluster-storage-operator",
-			Name:      "openshift-vsphere-problem-detector",
-		},
 	}
 
 	// Add known stale credentials requests here

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -390,22 +390,16 @@ func getWatchedSecrets(platformType configv1.PlatformType) []types.NamespacedNam
 	switch platformType {
 	case configv1.AWSPlatformType:
 		rootSecret.Name = constants.AWSCloudCredSecretName
-		secrets = append(secrets, constants.AWSUpcomingSecrets...)
 	case configv1.AzurePlatformType:
 		rootSecret.Name = constants.AzureCloudCredSecretName
-		secrets = append(secrets, constants.AzureUpcomingSecrets...)
 	case configv1.GCPPlatformType:
 		rootSecret.Name = constants.GCPCloudCredSecretName
-		secrets = append(secrets, constants.GCPUpcomingSecrets...)
 	case configv1.OpenStackPlatformType:
 		rootSecret.Name = constants.OpenStackCloudCredsSecretName
-		secrets = append(secrets, constants.OpenStackUpcomingSecrets...)
 	case configv1.OvirtPlatformType:
 		rootSecret.Name = constants.OvirtCloudCredsSecretName
-		secrets = append(secrets, constants.OvirtUpcomingSecrets...)
 	case configv1.VSpherePlatformType:
 		rootSecret.Name = constants.VSphereCloudCredSecretName
-		secrets = append(secrets, constants.VsphereUpcomingSecrets...)
 	default:
 		log.Infof("unable to provide upcoming secrets for unknown platform: %v", platformType)
 		return []types.NamespacedName{}

--- a/pkg/operator/utils/utils_test.go
+++ b/pkg/operator/utils/utils_test.go
@@ -5,6 +5,22 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/utils/pointer"
+
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	schemeutil "github.com/openshift/cloud-credential-operator/pkg/util"
 )
 
 func TestGenerateName(t *testing.T) {
@@ -54,6 +70,220 @@ func TestGenerateName(t *testing.T) {
 				//										infraName + '-' + credName + '-' + <random 5>
 				assert.True(t, len(generatedName) <= test.infraNameMaxLen+1+test.credentialNameMaxLen+1+5, "generate name has unexpected length")
 			}
+		})
+	}
+}
+
+func TestUpgradeableCheck(t *testing.T) {
+	schemeutil.SetupScheme(scheme.Scheme)
+
+	tests := []struct {
+		name                  string
+		mode                  operatorv1.CloudCredentialsMode
+		clusterVersionMissing bool
+		clusterVersion        *string
+		upgradeableAnnotation *string
+		expectedCondition     *configv1.ClusterOperatorStatusCondition
+		extraRuntimeObjects   []runtime.Object
+		rootSecretNameParam   types.NamespacedName
+	}{
+		{
+			name:                  "clusterVersion error (missing)",
+			mode:                  operatorv1.CloudCredentialsModeDefault,
+			clusterVersionMissing: true,
+			expectedCondition: &configv1.ClusterOperatorStatusCondition{
+				Status: configv1.ConditionFalse,
+				Reason: constants.ErrorDeterminingUpgradeableReason,
+			},
+		},
+		{
+			name:                  "upgradeable manual",
+			mode:                  operatorv1.CloudCredentialsModeManual,
+			clusterVersion:        pointer.StringPtr("4.6.0-1"),
+			upgradeableAnnotation: pointer.StringPtr("4.7"),
+		},
+		{
+			name:           "not upgradeable manual",
+			mode:           operatorv1.CloudCredentialsModeManual,
+			clusterVersion: pointer.StringPtr("4.6.0-1"),
+			expectedCondition: &configv1.ClusterOperatorStatusCondition{
+				Status: configv1.ConditionFalse,
+				Reason: constants.MissingUpgradeableAnnotationReason,
+			},
+		},
+		{
+			name: "clusterVersion has no history",
+			mode: operatorv1.CloudCredentialsModeDefault,
+			// no condition expected as Upgradeable will assume cluster is new/installing
+		},
+		{
+			name:           "clusterVersion has bad version",
+			mode:           operatorv1.CloudCredentialsModeDefault,
+			clusterVersion: pointer.StringPtr("not a semver version"),
+			expectedCondition: &configv1.ClusterOperatorStatusCondition{
+				Status: configv1.ConditionFalse,
+				Reason: constants.ErrorDeterminingUpgradeableReason,
+			},
+		},
+		{
+			name:                "default mode with root secret",
+			clusterVersion:      pointer.StringPtr("4.6.0"),
+			mode:                operatorv1.CloudCredentialsModeDefault,
+			rootSecretNameParam: types.NamespacedName{Name: constants.AWSCloudCredSecretName, Namespace: constants.CloudCredSecretNamespace},
+			extraRuntimeObjects: []runtime.Object{
+				testRootSecret(constants.AWSCloudCredSecretName),
+			},
+		},
+		{
+			name:                "default mode without root secret",
+			clusterVersion:      pointer.StringPtr("4.6.0"),
+			mode:                operatorv1.CloudCredentialsModeDefault,
+			rootSecretNameParam: types.NamespacedName{Name: constants.AWSCloudCredSecretName, Namespace: constants.CloudCredSecretNamespace},
+			expectedCondition: &configv1.ClusterOperatorStatusCondition{
+				Status: configv1.ConditionFalse,
+				Reason: constants.MissingRootCredentialUpgradeableReason,
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Setup
+			runtimeObjects := []runtime.Object{}
+
+			if !test.clusterVersionMissing {
+				clusterVersion := &configv1.ClusterVersion{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "version",
+					},
+				}
+				if test.clusterVersion != nil {
+					clusterVersion.Status.History = []configv1.UpdateHistory{
+						{
+							State:   configv1.CompletedUpdate,
+							Version: *test.clusterVersion,
+						},
+					}
+				}
+
+				runtimeObjects = append(runtimeObjects, clusterVersion)
+			}
+
+			clusterOperator := &operatorv1.CloudCredential{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "cluster",
+				},
+				Spec: operatorv1.CloudCredentialSpec{
+					CredentialsMode: test.mode,
+				},
+			}
+			runtimeObjects = append(runtimeObjects, clusterOperator)
+
+			if test.upgradeableAnnotation != nil {
+				clusterOperator.Annotations = map[string]string{
+					constants.UpgradeableAnnotation: *test.upgradeableAnnotation,
+				}
+			}
+			runtimeObjects = append(runtimeObjects, test.extraRuntimeObjects...)
+			fakeKubeClient := fake.NewFakeClient(runtimeObjects...)
+
+			// Test
+			returnedCondition := UpgradeableCheck(fakeKubeClient, test.mode, test.rootSecretNameParam)
+
+			// Assert
+			if test.expectedCondition != nil {
+				require.NotNil(t, returnedCondition, "expecting condition to compare against, but received no condition")
+
+				assert.Equal(t, configv1.OperatorUpgradeable, returnedCondition.Type, "unexpected type on returned condition")
+
+				assert.Equal(t, test.expectedCondition.Status, returnedCondition.Status, "unexpected status on returned condition")
+
+				assert.Equal(t, test.expectedCondition.Reason, returnedCondition.Reason, "unexpected reason on condition")
+			} else {
+				assert.Nil(t, returnedCondition, "did not expect a condition to be returned (default return) and received one")
+			}
+
+			assert.True(t, true)
+		})
+	}
+}
+
+func testRootSecret(name string) *corev1.Secret {
+	sec := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: constants.CloudCredSecretNamespace,
+		},
+	}
+	return sec
+}
+
+func TestVersionFinding(t *testing.T) {
+	tests := []struct {
+		name            string
+		expectedVersion string
+		history         []configv1.UpdateHistory
+	}{
+		{
+			name:            "single version",
+			expectedVersion: "v4.6.3",
+			history: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.6.3",
+				},
+			},
+		},
+		{
+			name:            "find latest version",
+			expectedVersion: "v4.6.3",
+			history: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.6.3",
+				},
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.5.3",
+				},
+			},
+		},
+		{
+			name:            "ignore incomplete version",
+			expectedVersion: "v4.6.3",
+			history: []configv1.UpdateHistory{
+				{
+					State:   configv1.CompletedUpdate,
+					Version: "4.6.3",
+				},
+				{
+					State:   configv1.PartialUpdate,
+					Version: "4.7.3",
+				},
+			},
+		},
+		{
+			name:            "no history",
+			expectedVersion: "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+
+			// Setup
+			clusterVersion := &configv1.ClusterVersion{
+				Status: configv1.ClusterVersionStatus{
+					History: test.history,
+				},
+			}
+
+			// Run
+			returnedVersion := getClusterVersionCompleted(clusterVersion)
+
+			// Assert
+			assert.Equal(t, test.expectedVersion, returnedVersion)
 		})
 	}
 }

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -400,9 +400,5 @@ func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *VSphereActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.getUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
-}
-
-func (a *VSphereActuator) getUpcomingCredSecrets() []types.NamespacedName {
-	return constants.VsphereUpcomingSecrets
+	return utils.UpgradeableCheck(a.Client, mode, a.GetCredentialsRootSecretLocation())
 }


### PR DESCRIPTION
Today CCO can mark itself Upgradeable=False if it sees that a Secret (containing credentials) that is required for the next minor upgrade is missing.

If an existing credentials in version 4.X simply needs new permissions in 4.Y, CCO in Manual mode cannot probe to determine this. (CCO being in Manual mode is basically CCO making minimal cloud API calls).
Introduce a system so that any/all platforms will set Upgradeable=False until an annotation has been appllied to CCO's CloudCredential config object.

This will set Upgradeable=False when in Manual mode until the user sets the annotation appropriately.

Additionally, this new annotation can be used to bypass situations that would otherwise have the cluster in Upgradeable=False (advanced use only).

Also: remove checks based on known upcoming secrets

moving forward, if CCO is in Manual mode, a user must set an appropriate annotation 'cloudcredential.openshift.io/upgradeable-to' to a higher version (semver-wise) than the most recently completed version installation/upgrade.

for mint/passthrough mode we will continue to only require the root cred secret to exist.


xref: https://issues.redhat.com/browse/CCO-15