### PR TITLE
Bug 1916868: Check 47 creds backport

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1198,75 +1198,7 @@ func isAWSCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 }
 
 func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
-		Status: configv1.ConditionTrue,
-		Type:   configv1.OperatorUpgradeable,
-	}
-	toRelease := "4.7"
-	if mode == operatorv1.CloudCredentialsModeManual {
-		// Check for the existence of credentials we know are coming in 4.6. If any do not exist, then we consider
-		// ourselves upgradable=false and inform the user why.
-		missingSecrets := []types.NamespacedName{}
-		for _, nsSecret := range a.GetUpcomingCredSecrets() {
-
-			secLog := log.WithField("secret", nsSecret).WithField("toRelease", toRelease)
-			secLog.Debug("checking that secrets exist for manual mode cluster upgrade")
-			secret := &corev1.Secret{}
-
-			err := a.Client.Get(context.Background(), nsSecret, secret)
-			if err != nil {
-				if errors.IsNotFound(err) {
-					secLog.Info("identified missing secret for upgrade")
-					missingSecrets = append(missingSecrets, nsSecret)
-				} else {
-					// If we can't figure out if you're upgradeable, you're not upgradeable:
-					secLog.WithError(err).Error("unexpected error looking up secret, marking upgradeable=false")
-					upgradeableCondition.Status = configv1.ConditionFalse
-					upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
-					upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
-						toRelease, err)
-					return upgradeableCondition
-				}
-			}
-		}
-
-		if len(missingSecrets) > 0 {
-			log.Infof("%d secrets missing, marking upgradeable=false", len(missingSecrets))
-			upgradeableCondition.Status = configv1.ConditionFalse
-			upgradeableCondition.Reason = constants.MissingSecretsForUpgradeReason
-			upgradeableCondition.Message = fmt.Sprintf(
-				"Cannot upgrade manual mode cluster to %s due to missing secret(s): %v Please see the Manually Creating IAM for AWS OpenShift documentation.",
-				toRelease,
-				missingSecrets)
-		}
-	} else {
-		// If in mint or passthrough, make sure the root cred secret exists, if not it must be restored prior to upgrade.
-		rootCred := a.GetCredentialsRootSecretLocation()
-		secret := &corev1.Secret{}
-
-		err := a.Client.Get(context.Background(), rootCred, secret)
-		if err != nil {
-
-			if errors.IsNotFound(err) {
-				log.WithField("secret", rootCred).Info("parent cred secret must be restored prior to upgrade, marking upgradeable=false")
-				upgradeableCondition.Status = configv1.ConditionFalse
-				upgradeableCondition.Reason = constants.MissingRootCredentialUpgradeableReason
-				upgradeableCondition.Message = fmt.Sprintf("Parent credential secret must be restored prior to upgrade: %s/%s",
-					rootCred.Namespace, rootCred.Name)
-				return upgradeableCondition
-			}
-
-			log.WithError(err).Error("unexpected error looking up parent secret, marking upgradeable=false")
-			// If we can't figure out if you're upgradeable, you're not upgradeable:
-			upgradeableCondition.Status = configv1.ConditionFalse
-			upgradeableCondition.Reason = constants.ErrorDeterminingUpgradeableReason
-			upgradeableCondition.Message = fmt.Sprintf("Error determining if cluster can be upgraded to %s: %v",
-				toRelease, err)
-			return upgradeableCondition
-		}
-	}
-
-	return upgradeableCondition
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.GetUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
 }
 
 func (a *AWSActuator) GetUpcomingCredSecrets() []types.NamespacedName {

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -21,18 +21,7 @@ import (
 	"fmt"
 	"reflect"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
-
-	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
-	ccgcp "github.com/openshift/cloud-credential-operator/pkg/gcp"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
-	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
-	gcputils "github.com/openshift/cloud-credential-operator/pkg/operator/utils/gcp"
 
 	// GCP packages
 	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
@@ -44,6 +33,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	ccgcp "github.com/openshift/cloud-credential-operator/pkg/gcp"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
+	gcputils "github.com/openshift/cloud-credential-operator/pkg/operator/utils/gcp"
 )
 
 const (
@@ -771,13 +772,9 @@ func checkServicesEnabled(gcpClient ccgcp.Client, permList []string, logger log.
 }
 
 func (a *Actuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
-		Status: configv1.ConditionTrue,
-		Type:   configv1.OperatorUpgradeable,
-	}
-	return upgradeableCondition
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.GetUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
 }
 
 func (a *Actuator) GetUpcomingCredSecrets() []types.NamespacedName {
-	return []types.NamespacedName{}
+	return constants.GCPUpcomingSecrets
 }

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -20,10 +20,6 @@ import (
 	"fmt"
 	"reflect"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
-	log "github.com/sirupsen/logrus"
-
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -31,9 +27,14 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+	log "github.com/sirupsen/logrus"
+
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
 const (
@@ -274,13 +275,9 @@ func (a *OpenStackActuator) getLogger(cr *minterv1.CredentialsRequest) log.Field
 }
 
 func (a *OpenStackActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
-		Status: configv1.ConditionTrue,
-		Type:   configv1.OperatorUpgradeable,
-	}
-	return upgradeableCondition
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.GetUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
 }
 
 func (a *OpenStackActuator) GetUpcomingCredSecrets() []types.NamespacedName {
-	return []types.NamespacedName{}
+	return constants.OpenStackUpcomingSecrets
 }

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -1,5 +1,7 @@
 package constants
 
+import "k8s.io/apimachinery/pkg/types"
+
 // CredentialsMode enumerates the possible modes of operation for CCO
 type CredentialsMode string
 
@@ -118,4 +120,28 @@ var (
 		ModeDegraded,
 		ModeUnknown,
 	}
+
+	// Add known new credentials for next version upgrade
+
+	// AWSUpcomingSecrets contains the list of known new AWS credential secrets for the next version of OpenShift
+	AWSUpcomingSecrets = []types.NamespacedName{}
+	// AzureUpcomingSecrets contains the list of known new Azure credential secrets for the next version of OpenShift
+	AzureUpcomingSecrets = []types.NamespacedName{}
+	// GCPUpcomingSecrets contains the list of known new GCP credential secrets for the next version of OpenShift
+	GCPUpcomingSecrets = []types.NamespacedName{
+		{
+			Namespace: "openshift-cluster-csi-drivers",
+			Name:      "gcp-pd-cloud-credentials",
+		},
+		{
+			Namespace: "openshift-cloud-credential-operator",
+			Name:      "cloud-credential-operator-gcp-ro-creds",
+		},
+	}
+	// OpenStackUpcomingSecrets contains the list of known new OpenStack credential secrets for the next version of OpenShift
+	OpenStackUpcomingSecrets = []types.NamespacedName{}
+	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift
+	OvirtUpcomingSecrets = []types.NamespacedName{}
+	// VsphereUpcomingSecrets contains the list of known new vSphere credential secrets for the next version of OpenShift
+	VsphereUpcomingSecrets = []types.NamespacedName{}
 )

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -143,5 +143,10 @@ var (
 	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift
 	OvirtUpcomingSecrets = []types.NamespacedName{}
 	// VsphereUpcomingSecrets contains the list of known new vSphere credential secrets for the next version of OpenShift
-	VsphereUpcomingSecrets = []types.NamespacedName{}
+	VsphereUpcomingSecrets = []types.NamespacedName{
+		{
+			Namespace: "openshift-cluster-storage-operator",
+			Name:      "openshift-vsphere-problem-detector",
+		},
+	}
 )

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -139,7 +139,12 @@ var (
 		},
 	}
 	// OpenStackUpcomingSecrets contains the list of known new OpenStack credential secrets for the next version of OpenShift
-	OpenStackUpcomingSecrets = []types.NamespacedName{}
+	OpenStackUpcomingSecrets = []types.NamespacedName{
+		{
+			Namespace: "openshift-cluster-csi-drivers",
+			Name:      "openstack-cloud-credentials",
+		},
+	}
 	// OvirtUpcomingSecrets contains the list of known new oVirt credential secrets for the next version of OpenShift
 	OvirtUpcomingSecrets = []types.NamespacedName{}
 	// VsphereUpcomingSecrets contains the list of known new vSphere credential secrets for the next version of OpenShift

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -20,20 +20,23 @@ import (
 	"fmt"
 	"reflect"
 
-	configv1 "github.com/openshift/api/config/v1"
-	operatorv1 "github.com/openshift/api/operator/v1"
 	log "github.com/sirupsen/logrus"
-
-	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
-	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
+
 	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configv1 "github.com/openshift/api/config/v1"
+	operatorv1 "github.com/openshift/api/operator/v1"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	actuatoriface "github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
 var _ actuatoriface.Actuator = (*VSphereActuator)(nil)
@@ -389,13 +392,9 @@ func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 }
 
 func (a *VSphereActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
-		Status: configv1.ConditionTrue,
-		Type:   configv1.OperatorUpgradeable,
-	}
-	return upgradeableCondition
+	return utils.UpgradeableCheck(a.Client, mode, "4.7", a.GetUpcomingCredSecrets(), a.GetCredentialsRootSecretLocation())
 }
 
 func (a *VSphereActuator) GetUpcomingCredSecrets() []types.NamespacedName {
-	return []types.NamespacedName{}
+	return constants.VsphereUpcomingSecrets
 }


### PR DESCRIPTION
Manual backport of #280 

Refactor AWS upgradeable checking so that other platforms can use the logic.

Add new GCP, OpenStack, and vSphere secrets to check/set upgradeable on.