### PR TITLE
specify Azure and GCP as supporting Manual mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,8 +211,8 @@ Future supported clouds: AWS
 Cloud | Mint | Mint + Remove Admin Cred | Passthrough | Manual | Token
 --- | --- | --- | --- | --- | ---
 AWS | Y | 4.4+ | Y | 4.3+ | 4.6+ (expected)
-Azure | Y | N | Y | unknown | N
-GCP | Y | 4.7+ | Y | unknown | N
+Azure | Y | N | Y | Y | N
+GCP | Y | 4.7+ | Y | Y | N
 KubeVirt | N | N | Y | N | N
 OpenStack | N | N | Y | N | N
 oVirt | N | N | Y | N | N


### PR DESCRIPTION
We publish official docs on how to run CCO in Manual mode for Azure and GCP. Update our readme to reflect that.