### PR TITLE
Add a CredentialsRequest field to store service account names

### DIFF
--- a/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
+++ b/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
@@ -80,6 +80,15 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+            serviceAccountNames:
+              description: ServiceAccountNames contains a list of ServiceAccounts
+                that will use permissions associated with this CredentialsRequest.
+                This is not used by CCO, but the information is needed for being able
+                to properly set up access control in the cloud provider when the ServiceAccounts
+                are used as part of the cloud credentials flow.
+              type: array
+              items:
+                type: string
         status:
           description: CredentialsRequestStatus defines the observed state of CredentialsRequest
           type: object

--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -84,6 +84,15 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+            serviceAccountNames:
+              description: ServiceAccountNames contains a list of ServiceAccounts
+                that will use permissions associated with this CredentialsRequest.
+                This is not used by CCO, but the information is needed for being able
+                to properly set up access control in the cloud provider when the ServiceAccounts
+                are used as part of the cloud credentials flow.
+              type: array
+              items:
+                type: string
         status:
           description: CredentialsRequestStatus defines the observed state of CredentialsRequest
           type: object

--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -53,6 +53,13 @@ type CredentialsRequestSpec struct {
 	// ProviderSpec contains the cloud provider specific credentials specification.
 	// +kubebuilder:pruning:PreserveUnknownFields
 	ProviderSpec *runtime.RawExtension `json:"providerSpec,omitempty"`
+
+	// ServiceAccountNames contains a list of ServiceAccounts that will use permissions associated with this
+	// CredentialsRequest. This is not used by CCO, but the information is needed for being able to properly
+	// set up access control in the cloud provider when the ServiceAccounts are used as part of the cloud
+	// credentials flow.
+	// +optional
+	ServiceAccountNames []string `json:"serviceAccountNames,omitempty"`
 }
 
 // CredentialsRequestStatus defines the observed state of CredentialsRequest

--- a/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
@@ -208,6 +208,11 @@ func (in *CredentialsRequestSpec) DeepCopyInto(out *CredentialsRequestSpec) {
 		*out = new(runtime.RawExtension)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.ServiceAccountNames != nil {
+		in, out := &in.ServiceAccountNames, &out.ServiceAccountNames
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/assets/bootstrap/bindata.go
+++ b/pkg/assets/bootstrap/bindata.go
@@ -138,6 +138,15 @@ spec:
                 uid:
                   description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
                   type: string
+            serviceAccountNames:
+              description: ServiceAccountNames contains a list of ServiceAccounts
+                that will use permissions associated with this CredentialsRequest.
+                This is not used by CCO, but the information is needed for being able
+                to properly set up access control in the cloud provider when the ServiceAccounts
+                are used as part of the cloud credentials flow.
+              type: array
+              items:
+                type: string
         status:
           description: CredentialsRequestStatus defines the observed state of CredentialsRequest
           type: object


### PR DESCRIPTION
The new field will not be used by CCO but is needed for ccoctl tool to
set up access control in the cloud provider.