### PR TITLE
report STS as a submode of Manual

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -55,9 +55,8 @@ const (
 	openshiftClusterIDKey     = "openshiftClusterID"
 	clusterVersionObjectName  = "version"
 
-	secretDataAccessKey      = "aws_access_key_id"
-	secretDataSecretKey      = "aws_secret_access_key"
-	secretDataCredentialsKey = "credentials"
+	secretDataAccessKey = "aws_access_key_id"
+	secretDataSecretKey = "aws_secret_access_key"
 )
 
 var _ actuatoriface.Actuator = (*AWSActuator)(nil)
@@ -165,7 +164,7 @@ func (a *AWSActuator) needsUpdate(ctx context.Context, cr *minterv1.CredentialsR
 
 	// Make sure we update old Secrets that don't have the new "credentials" field
 	if credentialsKey == "" || credentialsKey != string(generateAWSCredentialsConfig(accessKey, secretKey)) {
-		logger.Infof("Secret %s key needs updating, will update Secret contents", secretDataCredentialsKey)
+		logger.Infof("Secret %s key needs updating, will update Secret contents", constants.AWSSecretDataCredentialsKey)
 		return true, nil
 	}
 
@@ -737,9 +736,9 @@ func (a *AWSActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) (*core
 			existingSecretAccessKey = string(secretBytes)
 		}
 
-		credentialsKey, ok := existingSecret.Data[secretDataCredentialsKey]
+		credentialsKey, ok := existingSecret.Data[constants.AWSSecretDataCredentialsKey]
 		if !ok {
-			logger.Warningf("secret did not have expected key: %s, will be updated", secretDataCredentialsKey)
+			logger.Warningf("secret did not have expected key: %s, will be updated", constants.AWSSecretDataCredentialsKey)
 		} else {
 			existingCredentialsKey = string(credentialsKey)
 		}
@@ -877,9 +876,9 @@ func (a *AWSActuator) syncAccessKeySecret(cr *minterv1.CredentialsRequest, acces
 				},
 			},
 			Data: map[string][]byte{
-				secretDataAccessKey:      []byte(accessKeyID),
-				secretDataSecretKey:      []byte(secretAccessKey),
-				secretDataCredentialsKey: generateAWSCredentialsConfig(accessKeyID, secretAccessKey),
+				secretDataAccessKey:                   []byte(accessKeyID),
+				secretDataSecretKey:                   []byte(secretAccessKey),
+				constants.AWSSecretDataCredentialsKey: generateAWSCredentialsConfig(accessKeyID, secretAccessKey),
 			},
 		}
 
@@ -906,7 +905,7 @@ func (a *AWSActuator) syncAccessKeySecret(cr *minterv1.CredentialsRequest, acces
 	}
 
 	// Make sure credentials config data is synced with the stored access key / secret key
-	existingSecret.Data[secretDataCredentialsKey] = generateAWSCredentialsConfig(string(existingSecret.Data[secretDataAccessKey]), string(existingSecret.Data[secretDataSecretKey]))
+	existingSecret.Data[constants.AWSSecretDataCredentialsKey] = generateAWSCredentialsConfig(string(existingSecret.Data[secretDataAccessKey]), string(existingSecret.Data[secretDataSecretKey]))
 
 	if !reflect.DeepEqual(existingSecret, origSecret) {
 		sLog.Info("target secret has changed, updating")

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -34,6 +34,10 @@ const (
 	// running under (typically just haven't added support for the cloud/platform)
 	ModeUnknown CredentialsMode = "unknown"
 
+	// ModeManualPodIdentity is used to indicate that CCO has found at least one CredentialsRequest
+	// secret with content indicating Pod-level identity/credentials in use (eg AWS STS with WebIdentity).
+	ModeManualPodIdentity CredentialsMode = "manualpodidentity"
+
 	// StatusModeMismatch is used to set a clusteroperator condition when
 	// the legacy configmap setting of disabled: "true" conflicts with the
 	// specified operator config mode.
@@ -79,10 +83,14 @@ const (
 	// will use for logging purposes.
 	SecretAnnotatorControllerName = "secretannotator"
 
-	// cloud credential secret infor
+	// cloud credential secret info
 
 	// AWSCloudCredSecretName is the name of the secret created by the installer containing cloud creds.
 	AWSCloudCredSecretName = "aws-creds"
+
+	// AWSSecretDataCredentialsKey is the name of the key used to store the AWS config data in the Secret
+	// specified in the CredentialsRequest.Spec.SecretRef
+	AWSSecretDataCredentialsKey = "credentials"
 
 	// AzureCloudCredSecretName is the name of the secret created by the install containing cloud creds.
 	AzureCloudCredSecretName = "azure-credentials"
@@ -129,6 +137,7 @@ var (
 		ModeManual,
 		ModeDegraded,
 		ModeUnknown,
+		ModeManualPodIdentity,
 	}
 
 	// Add known new credentials for next version upgrade


### PR DESCRIPTION
Allow metrics reporting to detect and report a cluster where at least one
CredentialsRequest secret is configured for pod identity/STS.

- [x] make the "credentials" Secret key string a public constant
- [x] update the metrics accumulator logic to detect and record when a
  CredentialsRequest Secret contains pod identity/STS content
- [x] update test cases to cover case where accumulator needs to find
  pod identity/STS Secret content

xref: https://issues.redhat.com/browse/CCO-61