### PR TITLE
add generate-only mode for ccoctl create identity-provider

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -69,88 +69,88 @@ type ClientParams struct {
 	CABundle  string
 }
 
-type AWSClient struct {
-	IAMClient iamiface.IAMAPI
-	S3Client  s3iface.S3API
+type awsClient struct {
+	iamClient iamiface.IAMAPI
+	s3Client  s3iface.S3API
 }
 
-func (c *AWSClient) CreateAccessKey(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
-	return c.IAMClient.CreateAccessKey(input)
+func (c *awsClient) CreateAccessKey(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
+	return c.iamClient.CreateAccessKey(input)
 }
 
-func (c *AWSClient) CreateUser(input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
-	return c.IAMClient.CreateUser(input)
+func (c *awsClient) CreateUser(input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
+	return c.iamClient.CreateUser(input)
 }
 
-func (c *AWSClient) DeleteAccessKey(input *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
-	return c.IAMClient.DeleteAccessKey(input)
+func (c *awsClient) DeleteAccessKey(input *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
+	return c.iamClient.DeleteAccessKey(input)
 }
 
-func (c *AWSClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
-	return c.IAMClient.DeleteUser(input)
+func (c *awsClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
+	return c.iamClient.DeleteUser(input)
 }
 
-func (c *AWSClient) DeleteUserPolicy(input *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
-	return c.IAMClient.DeleteUserPolicy(input)
+func (c *awsClient) DeleteUserPolicy(input *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
+	return c.iamClient.DeleteUserPolicy(input)
 }
-func (c *AWSClient) GetUser(input *iam.GetUserInput) (*iam.GetUserOutput, error) {
-	return c.IAMClient.GetUser(input)
-}
-
-func (c *AWSClient) ListAccessKeys(input *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-	return c.IAMClient.ListAccessKeys(input)
+func (c *awsClient) GetUser(input *iam.GetUserInput) (*iam.GetUserOutput, error) {
+	return c.iamClient.GetUser(input)
 }
 
-func (c *AWSClient) ListUserPolicies(input *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
-	return c.IAMClient.ListUserPolicies(input)
+func (c *awsClient) ListAccessKeys(input *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
+	return c.iamClient.ListAccessKeys(input)
 }
 
-func (c *AWSClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
-	return c.IAMClient.PutUserPolicy(input)
+func (c *awsClient) ListUserPolicies(input *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
+	return c.iamClient.ListUserPolicies(input)
 }
 
-func (c *AWSClient) GetUserPolicy(input *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
-	return c.IAMClient.GetUserPolicy(input)
+func (c *awsClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
+	return c.iamClient.PutUserPolicy(input)
 }
 
-func (c *AWSClient) SimulatePrincipalPolicy(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
-	return c.IAMClient.SimulatePrincipalPolicy(input)
+func (c *awsClient) GetUserPolicy(input *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
+	return c.iamClient.GetUserPolicy(input)
 }
 
-func (c *AWSClient) SimulatePrincipalPolicyPages(input *iam.SimulatePrincipalPolicyInput, fn func(*iam.SimulatePolicyResponse, bool) bool) error {
-	return c.IAMClient.SimulatePrincipalPolicyPages(input, fn)
+func (c *awsClient) SimulatePrincipalPolicy(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
+	return c.iamClient.SimulatePrincipalPolicy(input)
 }
 
-func (c *AWSClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error) {
-	return c.IAMClient.TagUser(input)
+func (c *awsClient) SimulatePrincipalPolicyPages(input *iam.SimulatePrincipalPolicyInput, fn func(*iam.SimulatePolicyResponse, bool) bool) error {
+	return c.iamClient.SimulatePrincipalPolicyPages(input, fn)
 }
 
-func (c *AWSClient) ListOpenIDConnectProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	return c.IAMClient.ListOpenIDConnectProviders(input)
+func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return c.iamClient.TagUser(input)
 }
 
-func (c *AWSClient) CreateOpenIDConnectProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	return c.IAMClient.CreateOpenIDConnectProvider(input)
+func (c *awsClient) ListOpenIDConnectProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	return c.iamClient.ListOpenIDConnectProviders(input)
 }
 
-func (c *AWSClient) TagOpenIDConnectProvider(input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
-	return c.IAMClient.TagOpenIDConnectProvider(input)
+func (c *awsClient) CreateOpenIDConnectProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	return c.iamClient.CreateOpenIDConnectProvider(input)
 }
 
-func (c *AWSClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
-	return c.IAMClient.GetOpenIDConnectProvider(input)
+func (c *awsClient) TagOpenIDConnectProvider(input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return c.iamClient.TagOpenIDConnectProvider(input)
 }
 
-func (c *AWSClient) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
-	return c.S3Client.CreateBucket(input)
+func (c *awsClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
+	return c.iamClient.GetOpenIDConnectProvider(input)
 }
 
-func (c *AWSClient) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
-	return c.S3Client.PutBucketTagging(input)
+func (c *awsClient) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	return c.s3Client.CreateBucket(input)
 }
 
-func (c *AWSClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
-	return c.S3Client.PutObject(input)
+func (c *awsClient) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
+	return c.s3Client.PutBucketTagging(input)
+}
+
+func (c *awsClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	return c.s3Client.PutObject(input)
 }
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
@@ -188,8 +188,13 @@ func NewClient(accessKeyID, secretAccessKey []byte, params *ClientParams) (Clien
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io cloud-credential-operator", version.Get().String(), agentText),
 	})
 
-	return &AWSClient{
-		IAMClient: iam.New(s),
-		S3Client:  s3.New(s),
-	}, nil
+	return NewClientFromSession(s), nil
+}
+
+// NewClientFromSession will return a basic Client using only the provided awsSession
+func NewClientFromSession(sess *session.Session) Client {
+	return &awsClient{
+		iamClient: iam.New(sess),
+		s3Client:  s3.New(sess),
+	}
 }

--- a/pkg/cmd/provisioning/constants.go
+++ b/pkg/cmd/provisioning/constants.go
@@ -11,8 +11,6 @@ const (
 	keysURI = "keys.json"
 	// ccoctlAWSResourceTagKeyPrefix is the prefix of the tag key applied to the AWS resources created/shared by ccoctl
 	ccoctlAWSResourceTagKeyPrefix = "openshift.io/cloud-credential-operator"
-	// sharedCcoctlAWSResourceTagValue is the value of the tag applied to the AWS resources shared by ccoctl
-	sharedCcoctlAWSResourceTagValue = "shared"
 	// ownedCcoctlAWSResourceTagValue is the value of the tag applied to the AWS resources created by ccoctl
 	ownedCcoctlAWSResourceTagValue = "owned"
 )

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -13,7 +13,7 @@ type options struct {
 	PublicKeyPath string
 	Region        string
 	NamePrefix    string
-	GenerateOnly  bool
+	DryRun        bool
 }
 
 var (

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -13,6 +13,7 @@ type options struct {
 	PublicKeyPath string
 	Region        string
 	NamePrefix    string
+	GenerateOnly  bool
 }
 
 var (

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -12,7 +12,7 @@ type options struct {
 	TargetDir     string
 	PublicKeyPath string
 	Region        string
-	InfraName     string
+	NamePrefix    string
 }
 
 var (

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -306,10 +306,7 @@ func identityProviderCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	awsClient := &aws.AWSClient{
-		IAMClient: iam.New(s),
-		S3Client:  s3.New(s),
-	}
+	awsClient := aws.NewClientFromSession(s)
 
 	err = createIdentityProvider(awsClient, CreateOpts.InfraName, CreateOpts.Region, CreateOpts.PublicKeyPath, CreateOpts.TargetDir)
 	if err != nil {

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -65,7 +65,7 @@ type JSONWebKeySet struct {
 }
 
 func createIdentityProvider(client aws.Client, namePrefix, region, publicKeyPath, targetDir string) error {
-	bucketName := fmt.Sprintf("%s-installer", namePrefix)
+	bucketName := fmt.Sprintf("%s-oidc", namePrefix)
 	issuerURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com", bucketName, region)
 
 	var bucketTagValue string

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -308,7 +309,12 @@ func identityProviderCmd(cmd *cobra.Command, args []string) {
 
 	awsClient := aws.NewClientFromSession(s)
 
-	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, CreateOpts.PublicKeyPath, CreateOpts.TargetDir)
+	publicKeyPath := CreateOpts.PublicKeyPath
+	if publicKeyPath == "" {
+		publicKeyPath = path.Join(CreateOpts.TargetDir, publicKeyFile)
+	}
+
+	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -325,8 +331,7 @@ func NewIdentityProviderSetup() *cobra.Command {
 	identityProviderSetupCmd.MarkPersistentFlagRequired("name-prefix")
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
 	identityProviderSetupCmd.MarkPersistentFlagRequired("region")
-	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.PublicKeyPath, "public-key", "", "Path to public ServiceAccount signing key")
-	identityProviderSetupCmd.MarkPersistentFlagRequired("public-key")
+	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.PublicKeyPath, "public-key-file", "", "Path to public ServiceAccount signing key")
 
 	return identityProviderSetupCmd
 }

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -447,7 +447,7 @@ func identityProviderCmd(cmd *cobra.Command, args []string) {
 		publicKeyPath = path.Join(CreateOpts.TargetDir, publicKeyFile)
 	}
 
-	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir, CreateOpts.GenerateOnly)
+	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir, CreateOpts.DryRun)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -465,7 +465,7 @@ func NewIdentityProviderSetup() *cobra.Command {
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
 	identityProviderSetupCmd.MarkPersistentFlagRequired("region")
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.PublicKeyPath, "public-key-file", "", "Path to public ServiceAccount signing key")
-	identityProviderSetupCmd.PersistentFlags().BoolVar(&CreateOpts.GenerateOnly, "generate-files-only", false, "Skip creating objects, and just save what would have been created into files")
+	identityProviderSetupCmd.PersistentFlags().BoolVar(&CreateOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
 
 	return identityProviderSetupCmd
 }

--- a/pkg/cmd/provisioning/keypair.go
+++ b/pkg/cmd/provisioning/keypair.go
@@ -28,13 +28,13 @@ func createKeys(prefixDir string) error {
 	log.Print("Generating RSA keypair")
 	privateKey, err := rsa.GenerateKey(rand.Reader, bitSize)
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate private key")
+		return errors.Wrap(err, "failed to generate private key")
 	}
 
 	log.Print("Writing private key to ", privateKeyFilePath)
 	f, err := os.Create(privateKeyFilePath)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create private key file")
+		return errors.Wrap(err, "failed to create private key file")
 	}
 
 	err = pem.Encode(f, &pem.Block{
@@ -44,18 +44,18 @@ func createKeys(prefixDir string) error {
 	})
 	f.Close()
 	if err != nil {
-		return errors.Wrap(err, "Failed to write out private key data")
+		return errors.Wrap(err, "failed to write out private key data")
 	}
 
 	log.Print("Writing public key to ", publicKeyFilePath)
 	f, err = os.Create(publicKeyFilePath)
 	if err != nil {
-		errors.Wrap(err, "Failed to create public key file")
+		errors.Wrap(err, "failed to create public key file")
 	}
 
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
 	if err != nil {
-		errors.Wrap(err, "Failed to generate public key from private")
+		errors.Wrap(err, "failed to generate public key from private")
 	}
 
 	err = pem.Encode(f, &pem.Block{
@@ -65,7 +65,7 @@ func createKeys(prefixDir string) error {
 	})
 	f.Close()
 	if err != nil {
-		errors.Wrap(err, "Failed to write out public key data")
+		errors.Wrap(err, "failed to write out public key data")
 	}
 	return nil
 }


### PR DESCRIPTION
- [x] add NewClientFromSession() for creating AWS clients
- [x ] rename param from 'infra-name' to 'name-prefix'
- [x] Allow ccoctl to assume the location of the public key file instead of forcing to provide it (will assume that `ccoctl create key-pair` output files exist)
- [x ] name S3 bucket holding OIDC config "<bucket>-oidc" instead of "<bucket>-installer"
- [x] Allow someone to have ccoctl simply generate files instead of actually making the AWS API calls.
- [x ] Generate the issuerURL fingerprint instead of hardcoding

