### PR TITLE
iam-roles subcommand

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,8 +76,12 @@ $(call build-image,ocp-cloud-credential-operator,$(IMAGE_REGISTRY)/ocp/4.5:cloud
 $(call add-crd-gen,cloudcredential-manifests,./pkg/apis/cloudcredential/v1,./manifests,./manifests)
 $(call add-crd-gen,cloudcredential-bindata,./pkg/apis/cloudcredential/v1,./bindata/bootstrap,./bindata/bootstrap)
 
-update: update-vendored-crds update-codegen update-bindata
+update: update-vendored-crds update-codegen update-bindata generate
 .PHONY: update
+
+generate:
+	go generate ${GO_TEST_PACKAGES}
+.PHONY: generate
 
 update-vendored-crds:
 	# copy config CRD from openshift/api

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -69,88 +69,88 @@ type ClientParams struct {
 	CABundle  string
 }
 
-type AWSClient struct {
-	IAMClient iamiface.IAMAPI
-	S3Client  s3iface.S3API
+type awsClient struct {
+	iamClient iamiface.IAMAPI
+	s3Client  s3iface.S3API
 }
 
-func (c *AWSClient) CreateAccessKey(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
-	return c.IAMClient.CreateAccessKey(input)
+func (c *awsClient) CreateAccessKey(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
+	return c.iamClient.CreateAccessKey(input)
 }
 
-func (c *AWSClient) CreateUser(input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
-	return c.IAMClient.CreateUser(input)
+func (c *awsClient) CreateUser(input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
+	return c.iamClient.CreateUser(input)
 }
 
-func (c *AWSClient) DeleteAccessKey(input *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
-	return c.IAMClient.DeleteAccessKey(input)
+func (c *awsClient) DeleteAccessKey(input *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
+	return c.iamClient.DeleteAccessKey(input)
 }
 
-func (c *AWSClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
-	return c.IAMClient.DeleteUser(input)
+func (c *awsClient) DeleteUser(input *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
+	return c.iamClient.DeleteUser(input)
 }
 
-func (c *AWSClient) DeleteUserPolicy(input *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
-	return c.IAMClient.DeleteUserPolicy(input)
+func (c *awsClient) DeleteUserPolicy(input *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
+	return c.iamClient.DeleteUserPolicy(input)
 }
-func (c *AWSClient) GetUser(input *iam.GetUserInput) (*iam.GetUserOutput, error) {
-	return c.IAMClient.GetUser(input)
-}
-
-func (c *AWSClient) ListAccessKeys(input *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-	return c.IAMClient.ListAccessKeys(input)
+func (c *awsClient) GetUser(input *iam.GetUserInput) (*iam.GetUserOutput, error) {
+	return c.iamClient.GetUser(input)
 }
 
-func (c *AWSClient) ListUserPolicies(input *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
-	return c.IAMClient.ListUserPolicies(input)
+func (c *awsClient) ListAccessKeys(input *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
+	return c.iamClient.ListAccessKeys(input)
 }
 
-func (c *AWSClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
-	return c.IAMClient.PutUserPolicy(input)
+func (c *awsClient) ListUserPolicies(input *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
+	return c.iamClient.ListUserPolicies(input)
 }
 
-func (c *AWSClient) GetUserPolicy(input *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
-	return c.IAMClient.GetUserPolicy(input)
+func (c *awsClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
+	return c.iamClient.PutUserPolicy(input)
 }
 
-func (c *AWSClient) SimulatePrincipalPolicy(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
-	return c.IAMClient.SimulatePrincipalPolicy(input)
+func (c *awsClient) GetUserPolicy(input *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
+	return c.iamClient.GetUserPolicy(input)
 }
 
-func (c *AWSClient) SimulatePrincipalPolicyPages(input *iam.SimulatePrincipalPolicyInput, fn func(*iam.SimulatePolicyResponse, bool) bool) error {
-	return c.IAMClient.SimulatePrincipalPolicyPages(input, fn)
+func (c *awsClient) SimulatePrincipalPolicy(input *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
+	return c.iamClient.SimulatePrincipalPolicy(input)
 }
 
-func (c *AWSClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error) {
-	return c.IAMClient.TagUser(input)
+func (c *awsClient) SimulatePrincipalPolicyPages(input *iam.SimulatePrincipalPolicyInput, fn func(*iam.SimulatePolicyResponse, bool) bool) error {
+	return c.iamClient.SimulatePrincipalPolicyPages(input, fn)
 }
 
-func (c *AWSClient) ListOpenIDConnectProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	return c.IAMClient.ListOpenIDConnectProviders(input)
+func (c *awsClient) TagUser(input *iam.TagUserInput) (*iam.TagUserOutput, error) {
+	return c.iamClient.TagUser(input)
 }
 
-func (c *AWSClient) CreateOpenIDConnectProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	return c.IAMClient.CreateOpenIDConnectProvider(input)
+func (c *awsClient) ListOpenIDConnectProviders(input *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	return c.iamClient.ListOpenIDConnectProviders(input)
 }
 
-func (c *AWSClient) TagOpenIDConnectProvider(input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
-	return c.IAMClient.TagOpenIDConnectProvider(input)
+func (c *awsClient) CreateOpenIDConnectProvider(input *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	return c.iamClient.CreateOpenIDConnectProvider(input)
 }
 
-func (c *AWSClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
-	return c.IAMClient.GetOpenIDConnectProvider(input)
+func (c *awsClient) TagOpenIDConnectProvider(input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
+	return c.iamClient.TagOpenIDConnectProvider(input)
 }
 
-func (c *AWSClient) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
-	return c.S3Client.CreateBucket(input)
+func (c *awsClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
+	return c.iamClient.GetOpenIDConnectProvider(input)
 }
 
-func (c *AWSClient) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
-	return c.S3Client.PutBucketTagging(input)
+func (c *awsClient) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	return c.s3Client.CreateBucket(input)
 }
 
-func (c *AWSClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
-	return c.S3Client.PutObject(input)
+func (c *awsClient) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
+	return c.s3Client.PutBucketTagging(input)
+}
+
+func (c *awsClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	return c.s3Client.PutObject(input)
 }
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.
@@ -188,8 +188,13 @@ func NewClient(accessKeyID, secretAccessKey []byte, params *ClientParams) (Clien
 		Fn:   request.MakeAddToUserAgentHandler("openshift.io cloud-credential-operator", version.Get().String(), agentText),
 	})
 
-	return &AWSClient{
-		IAMClient: iam.New(s),
-		S3Client:  s3.New(s),
-	}, nil
+	return NewClientFromSession(s), nil
+}
+
+// NewClientFromSession will return a basic Client using only the provided awsSession
+func NewClientFromSession(sess *session.Session) Client {
+	return &awsClient{
+		iamClient: iam.New(sess),
+		s3Client:  s3.New(sess),
+	}
 }

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -37,22 +37,26 @@ import (
 type Client interface {
 	//IAM
 	CreateAccessKey(*iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error)
+	CreateOpenIDConnectProvider(*iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error)
+	CreateRole(*iam.CreateRoleInput) (*iam.CreateRoleOutput, error)
 	CreateUser(*iam.CreateUserInput) (*iam.CreateUserOutput, error)
 	DeleteAccessKey(*iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error)
 	DeleteUser(*iam.DeleteUserInput) (*iam.DeleteUserOutput, error)
 	DeleteUserPolicy(*iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error)
+	GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error)
+	GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error)
 	GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error)
-	ListAccessKeys(*iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error)
-	ListUserPolicies(*iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error)
-	PutUserPolicy(*iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error)
 	GetUserPolicy(*iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error)
+	ListAccessKeys(*iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error)
+	ListOpenIDConnectProviders(*iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error)
+	ListUserPolicies(*iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error)
+	PutRolePolicy(*iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error)
+	PutUserPolicy(*iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error)
 	SimulatePrincipalPolicy(*iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error)
 	SimulatePrincipalPolicyPages(*iam.SimulatePrincipalPolicyInput, func(*iam.SimulatePolicyResponse, bool) bool) error
-	TagUser(*iam.TagUserInput) (*iam.TagUserOutput, error)
-	ListOpenIDConnectProviders(*iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error)
-	CreateOpenIDConnectProvider(*iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error)
 	TagOpenIDConnectProvider(*iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error)
-	GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error)
+	TagUser(*iam.TagUserInput) (*iam.TagUserOutput, error)
+	UpdateAssumeRolePolicy(*iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error)
 
 	//S3
 	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
@@ -76,6 +80,10 @@ type awsClient struct {
 
 func (c *awsClient) CreateAccessKey(input *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
 	return c.iamClient.CreateAccessKey(input)
+}
+
+func (c *awsClient) CreateRole(input *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
+	return c.iamClient.CreateRole(input)
 }
 
 func (c *awsClient) CreateUser(input *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
@@ -105,8 +113,16 @@ func (c *awsClient) ListUserPolicies(input *iam.ListUserPoliciesInput) (*iam.Lis
 	return c.iamClient.ListUserPolicies(input)
 }
 
+func (c *awsClient) PutRolePolicy(input *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	return c.iamClient.PutRolePolicy(input)
+}
+
 func (c *awsClient) PutUserPolicy(input *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
 	return c.iamClient.PutUserPolicy(input)
+}
+
+func (c *awsClient) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	return c.iamClient.GetRole(input)
 }
 
 func (c *awsClient) GetUserPolicy(input *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
@@ -135,6 +151,10 @@ func (c *awsClient) CreateOpenIDConnectProvider(input *iam.CreateOpenIDConnectPr
 
 func (c *awsClient) TagOpenIDConnectProvider(input *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
 	return c.iamClient.TagOpenIDConnectProvider(input)
+}
+
+func (c *awsClient) UpdateAssumeRolePolicy(input *iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	return c.iamClient.UpdateAssumeRolePolicy(input)
 }
 
 func (c *awsClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {

--- a/pkg/aws/mock/client_generated.go
+++ b/pkg/aws/mock/client_generated.go
@@ -49,6 +49,36 @@ func (mr *MockClientMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockClient)(nil).CreateAccessKey), arg0)
 }
 
+// CreateOpenIDConnectProvider mocks base method
+func (m *MockClient) CreateOpenIDConnectProvider(arg0 *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOpenIDConnectProvider", arg0)
+	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOpenIDConnectProvider indicates an expected call of CreateOpenIDConnectProvider
+func (mr *MockClientMockRecorder) CreateOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).CreateOpenIDConnectProvider), arg0)
+}
+
+// CreateRole mocks base method
+func (m *MockClient) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRole", arg0)
+	ret0, _ := ret[0].(*iam.CreateRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRole indicates an expected call of CreateRole
+func (mr *MockClientMockRecorder) CreateRole(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockClient)(nil).CreateRole), arg0)
+}
+
 // CreateUser mocks base method
 func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
 	m.ctrl.T.Helper()
@@ -109,6 +139,36 @@ func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
 }
 
+// GetOpenIDConnectProvider mocks base method
+func (m *MockClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOpenIDConnectProvider", input)
+	ret0, _ := ret[0].(*iam.GetOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOpenIDConnectProvider indicates an expected call of GetOpenIDConnectProvider
+func (mr *MockClientMockRecorder) GetOpenIDConnectProvider(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).GetOpenIDConnectProvider), input)
+}
+
+// GetRole mocks base method
+func (m *MockClient) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetRole", input)
+	ret0, _ := ret[0].(*iam.GetRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetRole indicates an expected call of GetRole
+func (mr *MockClientMockRecorder) GetRole(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockClient)(nil).GetRole), input)
+}
+
 // GetUser mocks base method
 func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
 	m.ctrl.T.Helper()
@@ -122,6 +182,21 @@ func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error)
 func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
+}
+
+// GetUserPolicy mocks base method
+func (m *MockClient) GetUserPolicy(arg0 *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserPolicy", arg0)
+	ret0, _ := ret[0].(*iam.GetUserPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserPolicy indicates an expected call of GetUserPolicy
+func (mr *MockClientMockRecorder) GetUserPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicy", reflect.TypeOf((*MockClient)(nil).GetUserPolicy), arg0)
 }
 
 // ListAccessKeys mocks base method
@@ -139,6 +214,21 @@ func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
 }
 
+// ListOpenIDConnectProviders mocks base method
+func (m *MockClient) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOpenIDConnectProviders", arg0)
+	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOpenIDConnectProviders indicates an expected call of ListOpenIDConnectProviders
+func (mr *MockClientMockRecorder) ListOpenIDConnectProviders(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProviders", reflect.TypeOf((*MockClient)(nil).ListOpenIDConnectProviders), arg0)
+}
+
 // ListUserPolicies mocks base method
 func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
 	m.ctrl.T.Helper()
@@ -154,6 +244,21 @@ func (mr *MockClientMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockClient)(nil).ListUserPolicies), arg0)
 }
 
+// PutRolePolicy mocks base method
+func (m *MockClient) PutRolePolicy(arg0 *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutRolePolicy", arg0)
+	ret0, _ := ret[0].(*iam.PutRolePolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutRolePolicy indicates an expected call of PutRolePolicy
+func (mr *MockClientMockRecorder) PutRolePolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicy", reflect.TypeOf((*MockClient)(nil).PutRolePolicy), arg0)
+}
+
 // PutUserPolicy mocks base method
 func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
 	m.ctrl.T.Helper()
@@ -167,21 +272,6 @@ func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPo
 func (mr *MockClientMockRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicy", reflect.TypeOf((*MockClient)(nil).PutUserPolicy), arg0)
-}
-
-// GetUserPolicy mocks base method
-func (m *MockClient) GetUserPolicy(arg0 *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserPolicy", arg0)
-	ret0, _ := ret[0].(*iam.GetUserPolicyOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserPolicy indicates an expected call of GetUserPolicy
-func (mr *MockClientMockRecorder) GetUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicy", reflect.TypeOf((*MockClient)(nil).GetUserPolicy), arg0)
 }
 
 // SimulatePrincipalPolicy mocks base method
@@ -213,51 +303,6 @@ func (mr *MockClientMockRecorder) SimulatePrincipalPolicyPages(arg0, arg1 interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyPages", reflect.TypeOf((*MockClient)(nil).SimulatePrincipalPolicyPages), arg0, arg1)
 }
 
-// TagUser mocks base method
-func (m *MockClient) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "TagUser", arg0)
-	ret0, _ := ret[0].(*iam.TagUserOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// TagUser indicates an expected call of TagUser
-func (mr *MockClientMockRecorder) TagUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagUser", reflect.TypeOf((*MockClient)(nil).TagUser), arg0)
-}
-
-// ListOpenIDConnectProviders mocks base method
-func (m *MockClient) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenIDConnectProviders", arg0)
-	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListOpenIDConnectProviders indicates an expected call of ListOpenIDConnectProviders
-func (mr *MockClientMockRecorder) ListOpenIDConnectProviders(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProviders", reflect.TypeOf((*MockClient)(nil).ListOpenIDConnectProviders), arg0)
-}
-
-// CreateOpenIDConnectProvider mocks base method
-func (m *MockClient) CreateOpenIDConnectProvider(arg0 *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateOpenIDConnectProvider", arg0)
-	ret0, _ := ret[0].(*iam.CreateOpenIDConnectProviderOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateOpenIDConnectProvider indicates an expected call of CreateOpenIDConnectProvider
-func (mr *MockClientMockRecorder) CreateOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).CreateOpenIDConnectProvider), arg0)
-}
-
 // TagOpenIDConnectProvider mocks base method
 func (m *MockClient) TagOpenIDConnectProvider(arg0 *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
 	m.ctrl.T.Helper()
@@ -273,19 +318,34 @@ func (mr *MockClientMockRecorder) TagOpenIDConnectProvider(arg0 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).TagOpenIDConnectProvider), arg0)
 }
 
-// GetOpenIDConnectProvider mocks base method
-func (m *MockClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
+// TagUser mocks base method
+func (m *MockClient) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOpenIDConnectProvider", input)
-	ret0, _ := ret[0].(*iam.GetOpenIDConnectProviderOutput)
+	ret := m.ctrl.Call(m, "TagUser", arg0)
+	ret0, _ := ret[0].(*iam.TagUserOutput)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetOpenIDConnectProvider indicates an expected call of GetOpenIDConnectProvider
-func (mr *MockClientMockRecorder) GetOpenIDConnectProvider(input interface{}) *gomock.Call {
+// TagUser indicates an expected call of TagUser
+func (mr *MockClientMockRecorder) TagUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).GetOpenIDConnectProvider), input)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagUser", reflect.TypeOf((*MockClient)(nil).TagUser), arg0)
+}
+
+// UpdateAssumeRolePolicy mocks base method
+func (m *MockClient) UpdateAssumeRolePolicy(arg0 *iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAssumeRolePolicy", arg0)
+	ret0, _ := ret[0].(*iam.UpdateAssumeRolePolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAssumeRolePolicy indicates an expected call of UpdateAssumeRolePolicy
+func (mr *MockClientMockRecorder) UpdateAssumeRolePolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssumeRolePolicy", reflect.TypeOf((*MockClient)(nil).UpdateAssumeRolePolicy), arg0)
 }
 
 // CreateBucket mocks base method

--- a/pkg/cmd/provisioning/constants.go
+++ b/pkg/cmd/provisioning/constants.go
@@ -13,4 +13,16 @@ const (
 	ccoctlAWSResourceTagKeyPrefix = "openshift.io/cloud-credential-operator"
 	// ownedCcoctlAWSResourceTagValue is the value of the tag applied to the AWS resources created by ccoctl
 	ownedCcoctlAWSResourceTagValue = "owned"
+
+	// Generated files
+
+	// identity provider files
+	oidcBucketFilename          = "01-oidc-bucket.json"
+	oidcConfigurationFilename   = "02-openid-configuration"
+	oidcKeysFilename            = "03-keys.json"
+	iamIdentityProviderFilename = "04-iam-identity-provider.json"
+
+	// role files
+	roleFilenameFormat       = "05-%d-%s-role.json"
+	rolePolicyFilenameFormat = "06-%d-%s-policy.json"
 )

--- a/pkg/cmd/provisioning/constants.go
+++ b/pkg/cmd/provisioning/constants.go
@@ -11,8 +11,6 @@ const (
 	keysURI = "keys.json"
 	// ccoctlAWSResourceTagKeyPrefix is the prefix of the tag key applied to the AWS resources created/shared by ccoctl
 	ccoctlAWSResourceTagKeyPrefix = "openshift.io/cloud-credential-operator"
-	// sharedCcoctlAWSResourceTagValue is the value of the tag applied to the AWS resources shared by ccoctl
-	sharedCcoctlAWSResourceTagValue = "shared"
 	// ownedCcoctlAWSResourceTagValue is the value of the tag applied to the AWS resources created by ccoctl
 	ownedCcoctlAWSResourceTagValue = "owned"
 )

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -13,7 +13,7 @@ type options struct {
 	PublicKeyPath string
 	Region        string
 	NamePrefix    string
-	GenerateOnly  bool
+	DryRun        bool
 }
 
 var (

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -9,11 +9,13 @@ import (
 )
 
 type options struct {
-	TargetDir     string
-	PublicKeyPath string
-	Region        string
-	NamePrefix    string
-	DryRun        bool
+	TargetDir           string
+	PublicKeyPath       string
+	Region              string
+	NamePrefix          string
+	CredRequestDir      string
+	IdentityProviderARN string
+	DryRun              bool
 }
 
 var (
@@ -35,6 +37,7 @@ func NewCreateCmd() *cobra.Command {
 
 	createCmd.AddCommand(NewKeyProvision())
 	createCmd.AddCommand(NewIdentityProviderSetup())
+	createCmd.AddCommand(NewIAMRolesSetup())
 
 	return createCmd
 }

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -13,6 +13,7 @@ type options struct {
 	PublicKeyPath string
 	Region        string
 	NamePrefix    string
+	GenerateOnly  bool
 }
 
 var (

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -12,7 +12,7 @@ type options struct {
 	TargetDir     string
 	PublicKeyPath string
 	Region        string
-	InfraName     string
+	NamePrefix    string
 }
 
 var (

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -306,10 +306,7 @@ func identityProviderCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	awsClient := &aws.AWSClient{
-		IAMClient: iam.New(s),
-		S3Client:  s3.New(s),
-	}
+	awsClient := aws.NewClientFromSession(s)
 
 	err = createIdentityProvider(awsClient, CreateOpts.InfraName, CreateOpts.Region, CreateOpts.PublicKeyPath, CreateOpts.TargetDir)
 	if err != nil {

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -65,7 +65,7 @@ type JSONWebKeySet struct {
 }
 
 func createIdentityProvider(client aws.Client, namePrefix, region, publicKeyPath, targetDir string) error {
-	bucketName := fmt.Sprintf("%s-installer", namePrefix)
+	bucketName := fmt.Sprintf("%s-oidc", namePrefix)
 	issuerURL := fmt.Sprintf("https://%s.s3.%s.amazonaws.com", bucketName, region)
 
 	var bucketTagValue string

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -454,7 +454,7 @@ func NewIdentityProviderSetup() *cobra.Command {
 		Run: identityProviderCmd,
 	}
 
-	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.NamePrefix, "name-prefix", "", "Name prefix for all created AWS resources")
+	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.NamePrefix, "name-prefix", "", "User-defined name prefix for all created AWS resources (can be separate from the cluster's infra-id)")
 	identityProviderSetupCmd.MarkPersistentFlagRequired("name-prefix")
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
 	identityProviderSetupCmd.MarkPersistentFlagRequired("region")

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -12,6 +12,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 
@@ -308,7 +309,12 @@ func identityProviderCmd(cmd *cobra.Command, args []string) {
 
 	awsClient := aws.NewClientFromSession(s)
 
-	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, CreateOpts.PublicKeyPath, CreateOpts.TargetDir)
+	publicKeyPath := CreateOpts.PublicKeyPath
+	if publicKeyPath == "" {
+		publicKeyPath = path.Join(CreateOpts.TargetDir, publicKeyFile)
+	}
+
+	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -325,8 +331,7 @@ func NewIdentityProviderSetup() *cobra.Command {
 	identityProviderSetupCmd.MarkPersistentFlagRequired("name-prefix")
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
 	identityProviderSetupCmd.MarkPersistentFlagRequired("region")
-	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.PublicKeyPath, "public-key", "", "Path to public ServiceAccount signing key")
-	identityProviderSetupCmd.MarkPersistentFlagRequired("public-key")
+	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.PublicKeyPath, "public-key-file", "", "Path to public ServiceAccount signing key")
 
 	return identityProviderSetupCmd
 }

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -447,7 +447,7 @@ func identityProviderCmd(cmd *cobra.Command, args []string) {
 		publicKeyPath = path.Join(CreateOpts.TargetDir, publicKeyFile)
 	}
 
-	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir, CreateOpts.GenerateOnly)
+	err = createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir, CreateOpts.DryRun)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -465,7 +465,7 @@ func NewIdentityProviderSetup() *cobra.Command {
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
 	identityProviderSetupCmd.MarkPersistentFlagRequired("region")
 	identityProviderSetupCmd.PersistentFlags().StringVar(&CreateOpts.PublicKeyPath, "public-key-file", "", "Path to public ServiceAccount signing key")
-	identityProviderSetupCmd.PersistentFlags().BoolVar(&CreateOpts.GenerateOnly, "generate-files-only", false, "Skip creating objects, and just save what would have been created into files")
+	identityProviderSetupCmd.PersistentFlags().BoolVar(&CreateOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
 
 	return identityProviderSetupCmd
 }

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -39,12 +39,6 @@ var (
 		PublicKeyPath: "",
 	}
 
-	// Generated files
-	oidcBucketFilename          = "01-oidc-bucket.json"
-	oidcConfigurationFilename   = "02-openid-configuration"
-	oidcKeysFilename            = "03-keys.json"
-	iamIdentityProviderFilename = "04-iam-identity-provider.json"
-
 	// discoveryDocumentTemplate is a template of the discovery document that needs to be populated with appropriate values
 	discoveryDocumentTemplate = `{
 	"issuer": "%s",

--- a/pkg/cmd/provisioning/keypair.go
+++ b/pkg/cmd/provisioning/keypair.go
@@ -28,13 +28,13 @@ func createKeys(prefixDir string) error {
 	log.Print("Generating RSA keypair")
 	privateKey, err := rsa.GenerateKey(rand.Reader, bitSize)
 	if err != nil {
-		return errors.Wrap(err, "Failed to generate private key")
+		return errors.Wrap(err, "failed to generate private key")
 	}
 
 	log.Print("Writing private key to ", privateKeyFilePath)
 	f, err := os.Create(privateKeyFilePath)
 	if err != nil {
-		return errors.Wrap(err, "Failed to create private key file")
+		return errors.Wrap(err, "failed to create private key file")
 	}
 
 	err = pem.Encode(f, &pem.Block{
@@ -44,18 +44,18 @@ func createKeys(prefixDir string) error {
 	})
 	f.Close()
 	if err != nil {
-		return errors.Wrap(err, "Failed to write out private key data")
+		return errors.Wrap(err, "failed to write out private key data")
 	}
 
 	log.Print("Writing public key to ", publicKeyFilePath)
 	f, err = os.Create(publicKeyFilePath)
 	if err != nil {
-		errors.Wrap(err, "Failed to create public key file")
+		errors.Wrap(err, "failed to create public key file")
 	}
 
 	pubKeyBytes, err := x509.MarshalPKIXPublicKey(&privateKey.PublicKey)
 	if err != nil {
-		errors.Wrap(err, "Failed to generate public key from private")
+		errors.Wrap(err, "failed to generate public key from private")
 	}
 
 	err = pem.Encode(f, &pem.Block{
@@ -65,7 +65,7 @@ func createKeys(prefixDir string) error {
 	})
 	f.Close()
 	if err != nil {
-		errors.Wrap(err, "Failed to write out public key data")
+		errors.Wrap(err, "failed to write out public key data")
 	}
 	return nil
 }

--- a/pkg/cmd/provisioning/roles.go
+++ b/pkg/cmd/provisioning/roles.go
@@ -323,13 +323,13 @@ func NewIAMRolesSetup() *cobra.Command {
 		Run: iamRolesCmd,
 	}
 
-	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.NamePrefix, "name-prefix", "", "Name prefix for all created AWS resources")
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.NamePrefix, "name-prefix", "", "User-define name prefix for all created AWS resources (can be separate from the cluster's infra-id)")
 	iamRolesSetupCmd.MarkPersistentFlagRequired("name-prefix")
 	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
 	iamRolesSetupCmd.MarkPersistentFlagRequired("region")
-	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to create IAM Roles for")
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to create IAM Roles for (can be created by running 'oc adm release extract --credentials-requests --cloud=aws' against an OpenShift release image)")
 	iamRolesSetupCmd.MarkPersistentFlagRequired("credentials-requests-dir")
-	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.IdentityProviderARN, "identity-provider-arn", "", "ARN of IAM Identity provider for IAM Role trust relationship")
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.IdentityProviderARN, "identity-provider-arn", "", "ARN of IAM Identity provider for IAM Role trust relationship (can be created with the 'create identity-provider' sub-command)")
 	iamRolesSetupCmd.MarkPersistentFlagRequired("identity-provider-arn")
 	iamRolesSetupCmd.PersistentFlags().BoolVar(&CreateOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
 

--- a/pkg/cmd/provisioning/roles.go
+++ b/pkg/cmd/provisioning/roles.go
@@ -1,0 +1,337 @@
+package provisioning
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	"k8s.io/apimachinery/pkg/util/yaml"
+
+	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/aws"
+)
+
+const (
+	rolePolicyDocmentTemplate = `{ "Version": "2012-10-17", "Statement": [ { "Effect": "Allow", "Principal": { "Federated": "%s" }, "Action": "sts:AssumeRoleWithWebIdentity", "Condition": %s } ] }`
+
+	roleTemplate = `{
+	"RoleName": "%s",
+	"AssumeRolePolicyDocument": "%s",
+	"Description": "%s"
+}`
+
+	rolePolicyTemplate = `{
+	"RoleName": "%s",
+	"PolicyName": "%s",
+	"PolicyDocument": "%s"
+}`
+)
+
+func createIAMRoles(client aws.Client, identityProviderARN, namePrefix, credReqDir, targetDir string, generateOnly bool) error {
+	// Process directory
+	credRequests, err := getListOfCredentialsRequests(credReqDir)
+	if err != nil {
+		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
+	}
+
+	// Create IAM Roles (with policies)
+	if err := processCredentialsRequests(client, credRequests, identityProviderARN, namePrefix, targetDir, generateOnly); err != nil {
+		return errors.Wrap(err, "Failed while processing each CredentialsRequest")
+	}
+
+	return nil
+}
+
+func processCredentialsRequests(awsClient aws.Client, credReqs []*credreqv1.CredentialsRequest, identityProviderARN, namePrefix, targetDir string, generateOnly bool) error {
+
+	issuerURL, err := getIssuerURLFromIdentityProvider(awsClient, identityProviderARN)
+	if err != nil {
+		return err
+	}
+
+	for i, cr := range credReqs {
+		// infraName-targetNamespace-targetSecretName
+		_, err = createRole(awsClient, namePrefix, cr, i, identityProviderARN, issuerURL, targetDir, generateOnly)
+		if err != nil {
+			return err
+		}
+
+	}
+	return nil
+}
+
+func createRole(awsClient aws.Client, namePrefix string, credReq *credreqv1.CredentialsRequest, roleNum int, oidcProviderARN, issuerURL, targetDir string, generateOnly bool) (string, error) {
+	roleName := fmt.Sprintf("%s-%s-%s", namePrefix, credReq.Spec.SecretRef.Namespace, credReq.Spec.SecretRef.Name)
+
+	// Decode AWSProviderSpec
+	codec, err := credreqv1.NewCodec()
+	if err != nil {
+		return "", errors.Wrap(err, "Failed to create credReq codec")
+	}
+
+	awsProviderSpec := credreqv1.AWSProviderSpec{}
+	if err := codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &awsProviderSpec); err != nil {
+		return "", errors.Wrap(err, "Failed to decode the provider spec")
+	}
+
+	if awsProviderSpec.Kind != "AWSProviderSpec" {
+		return "", fmt.Errorf("CredentialsRequest %s/%s is not of type AWS", credReq.Namespace, credReq.Name)
+	}
+
+	// Ensure role name is no longer than 64 charactters
+	var shortenedRoleName string
+	if len(roleName) > 64 {
+		shortenedRoleName = roleName[0:64]
+	} else {
+		shortenedRoleName = roleName
+	}
+
+	rolePolicyDocument, err := createRolePolicyDocument(oidcProviderARN, issuerURL, credReq.Spec.ServiceAccountNames)
+	if err != nil {
+		return "", errors.Wrap(err, "Error while create Role policy document")
+	}
+
+	roleDescription := fmt.Sprintf("OpenShift role for %s/%s", credReq.Spec.SecretRef.Namespace, credReq.Spec.SecretRef.Name)
+
+	rolePolicy := createRolePolicy(awsProviderSpec.StatementEntries)
+
+	if generateOnly {
+		// Generate Role
+		// Need to escape all the double quotes in the generated JSON rolePolicyDocument
+		// so that the JSON text file is valid
+		escapedRolePolicyDoc := strings.Replace(rolePolicyDocument, "\"", "\\\"", -1)
+		roleJSON := fmt.Sprintf(roleTemplate, shortenedRoleName, escapedRolePolicyDoc, roleDescription)
+		roleFilename := fmt.Sprintf(roleFilenameFormat, roleNum, roleName)
+		roleFullPath := filepath.Join(targetDir, roleFilename)
+		if err := saveToFile(roleDescription, roleFullPath, []byte(roleJSON)); err != nil {
+			return "", errors.Wrap(err, "failed to save Role content JSON")
+		}
+
+		// Generate Role Policy
+		escapedRolePolicy := strings.Replace(rolePolicy, "\"", "\\\"", -1)
+		rolePolicyJSON := fmt.Sprintf(rolePolicyTemplate, shortenedRoleName, shortenedRoleName, escapedRolePolicy)
+		rolePolicyFilename := fmt.Sprintf(rolePolicyFilenameFormat, roleNum, roleName)
+		rolePolicyFullPath := filepath.Join(targetDir, rolePolicyFilename)
+		if err := saveToFile(roleDescription, rolePolicyFullPath, []byte(rolePolicyJSON)); err != nil {
+			return "", errors.Wrap(err, "failed to save Role Policy content JSON")
+		}
+
+	} else {
+		var role *iam.Role
+		outRole, err := awsClient.GetRole(&iam.GetRoleInput{
+			RoleName: awssdk.String(shortenedRoleName),
+		})
+
+		if err != nil {
+			var aerr awserr.Error
+			if errors.As(err, &aerr) {
+				switch aerr.Code() {
+				case iam.ErrCodeNoSuchEntityException:
+
+					roleOutput, err := awsClient.CreateRole(&iam.CreateRoleInput{
+						RoleName:                 awssdk.String(shortenedRoleName),
+						Description:              awssdk.String(roleDescription),
+						AssumeRolePolicyDocument: awssdk.String(rolePolicyDocument),
+						Tags: []*iam.Tag{
+							{
+								Key:   awssdk.String(fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, namePrefix)),
+								Value: awssdk.String(ownedCcoctlAWSResourceTagValue),
+							},
+						},
+					})
+					if err != nil {
+						return "", errors.Wrap(err, "Failed to create role")
+					}
+
+					role = roleOutput.Role
+					log.Printf("Role %s created", *role.Arn)
+
+				default:
+					return "", err
+				}
+
+			}
+		} else {
+			role = outRole.Role
+			log.Printf("Existing role %s found", *role.Arn)
+
+			// TODO: implement idemponent apply/update for role
+			_, err = awsClient.UpdateAssumeRolePolicy(&iam.UpdateAssumeRolePolicyInput{
+				RoleName:       role.RoleName,
+				PolicyDocument: awssdk.String(rolePolicyDocument),
+			})
+			if err != nil {
+				return "", errors.Wrap(err, "Faled to update Role Policy")
+			}
+			log.Printf("Updated Role policy document for role %s", *role.RoleName)
+		}
+
+		_, err = awsClient.PutRolePolicy(&iam.PutRolePolicyInput{
+			PolicyName:     awssdk.String(shortenedRoleName),
+			RoleName:       role.RoleName,
+			PolicyDocument: awssdk.String(rolePolicy),
+		})
+		if err != nil {
+			return "", errors.Wrap(err, "Failed to put role policy")
+		}
+		log.Printf("Updated Role policy for Role %s", *role.RoleName)
+	}
+
+	return "", nil
+}
+
+func createRolePolicyDocument(oidcProviderARN, issuerURL string, serviceAccountNames []string) (string, error) {
+	var conditionString string
+	if len(serviceAccountNames) > 0 {
+		var serviceAccountListString string
+		for i, sa := range serviceAccountNames {
+			if i == 0 {
+				serviceAccountListString = fmt.Sprintf(`[ "system:serviceaccount:%s:%s" `, sa, sa)
+			} else {
+				serviceAccountListString = fmt.Sprintf(`%s , "system:serviceaccount:%s:%s"`, serviceAccountListString, sa, sa)
+			}
+		}
+		serviceAccountListString += " ]"
+
+		conditionString = fmt.Sprintf(` { "StringEquals": { "%s:sub": %s } }`, issuerURL, serviceAccountListString)
+	} else {
+		// TODO: maybe return an error once all CredentialsRequest start including ServiceAccountNames
+		conditionString = fmt.Sprintf(`{ "StringEquals": { "%s:aud": "openshift" } }`, issuerURL)
+	}
+	policy := fmt.Sprintf(rolePolicyDocmentTemplate, oidcProviderARN, conditionString)
+
+	return policy, nil
+}
+
+func getListOfCredentialsRequests(dir string) ([]*credreqv1.CredentialsRequest, error) {
+	credRequests := []*credreqv1.CredentialsRequest{}
+	files, err := ioutil.ReadDir(dir)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, file := range files {
+		f, err := os.Open(filepath.Join(dir, file.Name()))
+		if err != nil {
+			return nil, errors.Wrap(err, "Failed to open file")
+		}
+		defer f.Close()
+		decoder := yaml.NewYAMLOrJSONDecoder(f, 4096)
+		for {
+			cr := &credreqv1.CredentialsRequest{}
+			if err := decoder.Decode(cr); err != nil {
+				if err == io.EOF {
+					break
+				}
+				return nil, errors.Wrap(err, "Failed to decode to CredentialsRequest")
+			}
+			credRequests = append(credRequests, cr)
+		}
+
+	}
+
+	return credRequests, nil
+}
+
+func getIssuerURLFromIdentityProvider(awsClient aws.Client, idProviderARN string) (string, error) {
+	idProvider, err := awsClient.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{
+		OpenIDConnectProviderArn: awssdk.String(idProviderARN),
+	})
+
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get IAM Identity Provider")
+	}
+
+	return *idProvider.Url, nil
+}
+
+func iamRolesCmd(cmd *cobra.Command, args []string) {
+	cfg := &awssdk.Config{
+		Region: awssdk.String(CreateOpts.Region),
+	}
+
+	s, err := session.NewSession(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	awsClient := aws.NewClientFromSession(s)
+
+	err = createIAMRoles(awsClient, CreateOpts.IdentityProviderARN, CreateOpts.NamePrefix, CreateOpts.CredRequestDir, CreateOpts.TargetDir, CreateOpts.DryRun)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+// StatementEntry is a simple type used to serialize to AWS' PolicyDocument format.
+type StatementEntry struct {
+	Effect   string
+	Action   []string
+	Resource string
+	// Must "omitempty" otherwise we send unacceptable JSON to the AWS API when no
+	// condition is defined.
+	Condition credreqv1.IAMPolicyCondition `json:",omitempty"`
+}
+
+// PolicyDocument is a simple type used to serialize to AWS' PolicyDocument format.
+type PolicyDocument struct {
+	Version   string
+	Statement []StatementEntry
+}
+
+func createRolePolicy(statements []credreqv1.StatementEntry) string {
+	policyDocument := PolicyDocument{
+		Version:   "2012-10-17",
+		Statement: []StatementEntry{},
+	}
+
+	for _, entry := range statements {
+		policyDocument.Statement = append(policyDocument.Statement,
+			StatementEntry{
+				Effect:    entry.Effect,
+				Action:    entry.Action,
+				Resource:  entry.Resource,
+				Condition: entry.PolicyCondition,
+			})
+	}
+
+	b, err := json.Marshal(&policyDocument)
+	if err != nil {
+		log.Fatalf("Failed to marshal the policy to JSON: %s", err)
+	}
+
+	return string(b)
+}
+
+// NewIAMRolesSetup provides the "create iam-roles" subcommand
+func NewIAMRolesSetup() *cobra.Command {
+	iamRolesSetupCmd := &cobra.Command{
+		Use: "iam-roles",
+		Run: iamRolesCmd,
+	}
+
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.NamePrefix, "name-prefix", "", "Name prefix for all created AWS resources")
+	iamRolesSetupCmd.MarkPersistentFlagRequired("name-prefix")
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
+	iamRolesSetupCmd.MarkPersistentFlagRequired("region")
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to create IAM Roles for")
+	iamRolesSetupCmd.MarkPersistentFlagRequired("credentials-requests-dir")
+	iamRolesSetupCmd.PersistentFlags().StringVar(&CreateOpts.IdentityProviderARN, "identity-provider-arn", "", "ARN of IAM Identity provider for IAM Role trust relationship")
+	iamRolesSetupCmd.MarkPersistentFlagRequired("identity-provider-arn")
+	iamRolesSetupCmd.PersistentFlags().BoolVar(&CreateOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
+
+	return iamRolesSetupCmd
+}

--- a/pkg/cmd/provisioning/roles_test.go
+++ b/pkg/cmd/provisioning/roles_test.go
@@ -1,0 +1,278 @@
+package provisioning
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/awserr"
+	"github.com/aws/aws-sdk-go/service/iam"
+
+	mockaws "github.com/openshift/cloud-credential-operator/pkg/aws/mock"
+)
+
+const (
+	testIdentityProviderARN = "arn:aws:iam::123456789012:oidc-provider/testing123-oidc.s3.amazonaws.com"
+	testIdentityProviderURL = "testing123-oidc.s3.amazonaws.com"
+	testNamePrefix          = "test-cluster1"
+)
+
+func TestIAMRoles(t *testing.T) {
+
+	tests := []struct {
+		name          string
+		mockAWSClient func(mockCtrl *gomock.Controller) *mockaws.MockClient
+		setup         func(*testing.T) string
+		verify        func(t *testing.T, tempDirName string)
+		cleanup       func(*testing.T)
+		generateOnly  bool
+		expectError   bool
+	}{
+		{
+			name:         "No CredReqs",
+			generateOnly: true,
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetOpenIDConnectProvider(mockAWSClient)
+				return mockAWSClient
+			},
+			setup: func(t *testing.T) string {
+				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory")
+				return tempDirName
+			},
+			verify: func(t *testing.T, targetDir string) {
+				files, err := ioutil.ReadDir(targetDir)
+				require.NoError(t, err, "unexpected error listing files in targetDir")
+
+				assert.Zero(t, len(files), "Should be no files in targetDir when no CredReqs to process")
+
+			},
+		},
+		{
+			name:         "Generate for one CredReq",
+			generateOnly: true,
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetOpenIDConnectProvider(mockAWSClient)
+				return mockAWSClient
+			},
+			setup: func(t *testing.T) string {
+				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory")
+
+				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
+				require.NoError(t, err, "errored while setting up test CredReq files")
+
+				return tempDirName
+			},
+			verify: func(t *testing.T, targetDir string) {
+				files, err := ioutil.ReadDir(targetDir)
+				require.NoError(t, err, "unexpected error listing files in targetDir")
+
+				assert.Equal(t, 2, len(files), "Should be exactly 1 IAM Role JSON and 1 IAM Role Policy file for each CredReq")
+
+			},
+		},
+		{
+			name:         "Create for one CredReq",
+			generateOnly: false,
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetOpenIDConnectProvider(mockAWSClient)
+				mockGetRole(mockAWSClient)
+				roleName := fmt.Sprintf("%s-namespace1-secretName1", testNamePrefix)
+				mockCreateRole(mockAWSClient, roleName)
+				mockPutRolePolicy(mockAWSClient)
+				return mockAWSClient
+			},
+			setup: func(t *testing.T) string {
+				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory")
+
+				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
+				require.NoError(t, err, "errored while setting up test CredReq files")
+
+				return tempDirName
+			},
+			verify: func(t *testing.T, targetDir string) {
+				files, err := ioutil.ReadDir(targetDir)
+				require.NoError(t, err, "unexpected error listing files in targetDir")
+
+				assert.Zero(t, len(files), "Should be no generated files when not in generate mode")
+
+			},
+		},
+		{
+			name:         "failed to create Role",
+			expectError:  true,
+			generateOnly: false,
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetOpenIDConnectProvider(mockAWSClient)
+				mockGetRole(mockAWSClient)
+				roleName := fmt.Sprintf("%s-namespace1-secretName1", testNamePrefix)
+				mockFailedCreateRole(mockAWSClient, roleName)
+				return mockAWSClient
+			},
+			setup: func(t *testing.T) string {
+				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory")
+
+				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
+				require.NoError(t, err, "errored while setting up test CredReq files")
+
+				return tempDirName
+			},
+			verify: func(t *testing.T, targetDir string) {},
+		},
+		{
+			name:         "Role already exists",
+			generateOnly: false,
+			mockAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
+				mockAWSClient := mockaws.NewMockClient(mockCtrl)
+				mockGetOpenIDConnectProvider(mockAWSClient)
+				roleName := fmt.Sprintf("%s-namespace1-secretName1", testNamePrefix)
+				mockGetRoleExists(mockAWSClient, roleName)
+				mockUpdateAssumeRolePolicy(mockAWSClient)
+				mockPutRolePolicy(mockAWSClient)
+				return mockAWSClient
+			},
+			setup: func(t *testing.T) string {
+				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory")
+
+				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
+				require.NoError(t, err, "errored while setting up test CredReq files")
+
+				return tempDirName
+			},
+			verify: func(t *testing.T, targetDir string) {},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mockCtrl := gomock.NewController(t)
+			defer mockCtrl.Finish()
+
+			mockAWSClient := test.mockAWSClient(mockCtrl)
+
+			credReqDir := test.setup(t)
+			defer os.RemoveAll(credReqDir)
+
+			targetDir, err := ioutil.TempDir(os.TempDir(), "iamroletest")
+			require.NoError(t, err, "unexpected error creating temp dir for test")
+
+			err = createIAMRoles(mockAWSClient, testIdentityProviderARN, testNamePrefix, credReqDir, targetDir, test.generateOnly)
+
+			if test.expectError {
+				require.Error(t, err, "expected error returned")
+			} else {
+				test.verify(t, targetDir)
+			}
+		})
+	}
+}
+
+func testCredentialsRequest(t *testing.T, crName, targetSecretNamespace, targetSecretName, targetDir string) error {
+	credReqTemplate := `---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: %s
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - ec2:DescribeInstances
+      effect: Allow
+      resource: '*'
+    - action:
+      - kms:Decrypt
+      - kms:Encrypt
+      - kms:GenerateDataKey
+      - kms:GenerateDataKeyWithoutPlainText
+      - kms:DescribeKey
+      effect: Allow
+      resource: '*'
+  secretRef:
+    namespace: %s
+    name: %s
+  serviceAccountNames:
+  - testServiceAccount1
+  - testServiceAccount2`
+
+	credReq := fmt.Sprintf(credReqTemplate, crName, targetSecretNamespace, targetSecretName)
+
+	f, err := ioutil.TempFile(targetDir, "testCredReq")
+	require.NoError(t, err, "error creating temp file for CredentialsRequest")
+	defer f.Close()
+
+	_, err = f.Write([]byte(credReq))
+	require.NoError(t, err, "error while writing out contents of CredentialsRequest file")
+
+	return nil
+}
+
+func mockGetOpenIDConnectProvider(mockAWSClient *mockaws.MockClient) {
+	mockAWSClient.EXPECT().GetOpenIDConnectProvider(gomock.Any()).Return(
+		&iam.GetOpenIDConnectProviderOutput{
+			Url: awssdk.String(testIdentityProviderURL),
+		}, nil).AnyTimes()
+}
+
+func mockGetRole(mockAWSClient *mockaws.MockClient) {
+	mockAWSClient.EXPECT().GetRole(gomock.Any()).Return(
+		nil, awserr.New(iam.ErrCodeNoSuchEntityException, "Role does not exist", fmt.Errorf("fake error")),
+	).Times(1)
+}
+
+func mockGetRoleExists(mockAWSClient *mockaws.MockClient, roleName string) {
+	mockAWSClient.EXPECT().GetRole(gomock.Any()).Return(
+		&iam.GetRoleOutput{
+			Role: &iam.Role{
+				Arn:      awssdk.String("test-role-arn"),
+				RoleName: awssdk.String(roleName),
+			},
+		}, nil,
+	).Times(1)
+}
+
+func mockCreateRole(mockAWSClient *mockaws.MockClient, roleName string) {
+	mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(
+		&iam.CreateRoleOutput{
+			Role: &iam.Role{
+				Arn:      awssdk.String("test-role-arn"),
+				RoleName: awssdk.String(roleName),
+			},
+		}, nil,
+	).Times(1)
+}
+
+func mockFailedCreateRole(mockAWSClient *mockaws.MockClient, roleName string) {
+	mockAWSClient.EXPECT().CreateRole(gomock.Any()).Return(
+		&iam.CreateRoleOutput{}, fmt.Errorf("test error on role create"),
+	).Times(1)
+}
+
+func mockPutRolePolicy(mockAWSClient *mockaws.MockClient) {
+	mockAWSClient.EXPECT().PutRolePolicy(gomock.Any()).Return(
+		&iam.PutRolePolicyOutput{}, nil,
+	).Times(1)
+}
+
+func mockUpdateAssumeRolePolicy(mockAWSClient *mockaws.MockClient) {
+	mockAWSClient.EXPECT().UpdateAssumeRolePolicy(gomock.Any()).Return(
+		&iam.UpdateAssumeRolePolicyOutput{}, nil,
+	).Times(1)
+}


### PR DESCRIPTION
This will take a directory with files representing the
CredentialsRequests that need IAM Roles/Policies created and the AWS IAM
Identity Provider ARN and create/update the Roles.

It also supports a '--generate-files-only' param which will place JSON
files of the IAM Roles and the IAM Role Policies that would have been
created (these can be used with the aws cli with the --cli-input-json
parameter).

Also, add make target for running 'go generate' (to update mock clients)

xref: https://issues.redhat.com/browse/CCO-70