### PR TITLE
manifests/0000_90_cloud-credential-operator_04_alertrules: Drop CloudCredentialOperatorDown

### DIFF
--- a/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
+++ b/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
@@ -42,10 +42,3 @@ spec:
       for: 5m
       labels:
         severity: warning
-    - alert: CloudCredentialOperatorDown
-      annotations:
-        message: cloud-credential-operator pod not running
-      expr: absent(up{job="cco-metrics"} == 1)
-      for: 20m
-      labels:
-        severity: critical


### PR DESCRIPTION
The cluster-version operator is responsible for complaining if the cloud-cred operator's deployment is sad, so no need for the operator to handle this directly (we end up doubling up if there's an issue).