### PR TITLE
Bug 1927017: Context cancel on stopped leading

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -156,7 +156,7 @@ func NewOperator() *cobra.Command {
 						OnStoppedLeading: func() {
 							// we can do cleanup here if necessary
 							leLog.Infof("leader lost")
-							os.Exit(0)
+							cancel()
 						},
 						OnNewLeader: func(identity string) {
 							if identity == id {


### PR DESCRIPTION
Post proxy CA change, pod was not relinquishing its leader election
quickly due to os.exit. Changed it to run cancel context to propagate
the exit cleanly