### PR TITLE
installer manifests and 'all' subcommand

### DIFF
--- a/docs/ccoctl.md
+++ b/docs/ccoctl.md
@@ -47,6 +47,8 @@ $ ccoctl create iam-roles --name-prefix=<name-prefix> --region=<aws-region> --cr
 
 This will create one IAM Role for each CredentialsRequest with a trust policy tied to the provided Identity Provider, and a permissions policy as defined in each CredentialsRequest object from the OpenShift release image.
 
+It will also populate the `<output-dir>/manifests` directory with Secret files for each CredentialsRequest that was processed. These can be provided to the installer so that the appropriate Secrets are available for each in-cluster component needing to make cloud API calls.
+
 ## Deleting resources
 
 To delete resources created by ccoctl, run

--- a/pkg/cmd/provisioning/all.go
+++ b/pkg/cmd/provisioning/all.go
@@ -5,10 +5,12 @@ import (
 	"log"
 	"path"
 
+	"github.com/spf13/cobra"
+
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
+
 	"github.com/openshift/cloud-credential-operator/pkg/aws"
-	"github.com/spf13/cobra"
 )
 
 func allCmd(cmd *cobra.Command, args []string) {

--- a/pkg/cmd/provisioning/all.go
+++ b/pkg/cmd/provisioning/all.go
@@ -1,0 +1,62 @@
+package provisioning
+
+import (
+	"fmt"
+	"log"
+	"path"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/openshift/cloud-credential-operator/pkg/aws"
+	"github.com/spf13/cobra"
+)
+
+func allCmd(cmd *cobra.Command, args []string) {
+	cfg := &awssdk.Config{
+		Region: awssdk.String(CreateOpts.Region),
+	}
+
+	s, err := session.NewSession(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	awsClient := aws.NewClientFromSession(s)
+
+	publicKeyPath := CreateOpts.PublicKeyPath
+	if publicKeyPath == "" {
+		publicKeyPath = path.Join(CreateOpts.TargetDir, publicKeyFile)
+	}
+
+	if err := createKeys(CreateOpts.TargetDir); err != nil {
+		log.Fatalf("Failed to create public/private key pair: %s", err)
+	}
+
+	identityProviderARN, err := createIdentityProvider(awsClient, CreateOpts.NamePrefix, CreateOpts.Region, publicKeyPath, CreateOpts.TargetDir, false)
+	fmt.Printf("ARN: %+v\n", identityProviderARN)
+	if err != nil {
+		log.Fatalf("Failed to create Identity provider: %s", err)
+	}
+
+	err = createIAMRoles(awsClient, identityProviderARN, CreateOpts.NamePrefix, CreateOpts.CredRequestDir, CreateOpts.TargetDir, false)
+	if err != nil {
+		log.Fatalf("Failed to process IAM Roles: %s", err)
+	}
+}
+
+// NewAllSetup provides the "create all" subcommand
+func NewAllSetup() *cobra.Command {
+	allSetupCmd := &cobra.Command{
+		Use: "all",
+		Run: allCmd,
+	}
+
+	allSetupCmd.PersistentFlags().StringVar(&CreateOpts.NamePrefix, "name-prefix", "", "User-defined name prefix for all created AWS resources (can be separate from the cluster's infra-id)")
+	allSetupCmd.MarkPersistentFlagRequired("name-prefix")
+	allSetupCmd.PersistentFlags().StringVar(&CreateOpts.Region, "region", "", "AWS region where the S3 OpenID Connect endpoint will be created")
+	allSetupCmd.MarkPersistentFlagRequired("region")
+	allSetupCmd.PersistentFlags().StringVar(&CreateOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to create IAM Roles for (can be created by running 'oc adm release extract --credentials-requests --cloud=aws' against an OpenShift release image)")
+	allSetupCmd.MarkPersistentFlagRequired("credentials-requests-dir")
+
+	return allSetupCmd
+}

--- a/pkg/cmd/provisioning/constants.go
+++ b/pkg/cmd/provisioning/constants.go
@@ -25,4 +25,7 @@ const (
 	// role files
 	roleFilenameFormat       = "05-%d-%s-role.json"
 	rolePolicyFilenameFormat = "06-%d-%s-policy.json"
+
+	manifestsDirName = "manifests"
+	tlsDirName       = "tls"
 )

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -59,6 +59,7 @@ func initEnv(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to resolve full path: %s", err)
 	}
 
+	// create target dir if necessary
 	sResult, err := os.Stat(fPath)
 	if os.IsNotExist(err) {
 		if err := os.Mkdir(fPath, 0700); err != nil {
@@ -71,5 +72,40 @@ func initEnv(cmd *cobra.Command, args []string) {
 
 	if !sResult.IsDir() {
 		log.Fatalf("File %s exists and is not a directory", fPath)
+	}
+
+	// create manifests dir if necessary
+	manifestsDir := filepath.Join(fPath, manifestsDirName)
+	sResult, err = os.Stat(manifestsDir)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(manifestsDir, 0700); err != nil {
+			log.Fatalf("Failed to create manifests directory: %s", err)
+		}
+		sResult, err = os.Stat(manifestsDir)
+	} else if err != nil {
+		log.Fatalf("Failed to stat: %+v", err)
+	}
+
+	if !sResult.IsDir() {
+		log.Fatalf("File %s exists and is not a directory", manifestsDir)
+	}
+
+	tlsDir := filepath.Join(fPath, tlsDirName)
+	ensureDir(tlsDir)
+}
+
+func ensureDir(path string) {
+	sResult, err := os.Stat(path)
+	if os.IsNotExist(err) {
+		if err := os.Mkdir(path, 0700); err != nil {
+			log.Fatalf("Failed to create directory: %s", err)
+		}
+		sResult, err = os.Stat(path)
+	} else if err != nil {
+		log.Fatalf("Failed to stat: %+v", err)
+	}
+
+	if !sResult.IsDir() {
+		log.Fatalf("File %s exists and is not a directory", path)
 	}
 }

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -39,6 +39,8 @@ func NewCreateCmd() *cobra.Command {
 	createCmd.AddCommand(NewIdentityProviderSetup())
 	createCmd.AddCommand(NewIAMRolesSetup())
 
+	createCmd.AddCommand(NewAllSetup())
+
 	return createCmd
 }
 

--- a/pkg/cmd/provisioning/create.go
+++ b/pkg/cmd/provisioning/create.go
@@ -62,35 +62,11 @@ func initEnv(cmd *cobra.Command, args []string) {
 	}
 
 	// create target dir if necessary
-	sResult, err := os.Stat(fPath)
-	if os.IsNotExist(err) {
-		if err := os.Mkdir(fPath, 0700); err != nil {
-			log.Fatalf("Failed to create directory: %s", err)
-		}
-		sResult, err = os.Stat(fPath)
-	} else if err != nil {
-		log.Fatalf("Failed to stat: %+v", err)
-	}
-
-	if !sResult.IsDir() {
-		log.Fatalf("File %s exists and is not a directory", fPath)
-	}
+	ensureDir(fPath)
 
 	// create manifests dir if necessary
 	manifestsDir := filepath.Join(fPath, manifestsDirName)
-	sResult, err = os.Stat(manifestsDir)
-	if os.IsNotExist(err) {
-		if err := os.Mkdir(manifestsDir, 0700); err != nil {
-			log.Fatalf("Failed to create manifests directory: %s", err)
-		}
-		sResult, err = os.Stat(manifestsDir)
-	} else if err != nil {
-		log.Fatalf("Failed to stat: %+v", err)
-	}
-
-	if !sResult.IsDir() {
-		log.Fatalf("File %s exists and is not a directory", manifestsDir)
-	}
+	ensureDir(manifestsDir)
 
 	tlsDir := filepath.Join(fPath, tlsDirName)
 	ensureDir(tlsDir)

--- a/pkg/cmd/provisioning/identity_provider_test.go
+++ b/pkg/cmd/provisioning/identity_provider_test.go
@@ -162,7 +162,7 @@ func TestCreateIdentityProvider(t *testing.T) {
 
 			testPublicKeyPath := filepath.Join(tempDirName, testPublicKeyFile)
 
-			err := createIdentityProvider(mockAWSClient, testInfraName, testRegionName, testPublicKeyPath, tempDirName, test.generateOnly)
+			_, err := createIdentityProvider(mockAWSClient, testInfraName, testRegionName, testPublicKeyPath, tempDirName, test.generateOnly)
 
 			if test.expectError {
 				require.Error(t, err, "expected error returned")

--- a/pkg/cmd/provisioning/keypair.go
+++ b/pkg/cmd/provisioning/keypair.go
@@ -14,6 +14,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const boundSAKeyFilename = "bound-service-account-signing-key.key"
+
 func createKeys(prefixDir string) error {
 
 	privateKeyFilePath := filepath.Join(prefixDir, privateKeyFile)
@@ -75,7 +77,7 @@ func createKeys(prefixDir string) error {
 }
 
 func copyPrivateKeyForInstaller(sourceFile, prefixDir string) {
-	privateKeyForInstaller := filepath.Join(prefixDir, tlsDirName, "bound-service-account-signing-key.key")
+	privateKeyForInstaller := filepath.Join(prefixDir, tlsDirName, boundSAKeyFilename)
 
 	log.Print("Copying signing key for use by installer")
 	from, err := os.Open(sourceFile)

--- a/pkg/cmd/provisioning/keypair_test.go
+++ b/pkg/cmd/provisioning/keypair_test.go
@@ -41,6 +41,11 @@ func TestKeyPair(t *testing.T) {
 				require.NoError(t, err, "unexpected error reading in test private key data")
 
 				assert.Equal(t, []byte("some data"), fileData, "unexpected change in test private key data")
+
+				tlsFileData, err := ioutil.ReadFile(filepath.Join(tempDirName, tlsDirName, boundSAKeyFilename))
+				require.NoError(t, err, "unexpected error reading in copied file %s/%s", tlsDirName, boundSAKeyFilename)
+
+				assert.Equal(t, []byte("some data"), tlsFileData, "unexpected file contents for %s/%s", tlsDirName, boundSAKeyFilename)
 			},
 		},
 		{
@@ -76,6 +81,11 @@ func TestKeyPair(t *testing.T) {
 				})
 
 				assert.Equal(t, pubFileBytes, calculatedPubKeyBytes, "Missmatch between written public key file and caluclated public key (from private key)")
+
+				tlsFileData, err := ioutil.ReadFile(filepath.Join(tempDirName, tlsDirName, boundSAKeyFilename))
+				require.NoError(t, err, "unexpected error reading in copied file %s/%s", tlsDirName, boundSAKeyFilename)
+
+				assert.Equal(t, privFile, tlsFileData, "unexpected file contents for %s/%s", tlsDirName, boundSAKeyFilename)
 
 			},
 		},

--- a/pkg/cmd/provisioning/keypair_test.go
+++ b/pkg/cmd/provisioning/keypair_test.go
@@ -26,10 +26,9 @@ func TestKeyPair(t *testing.T) {
 		{
 			name: "private key file exists",
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), keypairTestDirPrefix)
-				require.NoError(t, err, "Failed to create temp directory")
+				tempDirName := prepTempDir(t)
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, privateKeyFile), []byte("some data"), 0600)
+				err := ioutil.WriteFile(filepath.Join(tempDirName, privateKeyFile), []byte("some data"), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
@@ -47,8 +46,7 @@ func TestKeyPair(t *testing.T) {
 		{
 			name: "generate keys",
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), keypairTestDirPrefix)
-				require.NoError(t, err, "Failed to create temp directory")
+				tempDirName := prepTempDir(t)
 
 				return tempDirName
 			},
@@ -98,4 +96,16 @@ func TestKeyPair(t *testing.T) {
 			}
 		})
 	}
+}
+
+func prepTempDir(t *testing.T) string {
+	tempDirName, err := ioutil.TempDir(os.TempDir(), keypairTestDirPrefix)
+
+	require.NoError(t, err, "unexpected error setting up temp directory")
+
+	tlsDir := filepath.Join(tempDirName, tlsDirName)
+	err = os.Mkdir(tlsDir, 0770)
+	require.NoError(t, err, "errored trying to create temp tls dir")
+
+	return tempDirName
 }

--- a/pkg/cmd/provisioning/roles.go
+++ b/pkg/cmd/provisioning/roles.go
@@ -282,9 +282,7 @@ func getIssuerURLFromIdentityProvider(awsClient aws.Client, idProviderARN string
 }
 
 func iamRolesCmd(cmd *cobra.Command, args []string) {
-	cfg := &awssdk.Config{
-		//Region: awssdk.String(CreateOpts.Region),
-	}
+	cfg := &awssdk.Config{}
 
 	s, err := session.NewSession(cfg)
 	if err != nil {


### PR DESCRIPTION
generate manifests for installer for identity-provider and iam-roles subcommands
    
place secrets in the --output-dir/manifests directory for each CredentialsRequest being processed.
    
place the Authentication file in --output-dir/manifests during the identity-provider subcommand.

add 'all' subcommand
   
this will create the key-pair, identity-provider, and iam-roles (and all the manifests) all in one pass by sequentially running through the 'key-pair', 'identity-provider', and 'iam-roles' subcommands.

xref: https://issues.redhat.com/browse/CCO-72