### PR TITLE
CCO-73: Add command to delete resources created by ccoctl 

### DIFF
--- a/cmd/ccoctl/main.go
+++ b/cmd/ccoctl/main.go
@@ -17,6 +17,7 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&provisioning.CreateOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
 
 	rootCmd.AddCommand(provisioning.NewCreateCmd())
+	rootCmd.AddCommand(provisioning.NewDeleteCmd())
 
 	if err := rootCmd.Execute(); err != nil {
 		log.Fatal(err)

--- a/docs/ccoctl.md
+++ b/docs/ccoctl.md
@@ -46,3 +46,14 @@ $ ccoctl create iam-roles --name-prefix=<name-prefix> --region=<aws-region> --cr
 ```
 
 This will create one IAM Role for each CredentialsRequest with a trust policy tied to the provided Identity Provider, and a permissions policy as defined in each CredentialsRequest object from the OpenShift release image.
+
+## Deleting resources
+
+To delete resources created by ccoctl, run
+
+```bash
+$ ccoctl delete --name-prefix=<name-prefix> --region=<aws-region>
+
+```
+
+where `name-prefix` is the name used to tag and account cloud resources that were created. `region` is the aws region in which cloud resources were created.

--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -45,10 +45,15 @@ type Client interface {
 	DeleteUserPolicy(*iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error)
 	GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error)
 	GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error)
+	ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error)
+	DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error)
+	ListRolePolicies(input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error)
+	DeleteRolePolicy(input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error)
 	GetUser(*iam.GetUserInput) (*iam.GetUserOutput, error)
 	GetUserPolicy(*iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error)
 	ListAccessKeys(*iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error)
 	ListOpenIDConnectProviders(*iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error)
+	DeleteOpenIDConnectProvider(input *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error)
 	ListUserPolicies(*iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error)
 	PutRolePolicy(*iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error)
 	PutUserPolicy(*iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error)
@@ -61,7 +66,12 @@ type Client interface {
 	//S3
 	CreateBucket(*s3.CreateBucketInput) (*s3.CreateBucketOutput, error)
 	PutBucketTagging(*s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error)
+	GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error)
+	DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error)
 	PutObject(*s3.PutObjectInput) (*s3.PutObjectOutput, error)
+	ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error)
+	GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error)
+	DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error)
 }
 
 // ClientParams holds the various optional tunables that can be used to modify the AWS
@@ -161,6 +171,26 @@ func (c *awsClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProvider
 	return c.iamClient.GetOpenIDConnectProvider(input)
 }
 
+func (c *awsClient) DeleteOpenIDConnectProvider(input *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+	return c.iamClient.DeleteOpenIDConnectProvider(input)
+}
+
+func (c *awsClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
+	return c.iamClient.ListRoles(input)
+}
+
+func (c *awsClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+	return c.iamClient.DeleteRole(input)
+}
+
+func (c *awsClient) ListRolePolicies(input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	return c.iamClient.ListRolePolicies(input)
+}
+
+func (c *awsClient) DeleteRolePolicy(input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	return c.iamClient.DeleteRolePolicy(input)
+}
+
 func (c *awsClient) CreateBucket(input *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
 	return c.s3Client.CreateBucket(input)
 }
@@ -169,8 +199,28 @@ func (c *awsClient) PutBucketTagging(input *s3.PutBucketTaggingInput) (*s3.PutBu
 	return c.s3Client.PutBucketTagging(input)
 }
 
+func (c *awsClient) GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error) {
+	return c.s3Client.GetBucketTagging(input)
+}
+
+func (c *awsClient) DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+	return c.s3Client.DeleteBucket(input)
+}
+
 func (c *awsClient) PutObject(input *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
 	return c.s3Client.PutObject(input)
+}
+
+func (c *awsClient) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+	return c.s3Client.ListObjects(input)
+}
+
+func (c *awsClient) GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error) {
+	return c.s3Client.GetObjectTagging(input)
+}
+
+func (c *awsClient) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	return c.s3Client.DeleteObject(input)
 }
 
 // NewClient creates our client wrapper object for the actual AWS clients we use.

--- a/pkg/aws/mock/client_generated.go
+++ b/pkg/aws/mock/client_generated.go
@@ -169,6 +169,66 @@ func (mr *MockClientMockRecorder) GetRole(input interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockClient)(nil).GetRole), input)
 }
 
+// ListRoles mocks base method
+func (m *MockClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRoles", input)
+	ret0, _ := ret[0].(*iam.ListRolesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRoles indicates an expected call of ListRoles
+func (mr *MockClientMockRecorder) ListRoles(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoles", reflect.TypeOf((*MockClient)(nil).ListRoles), input)
+}
+
+// DeleteRole mocks base method
+func (m *MockClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRole", input)
+	ret0, _ := ret[0].(*iam.DeleteRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRole indicates an expected call of DeleteRole
+func (mr *MockClientMockRecorder) DeleteRole(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockClient)(nil).DeleteRole), input)
+}
+
+// ListRolePolicies mocks base method
+func (m *MockClient) ListRolePolicies(input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRolePolicies", input)
+	ret0, _ := ret[0].(*iam.ListRolePoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRolePolicies indicates an expected call of ListRolePolicies
+func (mr *MockClientMockRecorder) ListRolePolicies(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePolicies", reflect.TypeOf((*MockClient)(nil).ListRolePolicies), input)
+}
+
+// DeleteRolePolicy mocks base method
+func (m *MockClient) DeleteRolePolicy(input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRolePolicy", input)
+	ret0, _ := ret[0].(*iam.DeleteRolePolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRolePolicy indicates an expected call of DeleteRolePolicy
+func (mr *MockClientMockRecorder) DeleteRolePolicy(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePolicy", reflect.TypeOf((*MockClient)(nil).DeleteRolePolicy), input)
+}
+
 // GetUser mocks base method
 func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
 	m.ctrl.T.Helper()
@@ -227,6 +287,21 @@ func (m *MockClient) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvi
 func (mr *MockClientMockRecorder) ListOpenIDConnectProviders(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProviders", reflect.TypeOf((*MockClient)(nil).ListOpenIDConnectProviders), arg0)
+}
+
+// DeleteOpenIDConnectProvider mocks base method
+func (m *MockClient) DeleteOpenIDConnectProvider(input *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOpenIDConnectProvider", input)
+	ret0, _ := ret[0].(*iam.DeleteOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOpenIDConnectProvider indicates an expected call of DeleteOpenIDConnectProvider
+func (mr *MockClientMockRecorder) DeleteOpenIDConnectProvider(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).DeleteOpenIDConnectProvider), input)
 }
 
 // ListUserPolicies mocks base method
@@ -378,6 +453,36 @@ func (mr *MockClientMockRecorder) PutBucketTagging(arg0 interface{}) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBucketTagging", reflect.TypeOf((*MockClient)(nil).PutBucketTagging), arg0)
 }
 
+// GetBucketTagging mocks base method
+func (m *MockClient) GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBucketTagging", input)
+	ret0, _ := ret[0].(*s3.GetBucketTaggingOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBucketTagging indicates an expected call of GetBucketTagging
+func (mr *MockClientMockRecorder) GetBucketTagging(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTagging", reflect.TypeOf((*MockClient)(nil).GetBucketTagging), input)
+}
+
+// DeleteBucket mocks base method
+func (m *MockClient) DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBucket", input)
+	ret0, _ := ret[0].(*s3.DeleteBucketOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteBucket indicates an expected call of DeleteBucket
+func (mr *MockClientMockRecorder) DeleteBucket(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), input)
+}
+
 // PutObject mocks base method
 func (m *MockClient) PutObject(arg0 *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
 	m.ctrl.T.Helper()
@@ -391,4 +496,49 @@ func (m *MockClient) PutObject(arg0 *s3.PutObjectInput) (*s3.PutObjectOutput, er
 func (mr *MockClientMockRecorder) PutObject(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutObject", reflect.TypeOf((*MockClient)(nil).PutObject), arg0)
+}
+
+// ListObjects mocks base method
+func (m *MockClient) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListObjects", input)
+	ret0, _ := ret[0].(*s3.ListObjectsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjects indicates an expected call of ListObjects
+func (mr *MockClientMockRecorder) ListObjects(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockClient)(nil).ListObjects), input)
+}
+
+// GetObjectTagging mocks base method
+func (m *MockClient) GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObjectTagging", input)
+	ret0, _ := ret[0].(*s3.GetObjectTaggingOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetObjectTagging indicates an expected call of GetObjectTagging
+func (mr *MockClientMockRecorder) GetObjectTagging(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectTagging", reflect.TypeOf((*MockClient)(nil).GetObjectTagging), input)
+}
+
+// DeleteObject mocks base method
+func (m *MockClient) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObject", input)
+	ret0, _ := ret[0].(*s3.DeleteObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteObject indicates an expected call of DeleteObject
+func (mr *MockClientMockRecorder) DeleteObject(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockClient)(nil).DeleteObject), input)
 }

--- a/pkg/cmd/provisioning/delete.go
+++ b/pkg/cmd/provisioning/delete.go
@@ -1,0 +1,217 @@
+package provisioning
+
+import (
+	"fmt"
+	"log"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/iam"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	"github.com/openshift/cloud-credential-operator/pkg/aws"
+)
+
+var (
+	// DeleteOpts captures the options that affect deletion
+	// of the generated objects.
+	DeleteOpts = options{}
+)
+
+// deleteOIDCObjectsFromBucket deletes the OIDC objects from the S3 bucket
+func deleteOIDCObjectsFromBucket(client aws.Client, bucketName, namePrefix string) error {
+	objectsMetadata, err := client.ListObjects(&s3.ListObjectsInput{
+		Bucket: awssdk.String(bucketName),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch list of Identity Provider objects in the bucket %s", bucketName)
+	}
+
+	for _, objectMetadata := range objectsMetadata.Contents {
+		objectTags, err := client.GetObjectTagging(&s3.GetObjectTaggingInput{
+			Key:    objectMetadata.Key,
+			Bucket: awssdk.String(bucketName),
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch tags of Identity Provider object %s in the bucket %s", *objectMetadata.Key, bucketName)
+		}
+
+		for _, tag := range objectTags.TagSet {
+			if *tag.Key == fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, namePrefix) {
+				_, err := client.DeleteObject(&s3.DeleteObjectInput{
+					Key:    objectMetadata.Key,
+					Bucket: awssdk.String(bucketName),
+				})
+				if err != nil {
+					return errors.Wrapf(err, "failed to delete Identity Provider object %s in the bucket %s", *objectMetadata.Key, bucketName)
+				}
+				log.Printf("Identity Provider object %s deleted from the bucket %s", *objectMetadata.Key, bucketName)
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+// deleteOIDCBucket deletes the OIDC S3 bucket
+func deleteOIDCBucket(client aws.Client, bucketName, namePrefix string) error {
+	bucketTags, err := client.GetBucketTagging(&s3.GetBucketTaggingInput{
+		Bucket: awssdk.String(bucketName),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch tags of the bucket %s", bucketName)
+	}
+
+	for _, tag := range bucketTags.TagSet {
+		if *tag.Key == fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, namePrefix) {
+			_, err := client.DeleteBucket(&s3.DeleteBucketInput{
+				Bucket: awssdk.String(bucketName),
+			})
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete the Identity Provider bucket %s", bucketName)
+			}
+			log.Printf("Identity Provider bucket %s deleted", bucketName)
+			break
+		}
+	}
+
+	return nil
+}
+
+// deleteIAMRoles deletes the IAM Roles created by ccoctl
+func deleteIAMRoles(client aws.Client, namePrefix string) error {
+	roleList, err := client.ListRoles(&iam.ListRolesInput{})
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch a list of IAM roles")
+	}
+
+	for _, roleMetadata := range roleList.Roles {
+		roleOutput, err := client.GetRole(&iam.GetRoleInput{
+			RoleName: roleMetadata.RoleName,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to fetch IAM role %s", *roleOutput.Role.RoleName)
+		}
+
+		for _, tag := range roleOutput.Role.Tags {
+			if *tag.Key == fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, namePrefix) {
+				if err := deleteRolePolicies(client, *roleOutput.Role.RoleName); err != nil {
+					return errors.Wrapf(err, "failed to delete policies associated with IAM Role %s", *roleOutput.Role.RoleName)
+				}
+
+				_, err := client.DeleteRole(&iam.DeleteRoleInput{
+					RoleName: roleOutput.Role.RoleName,
+				})
+				if err != nil {
+					return errors.Wrapf(err, "failed to delete IAM Role %s", *roleOutput.Role.RoleName)
+				}
+				log.Printf("IAM Role %s deleted", *roleOutput.Role.RoleName)
+				break
+			}
+		}
+	}
+
+	return nil
+}
+
+// deleteRolePolicies deletes the Polices associated with IAM Role created by ccoctl
+func deleteRolePolicies(client aws.Client, roleName string) error {
+	policies, err := client.ListRolePolicies(&iam.ListRolePoliciesInput{
+		RoleName: awssdk.String(roleName),
+	})
+	if err != nil {
+		return errors.Wrapf(err, "failed to fetch a list of policies associated with IAM role %s", roleName)
+	}
+
+	for _, policyName := range policies.PolicyNames {
+		_, err := client.DeleteRolePolicy(&iam.DeleteRolePolicyInput{
+			RoleName:   awssdk.String(roleName),
+			PolicyName: policyName,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "failed to delete policy %s associated with IAM Role %s", *policyName, roleName)
+		}
+		log.Printf("Policy %s associated with IAM Role %s deleted", *policyName, roleName)
+	}
+
+	return nil
+}
+
+// deleteIAMIdentityProvider deletes the IAM Identity Provider
+func deleteIAMIdentityProvider(client aws.Client, namePrefix string) error {
+	oidcProviderList, err := client.ListOpenIDConnectProviders(&iam.ListOpenIDConnectProvidersInput{})
+	if err != nil {
+		return errors.Wrap(err, "failed to fetch list of Identity Providers")
+	}
+
+	for _, provider := range oidcProviderList.OpenIDConnectProviderList {
+		ok, err := isExistingIdentifyProvider(client, *provider.Arn, namePrefix)
+		if err != nil {
+			return errors.Wrapf(err, "failed to check for existing Identity Provider")
+		}
+
+		if ok {
+			_, err := client.DeleteOpenIDConnectProvider(&iam.DeleteOpenIDConnectProviderInput{
+				OpenIDConnectProviderArn: awssdk.String(*provider.Arn),
+			})
+			if err != nil {
+				return errors.Wrapf(err, "failed to delete Identity Provider with ARN %s", *provider.Arn)
+			}
+			log.Printf("Identity Provider with ARN %s deleted", *provider.Arn)
+			break
+		}
+	}
+
+	return nil
+}
+
+func deleteCmd(cmd *cobra.Command, args []string) {
+	cfg := &awssdk.Config{
+		Region: awssdk.String(DeleteOpts.Region),
+	}
+
+	s, err := session.NewSession(cfg)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	awsClient := aws.NewClientFromSession(s)
+	bucketName := fmt.Sprintf("%s-oidc", DeleteOpts.NamePrefix)
+
+	if err := deleteOIDCObjectsFromBucket(awsClient, bucketName, DeleteOpts.NamePrefix); err != nil {
+		log.Print(err)
+	}
+
+	if err := deleteOIDCBucket(awsClient, bucketName, DeleteOpts.NamePrefix); err != nil {
+		log.Print(err)
+	}
+
+	if err := deleteIAMRoles(awsClient, DeleteOpts.NamePrefix); err != nil {
+		log.Print(err)
+	}
+
+	if err := deleteIAMIdentityProvider(awsClient, DeleteOpts.NamePrefix); err != nil {
+		log.Print(err)
+	}
+}
+
+// NewDeleteCmd implements the "delete" command for the credentials provisioning
+func NewDeleteCmd() *cobra.Command {
+	deleteCmd := &cobra.Command{
+		Use:              "delete",
+		Short:            "Delete credentials objects",
+		Long:             "Deleting objects related to cloud credentials",
+		PersistentPreRun: initEnv,
+		Run:              deleteCmd,
+	}
+
+	deleteCmd.PersistentFlags().StringVar(&DeleteOpts.NamePrefix, "name-prefix", "", "User-defined name prefix for all created AWS resources (can be separate from the cluster's infra-id)")
+	deleteCmd.MarkPersistentFlagRequired("name-prefix")
+	deleteCmd.PersistentFlags().StringVar(&DeleteOpts.Region, "region", "", "AWS region where the resources were created")
+	deleteCmd.MarkPersistentFlagRequired("region")
+
+	return deleteCmd
+}

--- a/pkg/cmd/provisioning/identity_provider.go
+++ b/pkg/cmd/provisioning/identity_provider.go
@@ -417,7 +417,7 @@ func isExistingIdentifyProvider(client aws.Client, providerARN, namePrefix strin
 	}
 
 	for _, tag := range provider.Tags {
-		if tag.Key == awssdk.String(fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, namePrefix)) {
+		if *tag.Key == fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, namePrefix) {
 			return true, nil
 		}
 	}


### PR DESCRIPTION
`ccoctl create` creates resources with the following tag

`openshift.io/cloud-credential-operator/<name-prefix>: owned`

This command takes name-prefix and region as input and deletes all
the resources with the above tag