### PR TITLE
Bug 1946097: oVirt credentials secret contains unnecessary "ovirt_cafile"

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ data:
   ovirt_url: Base64encodeURL
   ovirt_username: Base64encodeUsername
   ovirt_password: Base64encodePassword
-  ovirt_cafile: Base64encodeCAFile
   ovirt_insecure: Base64encodeInsecure
   ovirt_ca_bundle: Base64encodeCABundle
 ```

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -40,7 +40,6 @@ const (
 	urlKey      = "ovirt_url"
 	usernameKey = "ovirt_username"
 	passwordKey = "ovirt_password"
-	cafileKey   = "ovirt_cafile"
 	insecureKey = "ovirt_insecure"
 	cabundleKey = "ovirt_ca_bundle"
 )
@@ -53,8 +52,7 @@ type OvirtActuator struct {
 type OvirtCreds struct {
 	URL      string `json:"ovirt_url"`
 	Username string `json:"ovirt_username"`
-	Passord  string `json:"ovirt_password"`
-	CAFile   string `json:"ovirt_cafile"`
+	Password string `json:"ovirt_password"`
 	CABundle string `json:"ovirt_ca_bundle"`
 	Insecure bool   `json:"ovirt_insecure"`
 }
@@ -233,9 +231,6 @@ func (a *OvirtActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) (*co
 	if _, ok := loadedSecret.Data[passwordKey]; !ok {
 		logger.Warningf("secret did not have expected key: %s", passwordKey)
 	}
-	if _, ok := loadedSecret.Data[cafileKey]; !ok {
-		logger.Warningf("secret did not have expected key: %s", cafileKey)
-	}
 	if _, ok := loadedSecret.Data[cabundleKey]; !ok {
 		logger.Warningf("secret did not have expected key: %s", cabundleKey)
 	}
@@ -291,10 +286,6 @@ func secretToCreds(secret *corev1.Secret) (OvirtCreds, error) {
 	if !ok {
 		return c, fmt.Errorf("missing field %s", passwordKey)
 	}
-	cafile, ok := secret.Data[cafileKey]
-	if !ok {
-		return c, fmt.Errorf("missing field %s", cafileKey)
-	}
 	insecure, ok := secret.Data[insecureKey]
 	if !ok {
 		return c, fmt.Errorf("missing field %s", insecureKey)
@@ -306,8 +297,7 @@ func secretToCreds(secret *corev1.Secret) (OvirtCreds, error) {
 
 	c.URL = string(url)
 	c.Username = string(username)
-	c.Passord = string(password)
-	c.CAFile = string(cafile)
+	c.Password = string(password)
 	parse, err := strconv.ParseBool(string(insecure))
 	if err != nil {
 		return c, fmt.Errorf("failed to parse filed: insecure to boolean from value: %v error: %s", insecure, err)
@@ -351,8 +341,7 @@ func secretDataFrom(ovirtCreds *OvirtCreds) map[string][]byte {
 	return map[string][]byte{
 		urlKey:      []byte(ovirtCreds.URL),
 		usernameKey: []byte(ovirtCreds.Username),
-		passwordKey: []byte(ovirtCreds.Passord),
-		cafileKey:   []byte(ovirtCreds.CAFile),
+		passwordKey: []byte(ovirtCreds.Password),
 		insecureKey: []byte(strconv.FormatBool(ovirtCreds.Insecure)),
 		cabundleKey: []byte(ovirtCreds.CABundle),
 	}

--- a/pkg/ovirt/actuator_test.go
+++ b/pkg/ovirt/actuator_test.go
@@ -62,7 +62,6 @@ func TestConvertRootCredentials(t *testing.T) {
 					"ovirt_url":       []byte("https://enginefqdn/ovirt-engine/api"),
 					"ovirt_username":  []byte("admin@internal"),
 					"ovirt_password":  []byte("secret"),
-					"ovirt_cafile":    []byte("/etc/pki/ovirt-engine/ca.pem"),
 					"ovirt_ca_bundle": []byte(ca_bundle),
 					"ovirt_insecure":  []byte("true"),
 				},
@@ -72,8 +71,7 @@ func TestConvertRootCredentials(t *testing.T) {
 			expectedCreds: OvirtCreds{
 				URL:      "https://enginefqdn/ovirt-engine/api",
 				Username: "admin@internal",
-				Passord:  "secret",
-				CAFile:   "/etc/pki/ovirt-engine/ca.pem",
+				Password: "secret",
 				CABundle: ca_bundle,
 				Insecure: true,
 			},
@@ -90,8 +88,7 @@ func TestConvertRootCredentials(t *testing.T) {
 			expectedCreds: OvirtCreds{
 				URL:      "",
 				Username: "",
-				Passord:  "",
-				CAFile:   "",
+				Password: "",
 				Insecure: false,
 			},
 			expectedToFail: true,


### PR DESCRIPTION
This PR removes the ovirt_cafile field from the secret