### PR TITLE
Bug 1949862: avoid referencing object after error

### DIFF
--- a/pkg/cmd/provisioning/aws/create_identity_provider.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider.go
@@ -18,8 +18,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
-
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -30,6 +28,7 @@ import (
 	jose "gopkg.in/square/go-jose.v2"
 
 	"github.com/openshift/cloud-credential-operator/pkg/aws"
+	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 )
 
 var (

--- a/pkg/cmd/provisioning/aws/delete.go
+++ b/pkg/cmd/provisioning/aws/delete.go
@@ -93,7 +93,7 @@ func deleteIAMRoles(client aws.Client, namePrefix string) error {
 			RoleName: roleMetadata.RoleName,
 		})
 		if err != nil {
-			return errors.Wrapf(err, "failed to fetch IAM role %s", *roleOutput.Role.RoleName)
+			return errors.Wrapf(err, "failed to fetch IAM role %s", *roleMetadata.RoleName)
 		}
 
 		for _, tag := range roleOutput.Role.Tags {


### PR DESCRIPTION
After a GetRole() has failed, do not assume the returned value is
non-nil.