### PR TITLE
Bug 1953077: rework GCP passthrough permissions checking

### DIFF
--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -259,7 +259,10 @@ func (a *Actuator) syncPassthrough(ctx context.Context, cr *minterv1.Credentials
 
 	enoughPerms, err := gcputils.CheckPermissionsAgainstPermissionList(rootClient, permList, logger)
 	if err != nil {
-		return fmt.Errorf("error checking whether GCP client has sufficient permissions: %v", err)
+		return &actuatoriface.ActuatorError{
+			ErrReason: minterv1.CredentialsProvisionFailure,
+			Message:   fmt.Sprintf("error while validating permissions: %s", err.Error()),
+		}
 	}
 
 	if !enoughPerms {

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -46,6 +46,7 @@ type Client interface {
 	GetRole(context.Context, *iamadminpb.GetRoleRequest) (*iamadminpb.Role, error)
 	GetServiceAccount(context.Context, *iamadminpb.GetServiceAccountRequest) (*iamadminpb.ServiceAccount, error)
 	ListServiceAccountKeys(context.Context, *iamadminpb.ListServiceAccountKeysRequest) (*iamadminpb.ListServiceAccountKeysResponse, error)
+	QueryTestablePermissions(context.Context, *iamadminpb.QueryTestablePermissionsRequest) (*iamadminpb.QueryTestablePermissionsResponse, error)
 
 	//CloudResourceManager
 	GetProjectIamPolicy(projectName string, request *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error)
@@ -140,6 +141,12 @@ func (c *gcpClient) TestIamPermissions(projectName string, permRequest *cloudres
 		return nil, err
 	}
 	return response, nil
+}
+
+func (c *gcpClient) QueryTestablePermissions(ctx context.Context, request *iamadminpb.QueryTestablePermissionsRequest) (*iamadminpb.QueryTestablePermissionsResponse, error) {
+	ctx, cancel := contextWithTimeout(ctx)
+	defer cancel()
+	return c.iamClient.QueryTestablePermissions(ctx, request)
 }
 
 func (c *gcpClient) ListServicesEnabled() (map[string]bool, error) {

--- a/pkg/gcp/mock/client_generated.go
+++ b/pkg/gcp/mock/client_generated.go
@@ -138,6 +138,21 @@ func (mr *MockClientMockRecorder) ListServiceAccountKeys(arg0, arg1 interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountKeys", reflect.TypeOf((*MockClient)(nil).ListServiceAccountKeys), arg0, arg1)
 }
 
+// QueryTestablePermissions mocks base method
+func (m *MockClient) QueryTestablePermissions(arg0 context.Context, arg1 *admin.QueryTestablePermissionsRequest) (*admin.QueryTestablePermissionsResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "QueryTestablePermissions", arg0, arg1)
+	ret0, _ := ret[0].(*admin.QueryTestablePermissionsResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// QueryTestablePermissions indicates an expected call of QueryTestablePermissions
+func (mr *MockClientMockRecorder) QueryTestablePermissions(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryTestablePermissions", reflect.TypeOf((*MockClient)(nil).QueryTestablePermissions), arg0, arg1)
+}
+
 // GetProjectIamPolicy mocks base method
 func (m *MockClient) GetProjectIamPolicy(projectName string, request *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
 	m.ctrl.T.Helper()

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -555,6 +555,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				mockListServicesEnabled(mockGCPClient)
 
 				mockGetRole(mockGCPClient)
+				mockQueryableTestablePermissions(mockGCPClient)
 				mockTestIamPermissions(mockGCPClient)
 
 				return mockGCPClient
@@ -891,6 +892,17 @@ func mockGetRole(mockGCPClient *mockgcp.MockClient) {
 func mockListServicesEnabled(mockGCPClient *mockgcp.MockClient) {
 	mockGCPClient.EXPECT().ListServicesEnabled().Return(map[string]bool{
 		testServiceAPIName: true,
+	}, nil)
+}
+
+func mockQueryableTestablePermissions(mockGCPClient *mockgcp.MockClient) {
+	permResponse := []*iamadminpb.Permission{}
+
+	for _, perm := range testRolePermissions {
+		permResponse = append(permResponse, &iamadminpb.Permission{Name: perm})
+	}
+	mockGCPClient.EXPECT().QueryTestablePermissions(gomock.Any(), gomock.Any()).Return(&iamadminpb.QueryTestablePermissionsResponse{
+		Permissions: permResponse,
 	}, nil)
 }
 


### PR DESCRIPTION
In GCP Passthrough mode, the permissions are dynamically checked before
copying the secret contents over. This is done by performing a
TestIamPermissions() call against the current GCP project.

There are certain permissions that make no sense to check against the
project level. Periodically fetch a list of testable permissions using the
QueryTestablePermissions() API call.

Before making a TestIamPermissions() call, filter the permissions through the
allowed list to avoid needlessly receiving errors when calling TestIamPermissions()
against a GCP Project resource.