### PR TITLE
Bug 1952891: OpenStack: don't modify empty cacert

### DIFF
--- a/pkg/operator/secretannotator/openstack/reconciler.go
+++ b/pkg/operator/secretannotator/openstack/reconciler.go
@@ -215,6 +215,10 @@ func fixInvalidCACertFile(content string) (string, bool, error) {
 		}
 
 		if len(path) == 1 {
+			if y[path[0]] == "" {
+				// We need to update the path only if it is non-empty.
+				return false
+			}
 			y[path[0]] = openstack.CACertFile
 			return true
 		}

--- a/pkg/operator/secretannotator/openstack/reconciler_test.go
+++ b/pkg/operator/secretannotator/openstack/reconciler_test.go
@@ -251,6 +251,12 @@ func TestReconcileCloudCredSecret_Reconcile(t *testing.T) {
 				wantErr:        false,
 			},
 			{
+				name:           "Empty CA Cert",
+				cacert:         "\"\"",
+				expectedCACert: "",
+				wantErr:        false,
+			},
+			{
 				name:           "Incorrect CA Cert",
 				cacert:         incorrectCACertFile,
 				expectedCACert: correctCACertFile,


### PR DESCRIPTION
Previously gophercloud utils had a bug, which caused incorrect yaml marshaling for empty fields. It was fixed with
https://github.com/gophercloud/utils/pull/100 but we still see the consequences: if cacert is not in the original clouds.yaml the utils produce `cacert: ""` in the system clouds.yaml.

When we introduced https://github.com/openshift/cloud-credential-operator/pull/314, it just checks that the key (cacert) exists in the file, omitting the fact it can be empty, and inserts an incorrect value after that.

To fix the issue this commit ignores empty cacert field.