### PR TITLE
Bug 1954765: v1beta1 to v1 mutatingwebhookconfiguration

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/clusterrole.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/clusterrole.yaml
@@ -11,3 +11,12 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch

--- a/bindata/v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml
@@ -1,4 +1,4 @@
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
@@ -6,6 +6,8 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
 - name: pod-identity-webhook.amazonaws.com
+  admissionReviewVersions:
+  - v1beta1
   failurePolicy: Ignore
   sideEffects: None
   clientConfig:

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -74,6 +74,15 @@ rules:
   - get
   - watch
   - list
+- apiGroups:
+  - certificates.k8s.io
+  resources:
+  - certificatesigningrequests
+  verbs:
+  - create
+  - get
+  - list
+  - watch
 `)
 
 func v410AwsPodIdentityWebhookClusterroleYamlBytes() ([]byte, error) {
@@ -192,7 +201,7 @@ func v410AwsPodIdentityWebhookDeploymentYaml() (*asset, error) {
 	return a, nil
 }
 
-var _v410AwsPodIdentityWebhookMutatingwebhookYaml = []byte(`apiVersion: admissionregistration.k8s.io/v1beta1
+var _v410AwsPodIdentityWebhookMutatingwebhookYaml = []byte(`apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: pod-identity-webhook
@@ -200,6 +209,8 @@ metadata:
     service.beta.openshift.io/inject-cabundle: "true"
 webhooks:
 - name: pod-identity-webhook.amazonaws.com
+  admissionReviewVersions:
+  - v1beta1
   failurePolicy: Ignore
   sideEffects: None
   clientConfig:

--- a/pkg/operator/awspodidentity/controller.go
+++ b/pkg/operator/awspodidentity/controller.go
@@ -9,7 +9,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	admissionregistrationv1beta1 "k8s.io/api/admissionregistration/v1beta1"
+	admissionregistrationv1 "k8s.io/api/admissionregistration/v1"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -17,7 +17,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/serializer"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
-	admissionregistrationclientv1beta1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1beta1"
+	admissionregistrationclientv1 "k8s.io/client-go/kubernetes/typed/admissionregistration/v1"
 
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
@@ -289,8 +289,8 @@ func (r *staticResourceReconciler) ReconcileResources() error {
 	}
 
 	// "v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml"
-	requestedMutatingWebhookConfiguration := ReadMutatingWebhookConfigurationV1Beta1OrDie(v410_00_assets.MustAsset("v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml"))
-	_, modified, err = ApplyMutatingWebhookConfiguration(r.clientset.AdmissionregistrationV1beta1(), r.eventRecorder, requestedMutatingWebhookConfiguration)
+	requestedMutatingWebhookConfiguration := ReadMutatingWebhookConfigurationV1OrDie(v410_00_assets.MustAsset("v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml"))
+	_, modified, err = ApplyMutatingWebhookConfiguration(r.clientset.AdmissionregistrationV1(), r.eventRecorder, requestedMutatingWebhookConfiguration)
 	if err != nil {
 		r.logger.WithError(err).Error("error applying MutatingWebhookConfiguration")
 		return err
@@ -303,16 +303,16 @@ func (r *staticResourceReconciler) ReconcileResources() error {
 
 // TODO: add MutatingWebhookConfiguration helpers to library-go/operator/resource
 
-func ReadMutatingWebhookConfigurationV1Beta1OrDie(objBytes []byte) *admissionregistrationv1beta1.MutatingWebhookConfiguration {
-	requiredObj, err := runtime.Decode(defaultCodecs.UniversalDecoder(admissionregistrationv1beta1.SchemeGroupVersion), objBytes)
+func ReadMutatingWebhookConfigurationV1OrDie(objBytes []byte) *admissionregistrationv1.MutatingWebhookConfiguration {
+	requiredObj, err := runtime.Decode(defaultCodecs.UniversalDecoder(admissionregistrationv1.SchemeGroupVersion), objBytes)
 	if err != nil {
 		panic(err)
 	}
-	return requiredObj.(*admissionregistrationv1beta1.MutatingWebhookConfiguration)
+	return requiredObj.(*admissionregistrationv1.MutatingWebhookConfiguration)
 }
 
 // ApplyMutatingWebhookConfiguration merges objectmeta, does not worry about anything else
-func ApplyMutatingWebhookConfiguration(client admissionregistrationclientv1beta1.MutatingWebhookConfigurationsGetter, recorder events.Recorder, required *admissionregistrationv1beta1.MutatingWebhookConfiguration) (*admissionregistrationv1beta1.MutatingWebhookConfiguration, bool, error) {
+func ApplyMutatingWebhookConfiguration(client admissionregistrationclientv1.MutatingWebhookConfigurationsGetter, recorder events.Recorder, required *admissionregistrationv1.MutatingWebhookConfiguration) (*admissionregistrationv1.MutatingWebhookConfiguration, bool, error) {
 	existing, err := client.MutatingWebhookConfigurations().Get(context.TODO(), required.Name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) {
 		actual, err := client.MutatingWebhookConfigurations().Create(context.TODO(), required, metav1.CreateOptions{})


### PR DESCRIPTION
New kubernetes versions have removed support for v1beta1
MutatingWebhookConfiguration CRs. Migrate to deploying v1.

Update pod-identity-webhook ClusterRole to grant permissions around
certificatesigningrequests (fixes `E0503 15:37:23.227864       1 certificate_manager.go:434] Failed while requesting a signed certificate from the master: cannot create certificate signing request: certificatesigningrequests.certificates.k8s.io is forbidden: User "system:serviceaccount:openshift-cloud-credential-operator:pod-identity-webhook" cannot create resource "certificatesigningrequests" in API group "certificates.k8s.io" at the cluster scope`).

Add the newly required `admissionReviewVersions` field to the v1
MutatingWebhookConfiguration.

Update awspodidentity controller to stop reading in v1beta1 versions of
MutatingWebhookConfiguration CRs.
