### PR TITLE
Bug 1954865: add priorityClass to pod-identity Deployment

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -37,6 +37,7 @@ spec:
           readOnly: false
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
       serviceAccountName: pod-identity-webhook
       tolerations:
       - effect: NoSchedule

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -159,6 +159,7 @@ spec:
           readOnly: false
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
       serviceAccountName: pod-identity-webhook
       tolerations:
       - effect: NoSchedule


### PR DESCRIPTION
Since the pod-identity-webhook exists for user workloads, mark the
priority class as "system-cluster-critical" (not be preempted by user
workloads).