### PR TITLE
Bug 1957446: v1beta to v1 for the CredentialsRequest CRD

### DIFF
--- a/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
+++ b/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
@@ -1,6 +1,9 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
   name: credentialsrequests.cloudcredential.openshift.io
 spec:
   group: cloudcredential.openshift.io
@@ -10,151 +13,155 @@ spec:
     plural: credentialsrequests
     singular: credentialsrequest
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1
-  validation:
-    openAPIV3Schema:
-      description: CredentialsRequest is the Schema for the credentialsrequests API
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CredentialsRequestSpec defines the desired state of CredentialsRequest
-          type: object
-          required:
-          - secretRef
-          properties:
-            providerSpec:
-              description: ProviderSpec contains the cloud provider specific credentials
-                specification.
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            secretRef:
-              description: SecretRef points to the secret where the credentials should
-                be stored once generated.
-              type: object
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-            serviceAccountNames:
-              description: ServiceAccountNames contains a list of ServiceAccounts
-                that will use permissions associated with this CredentialsRequest.
-                This is not used by CCO, but the information is needed for being able
-                to properly set up access control in the cloud provider when the ServiceAccounts
-                are used as part of the cloud credentials flow.
-              type: array
-              items:
-                type: string
-        status:
-          description: CredentialsRequestStatus defines the observed state of CredentialsRequest
-          type: object
-          required:
-          - lastSyncGeneration
-          - provisioned
-          properties:
-            conditions:
-              description: Conditions includes detailed status for the CredentialsRequest
-              type: array
-              items:
-                description: CredentialsRequestCondition contains details for any
-                  of the conditions on a CredentialsRequest object
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CredentialsRequest is the Schema for the credentialsrequests
+          API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CredentialsRequestSpec defines the desired state of CredentialsRequest
+            type: object
+            required:
+            - secretRef
+            properties:
+              providerSpec:
+                description: ProviderSpec contains the cloud provider specific credentials
+                  specification.
                 type: object
-                required:
-                - status
-                - type
+                x-kubernetes-preserve-unknown-fields: true
+              secretRef:
+                description: SecretRef points to the secret where the credentials
+                  should be stored once generated.
+                type: object
                 properties:
-                  lastProbeTime:
-                    description: LastProbeTime is the last time we probed the condition
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                    format: date-time
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      transitioned from one status to another.
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
                     type: string
-                    format: date-time
-                  message:
-                    description: Message is a human-readable message indicating details
-                      about the last transition
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
-                  reason:
-                    description: Reason is a unique, one-word, CamelCase reason for
-                      the condition's last transition
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  status:
-                    description: Status is the status of the condition
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                     type: string
-                  type:
-                    description: Type is the specific type of the condition
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                     type: string
-            lastSyncCloudCredsSecretResourceVersion:
-              description: LastSyncCloudCredsSecretResourceVersion is the resource
-                version of the cloud credentials secret resource when the credentials
-                request resource was last synced. Used to determine if the the cloud
-                credentials have been updated since the last sync.
-              type: string
-            lastSyncGeneration:
-              description: LastSyncGeneration is the generation of the credentials
-                request resource that was last synced. Used to determine if the object
-                has changed and requires a sync.
-              type: integer
-              format: int64
-            lastSyncTimestamp:
-              description: LastSyncTimestamp is the time that the credentials were
-                last synced.
-              type: string
-              format: date-time
-            providerStatus:
-              description: ProviderStatus contains cloud provider specific status.
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            provisioned:
-              description: Provisioned is true once the credentials have been initially
-                provisioned.
-              type: boolean
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              serviceAccountNames:
+                description: ServiceAccountNames contains a list of ServiceAccounts
+                  that will use permissions associated with this CredentialsRequest.
+                  This is not used by CCO, but the information is needed for being
+                  able to properly set up access control in the cloud provider when
+                  the ServiceAccounts are used as part of the cloud credentials flow.
+                type: array
+                items:
+                  type: string
+          status:
+            description: CredentialsRequestStatus defines the observed state of CredentialsRequest
+            type: object
+            required:
+            - lastSyncGeneration
+            - provisioned
+            properties:
+              conditions:
+                description: Conditions includes detailed status for the CredentialsRequest
+                type: array
+                items:
+                  description: CredentialsRequestCondition contains details for any
+                    of the conditions on a CredentialsRequest object
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last transition
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition
+                      type: string
+                    type:
+                      description: Type is the specific type of the condition
+                      type: string
+              lastSyncCloudCredsSecretResourceVersion:
+                description: LastSyncCloudCredsSecretResourceVersion is the resource
+                  version of the cloud credentials secret resource when the credentials
+                  request resource was last synced. Used to determine if the the cloud
+                  credentials have been updated since the last sync.
+                type: string
+              lastSyncGeneration:
+                description: LastSyncGeneration is the generation of the credentials
+                  request resource that was last synced. Used to determine if the
+                  object has changed and requires a sync.
+                type: integer
+                format: int64
+              lastSyncTimestamp:
+                description: LastSyncTimestamp is the time that the credentials were
+                  last synced.
+                type: string
+                format: date-time
+              providerStatus:
+                description: ProviderStatus contains cloud provider specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              provisioned:
+                description: Provisioned is true once the credentials have been initially
+                  provisioned.
+                type: boolean
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -1,10 +1,10 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
-  name: credentialsrequests.cloudcredential.openshift.io
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
+  name: credentialsrequests.cloudcredential.openshift.io
 spec:
   group: cloudcredential.openshift.io
   names:
@@ -13,152 +13,155 @@ spec:
     plural: credentialsrequests
     singular: credentialsrequest
   scope: Namespaced
-  preserveUnknownFields: false
-  subresources:
-    status: {}
-  version: v1
-  validation:
-    openAPIV3Schema:
-      description: CredentialsRequest is the Schema for the credentialsrequests API
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CredentialsRequestSpec defines the desired state of CredentialsRequest
-          type: object
-          required:
-          - secretRef
-          properties:
-            providerSpec:
-              description: ProviderSpec contains the cloud provider specific credentials
-                specification.
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            secretRef:
-              description: SecretRef points to the secret where the credentials should
-                be stored once generated.
-              type: object
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-            serviceAccountNames:
-              description: ServiceAccountNames contains a list of ServiceAccounts
-                that will use permissions associated with this CredentialsRequest.
-                This is not used by CCO, but the information is needed for being able
-                to properly set up access control in the cloud provider when the ServiceAccounts
-                are used as part of the cloud credentials flow.
-              type: array
-              items:
-                type: string
-        status:
-          description: CredentialsRequestStatus defines the observed state of CredentialsRequest
-          type: object
-          required:
-          - lastSyncGeneration
-          - provisioned
-          properties:
-            conditions:
-              description: Conditions includes detailed status for the CredentialsRequest
-              type: array
-              items:
-                description: CredentialsRequestCondition contains details for any
-                  of the conditions on a CredentialsRequest object
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CredentialsRequest is the Schema for the credentialsrequests
+          API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CredentialsRequestSpec defines the desired state of CredentialsRequest
+            type: object
+            required:
+            - secretRef
+            properties:
+              providerSpec:
+                description: ProviderSpec contains the cloud provider specific credentials
+                  specification.
                 type: object
-                required:
-                - status
-                - type
+                x-kubernetes-preserve-unknown-fields: true
+              secretRef:
+                description: SecretRef points to the secret where the credentials
+                  should be stored once generated.
+                type: object
                 properties:
-                  lastProbeTime:
-                    description: LastProbeTime is the last time we probed the condition
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                    format: date-time
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      transitioned from one status to another.
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
                     type: string
-                    format: date-time
-                  message:
-                    description: Message is a human-readable message indicating details
-                      about the last transition
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
-                  reason:
-                    description: Reason is a unique, one-word, CamelCase reason for
-                      the condition's last transition
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  status:
-                    description: Status is the status of the condition
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                     type: string
-                  type:
-                    description: Type is the specific type of the condition
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                     type: string
-            lastSyncCloudCredsSecretResourceVersion:
-              description: LastSyncCloudCredsSecretResourceVersion is the resource
-                version of the cloud credentials secret resource when the credentials
-                request resource was last synced. Used to determine if the the cloud
-                credentials have been updated since the last sync.
-              type: string
-            lastSyncGeneration:
-              description: LastSyncGeneration is the generation of the credentials
-                request resource that was last synced. Used to determine if the object
-                has changed and requires a sync.
-              type: integer
-              format: int64
-            lastSyncTimestamp:
-              description: LastSyncTimestamp is the time that the credentials were
-                last synced.
-              type: string
-              format: date-time
-            providerStatus:
-              description: ProviderStatus contains cloud provider specific status.
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            provisioned:
-              description: Provisioned is true once the credentials have been initially
-                provisioned.
-              type: boolean
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              serviceAccountNames:
+                description: ServiceAccountNames contains a list of ServiceAccounts
+                  that will use permissions associated with this CredentialsRequest.
+                  This is not used by CCO, but the information is needed for being
+                  able to properly set up access control in the cloud provider when
+                  the ServiceAccounts are used as part of the cloud credentials flow.
+                type: array
+                items:
+                  type: string
+          status:
+            description: CredentialsRequestStatus defines the observed state of CredentialsRequest
+            type: object
+            required:
+            - lastSyncGeneration
+            - provisioned
+            properties:
+              conditions:
+                description: Conditions includes detailed status for the CredentialsRequest
+                type: array
+                items:
+                  description: CredentialsRequestCondition contains details for any
+                    of the conditions on a CredentialsRequest object
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last transition
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition
+                      type: string
+                    type:
+                      description: Type is the specific type of the condition
+                      type: string
+              lastSyncCloudCredsSecretResourceVersion:
+                description: LastSyncCloudCredsSecretResourceVersion is the resource
+                  version of the cloud credentials secret resource when the credentials
+                  request resource was last synced. Used to determine if the the cloud
+                  credentials have been updated since the last sync.
+                type: string
+              lastSyncGeneration:
+                description: LastSyncGeneration is the generation of the credentials
+                  request resource that was last synced. Used to determine if the
+                  object has changed and requires a sync.
+                type: integer
+                format: int64
+              lastSyncTimestamp:
+                description: LastSyncTimestamp is the time that the credentials were
+                  last synced.
+                type: string
+                format: date-time
+              providerStatus:
+                description: ProviderStatus contains cloud provider specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              provisioned:
+                description: Provisioned is true once the credentials have been initially
+                  provisioned.
+                type: boolean
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/pkg/apis/apis.go
+++ b/pkg/apis/apis.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Generate deepcopy for apis
-//go:generate go run -mod vendor ../../vendor/k8s.io/code-generator/cmd/deepcopy-gen/main.go -O zz_generated.deepcopy -i ./... -h ../../hack/boilerplate.go.txt
-
 // Package apis contains Kubernetes API groups.
 package apis
 

--- a/pkg/assets/bootstrap/bindata.go
+++ b/pkg/assets/bootstrap/bindata.go
@@ -56,9 +56,12 @@ func (fi bindataFileInfo) Sys() interface{} {
 	return nil
 }
 
-var _bootstrapCloudcredential_v1_credentialsrequest_crdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1beta1
+var _bootstrapCloudcredential_v1_credentialsrequest_crdYaml = []byte(`apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
   name: credentialsrequests.cloudcredential.openshift.io
 spec:
   group: cloudcredential.openshift.io
@@ -68,151 +71,155 @@ spec:
     plural: credentialsrequests
     singular: credentialsrequest
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1
-  validation:
-    openAPIV3Schema:
-      description: CredentialsRequest is the Schema for the credentialsrequests API
-      type: object
-      required:
-      - spec
-      properties:
-        apiVersion:
-          description: 'APIVersion defines the versioned schema of this representation
-            of an object. Servers should convert recognized schemas to the latest
-            internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
-          type: string
-        kind:
-          description: 'Kind is a string value representing the REST resource this
-            object represents. Servers may infer this from the endpoint the client
-            submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-          type: string
-        metadata:
-          type: object
-        spec:
-          description: CredentialsRequestSpec defines the desired state of CredentialsRequest
-          type: object
-          required:
-          - secretRef
-          properties:
-            providerSpec:
-              description: ProviderSpec contains the cloud provider specific credentials
-                specification.
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            secretRef:
-              description: SecretRef points to the secret where the credentials should
-                be stored once generated.
-              type: object
-              properties:
-                apiVersion:
-                  description: API version of the referent.
-                  type: string
-                fieldPath:
-                  description: 'If referring to a piece of an object instead of an
-                    entire object, this string should contain a valid JSON/Go field
-                    access statement, such as desiredState.manifest.containers[2].
-                    For example, if the object reference is to a container within
-                    a pod, this would take on a value like: "spec.containers{name}"
-                    (where "name" refers to the name of the container that triggered
-                    the event) or if no container name is specified "spec.containers[2]"
-                    (container with index 2 in this pod). This syntax is chosen only
-                    to have some well-defined way of referencing a part of an object.
-                    TODO: this design is not final and this field is subject to change
-                    in the future.'
-                  type: string
-                kind:
-                  description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
-                  type: string
-                name:
-                  description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
-                  type: string
-                namespace:
-                  description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
-                  type: string
-                resourceVersion:
-                  description: 'Specific resourceVersion to which this reference is
-                    made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
-                  type: string
-                uid:
-                  description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
-                  type: string
-            serviceAccountNames:
-              description: ServiceAccountNames contains a list of ServiceAccounts
-                that will use permissions associated with this CredentialsRequest.
-                This is not used by CCO, but the information is needed for being able
-                to properly set up access control in the cloud provider when the ServiceAccounts
-                are used as part of the cloud credentials flow.
-              type: array
-              items:
-                type: string
-        status:
-          description: CredentialsRequestStatus defines the observed state of CredentialsRequest
-          type: object
-          required:
-          - lastSyncGeneration
-          - provisioned
-          properties:
-            conditions:
-              description: Conditions includes detailed status for the CredentialsRequest
-              type: array
-              items:
-                description: CredentialsRequestCondition contains details for any
-                  of the conditions on a CredentialsRequest object
+  versions:
+  - name: v1
+    schema:
+      openAPIV3Schema:
+        description: CredentialsRequest is the Schema for the credentialsrequests
+          API
+        type: object
+        required:
+        - spec
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: CredentialsRequestSpec defines the desired state of CredentialsRequest
+            type: object
+            required:
+            - secretRef
+            properties:
+              providerSpec:
+                description: ProviderSpec contains the cloud provider specific credentials
+                  specification.
                 type: object
-                required:
-                - status
-                - type
+                x-kubernetes-preserve-unknown-fields: true
+              secretRef:
+                description: SecretRef points to the secret where the credentials
+                  should be stored once generated.
+                type: object
                 properties:
-                  lastProbeTime:
-                    description: LastProbeTime is the last time we probed the condition
+                  apiVersion:
+                    description: API version of the referent.
                     type: string
-                    format: date-time
-                  lastTransitionTime:
-                    description: LastTransitionTime is the last time the condition
-                      transitioned from one status to another.
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
                     type: string
-                    format: date-time
-                  message:
-                    description: Message is a human-readable message indicating details
-                      about the last transition
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
                     type: string
-                  reason:
-                    description: Reason is a unique, one-word, CamelCase reason for
-                      the condition's last transition
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
                     type: string
-                  status:
-                    description: Status is the status of the condition
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
                     type: string
-                  type:
-                    description: Type is the specific type of the condition
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
                     type: string
-            lastSyncCloudCredsSecretResourceVersion:
-              description: LastSyncCloudCredsSecretResourceVersion is the resource
-                version of the cloud credentials secret resource when the credentials
-                request resource was last synced. Used to determine if the the cloud
-                credentials have been updated since the last sync.
-              type: string
-            lastSyncGeneration:
-              description: LastSyncGeneration is the generation of the credentials
-                request resource that was last synced. Used to determine if the object
-                has changed and requires a sync.
-              type: integer
-              format: int64
-            lastSyncTimestamp:
-              description: LastSyncTimestamp is the time that the credentials were
-                last synced.
-              type: string
-              format: date-time
-            providerStatus:
-              description: ProviderStatus contains cloud provider specific status.
-              type: object
-              x-kubernetes-preserve-unknown-fields: true
-            provisioned:
-              description: Provisioned is true once the credentials have been initially
-                provisioned.
-              type: boolean
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+              serviceAccountNames:
+                description: ServiceAccountNames contains a list of ServiceAccounts
+                  that will use permissions associated with this CredentialsRequest.
+                  This is not used by CCO, but the information is needed for being
+                  able to properly set up access control in the cloud provider when
+                  the ServiceAccounts are used as part of the cloud credentials flow.
+                type: array
+                items:
+                  type: string
+          status:
+            description: CredentialsRequestStatus defines the observed state of CredentialsRequest
+            type: object
+            required:
+            - lastSyncGeneration
+            - provisioned
+            properties:
+              conditions:
+                description: Conditions includes detailed status for the CredentialsRequest
+                type: array
+                items:
+                  description: CredentialsRequestCondition contains details for any
+                    of the conditions on a CredentialsRequest object
+                  type: object
+                  required:
+                  - status
+                  - type
+                  properties:
+                    lastProbeTime:
+                      description: LastProbeTime is the last time we probed the condition
+                      type: string
+                      format: date-time
+                    lastTransitionTime:
+                      description: LastTransitionTime is the last time the condition
+                        transitioned from one status to another.
+                      type: string
+                      format: date-time
+                    message:
+                      description: Message is a human-readable message indicating
+                        details about the last transition
+                      type: string
+                    reason:
+                      description: Reason is a unique, one-word, CamelCase reason
+                        for the condition's last transition
+                      type: string
+                    status:
+                      description: Status is the status of the condition
+                      type: string
+                    type:
+                      description: Type is the specific type of the condition
+                      type: string
+              lastSyncCloudCredsSecretResourceVersion:
+                description: LastSyncCloudCredsSecretResourceVersion is the resource
+                  version of the cloud credentials secret resource when the credentials
+                  request resource was last synced. Used to determine if the the cloud
+                  credentials have been updated since the last sync.
+                type: string
+              lastSyncGeneration:
+                description: LastSyncGeneration is the generation of the credentials
+                  request resource that was last synced. Used to determine if the
+                  object has changed and requires a sync.
+                type: integer
+                format: int64
+              lastSyncTimestamp:
+                description: LastSyncTimestamp is the time that the credentials were
+                  last synced.
+                type: string
+                format: date-time
+              providerStatus:
+                description: ProviderStatus contains cloud provider specific status.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
+              provisioned:
+                description: Provisioned is true once the credentials have been initially
+                  provisioned.
+                type: boolean
+    served: true
+    storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""


### PR DESCRIPTION
migrate to v1 CRDs in anticipation of kube 1.22 dropping support for
v1beta1.

Process used was to first generate v1 CRD into a temporary location:
`_output/tools/bin/controller-gen paths=./pkg/apis/...  crd:crdVersions=v1 output:crd:artifacts:config=tmpcrds`

Next copy the CRD to manifests/00-crd.yaml, and compare for any
unexpected changes.

Add back the `include.release.openshift.io` annotations.

Finally, copy that CRD to
`bindata/boostrap/cloudcredential_v1_credentialsrequest_crd.yaml`.

`make update` will now take any new API changes and update the generated
CRDs appropriately (keeping the v1 CRD).

Also remove broken `go generate` which wasn't actually creating the
deepcopy functions anymore.

xref: https://issues.redhat.com/browse/CCO-65