### PR TITLE
Flag to skip creating and configuring S3 with OIDC configuration

### DIFF
--- a/pkg/cmd/provisioning/aws/aws.go
+++ b/pkg/cmd/provisioning/aws/aws.go
@@ -12,6 +12,7 @@ type options struct {
 	CredRequestDir      string
 	IdentityProviderARN string
 	DryRun              bool
+	ConfigureS3Bucket   bool
 }
 
 // NewAWSCmd implements the "aws" subcommand for the credentials provisioning

--- a/pkg/cmd/provisioning/aws/create_all.go
+++ b/pkg/cmd/provisioning/aws/create_all.go
@@ -44,7 +44,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create public/private key pair: %s", err)
 	}
 
-	identityProviderARN, err := createIdentityProvider(awsClient, CreateAllOpts.Name, CreateAllOpts.Region, publicKeyPath, CreateAllOpts.TargetDir, false)
+	identityProviderARN, err := createIdentityProvider(awsClient, CreateAllOpts.Name, CreateAllOpts.Region, publicKeyPath, CreateAllOpts.TargetDir, false, true)
 	if err != nil {
 		log.Fatalf("Failed to create Identity provider: %s", err)
 	}

--- a/pkg/cmd/provisioning/aws/create_identity_provider_test.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider_test.go
@@ -44,13 +44,14 @@ const (
 func TestCreateIdentityProvider(t *testing.T) {
 
 	tests := []struct {
-		name          string
-		mockAWSClient func(mockCtrl *gomock.Controller) *mockaws.MockClient
-		setup         func(*testing.T) string
-		verify        func(t *testing.T, tempDirName string)
-		cleanup       func(*testing.T)
-		generateOnly  bool
-		expectError   bool
+		name              string
+		mockAWSClient     func(mockCtrl *gomock.Controller) *mockaws.MockClient
+		setup             func(*testing.T) string
+		verify            func(t *testing.T, tempDirName string)
+		cleanup           func(*testing.T)
+		generateOnly      bool
+		configureS3Bucket bool
+		expectError       bool
 	}{
 		{
 			name: "Public key not found",
@@ -145,8 +146,9 @@ func TestCreateIdentityProvider(t *testing.T) {
 				require.NoError(t, err, "error calculating expected key id")
 				assert.Equalf(t, expectedKeyID, kid, "unexpected key id")
 			},
-			generateOnly: true,
-			expectError:  false,
+			generateOnly:      true,
+			configureS3Bucket: true,
+			expectError:       false,
 		},
 	}
 
@@ -162,7 +164,7 @@ func TestCreateIdentityProvider(t *testing.T) {
 
 			testPublicKeyPath := filepath.Join(tempDirName, testPublicKeyFile)
 
-			_, err := createIdentityProvider(mockAWSClient, testInfraName, testRegionName, testPublicKeyPath, tempDirName, test.generateOnly)
+			_, err := createIdentityProvider(mockAWSClient, testInfraName, testRegionName, testPublicKeyPath, tempDirName, test.generateOnly, test.configureS3Bucket)
 
 			if test.expectError {
 				require.Error(t, err, "expected error returned")


### PR DESCRIPTION
Adds a flag to skip configuring of the S3 bucket and OIDC configuration for the `create-identity-provider` command.

`--configure-s3-bucket=false` Will skip creating the S3 bucket and placing the OIDC configuration in it.