### PR TITLE
Bug 1864116: Fix "unsupported platform type" log spamming on BareMetal.

### DIFF
--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -786,7 +786,8 @@ func crInfraMatches(cr *minterv1.CredentialsRequest, clusterCloudPlatform config
 	case configv1.KubevirtPlatformType:
 		return cloudType == reflect.TypeOf(minterv1.KubevirtProviderSpec{}).Name(), nil
 	default:
-		return false, fmt.Errorf("unsupported platorm type: %v", clusterCloudPlatform)
+		// Unsupported platform, not considered an error. (i.e. bare metal)
+		return false, nil
 	}
 }
 


### PR DESCRIPTION
We were treating our not having a Spec implementation the clusters
Infrastructure platform as an error, but this is normal in BareMetal
clusters which have no CredentialsRequests.

Stop treating as an error and just return that the CredRequest is for
another cloud, which is true, and continue.

/assign @akhil-rane 
/cc @joelddiaz 