### PR TITLE
Bug 1910396: Add ErrorScrub utility to prevent infinite update/reconc…

### DIFF
--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -677,7 +677,7 @@ func setFailedToProvisionCredentialsRequest(cr *minterv1.CredentialsRequest, fai
 		updateCheck utils.UpdateConditionCheck
 	)
 	if failed {
-		msg = fmt.Sprintf("failed to grant creds: %v", err)
+		msg = fmt.Sprintf("failed to grant creds: %v", utils.ErrorScrub(err))
 		status = corev1.ConditionTrue
 		reason = credentialsProvisionFailure
 		updateCheck = utils.UpdateConditionIfReasonOrMessageChange
@@ -698,7 +698,7 @@ func setCredentialsDeprovisionFailureCondition(cr *minterv1.CredentialsRequest, 
 		updateCheck utils.UpdateConditionCheck
 	)
 	if failed {
-		msg = fmt.Sprintf("failed to deprovision resource: %v", err)
+		msg = fmt.Sprintf("failed to deprovision resource: %v", utils.ErrorScrub(err))
 		status = corev1.ConditionTrue
 		reason = cloudCredDeprovisionFailure
 		updateCheck = utils.UpdateConditionIfReasonOrMessageChange

--- a/pkg/operator/utils/errorscrub.go
+++ b/pkg/operator/utils/errorscrub.go
@@ -1,0 +1,18 @@
+package utils
+
+import (
+	"regexp"
+)
+
+var (
+	awsRequestIDRE = regexp.MustCompile(`(, )*(request id|Request ID): ([-0-9a-f]+)`)
+	newlineTabRE   = regexp.MustCompile(`(\n\t)`)
+)
+
+// ErrorScrub scrubs cloud error messages destined for CRD status to remove things that
+// change every attempt, such as request IDs, which subsequently cause an infinite update/reconcile loop.
+func ErrorScrub(err error) string {
+	s := awsRequestIDRE.ReplaceAllString(err.Error(), "")
+	s = newlineTabRE.ReplaceAllString(s, ", ")
+	return s
+}

--- a/pkg/operator/utils/errorscrub_test.go
+++ b/pkg/operator/utils/errorscrub_test.go
@@ -1,0 +1,38 @@
+package utils
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestErrorScrubber(t *testing.T) {
+	cases := []struct {
+		name string
+
+		input    string
+		expected string
+	}{
+		{
+			name:     "aws request id",
+			input:    "failed to grant creds: error syncing creds in mint-mode: AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000\n\tstatus code: 409, request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71",
+			expected: "failed to grant creds: error syncing creds in mint-mode: AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000, status code: 409",
+		},
+		{
+			name:     "request id mid",
+			input:    "AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000, request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71, something else",
+			expected: "AWS Error: LimitExceeded - LimitExceeded: Cannot exceed quota for UsersPerAccount: 5000, something else",
+		},
+		{
+			name:     "request id start",
+			input:    "request id: 0604c1a4-0a68-4d1a-b8e6-cdcf68176d71, something else", // shouldn't really happen
+			expected: ", something else",                                                 // not pretty but what I want to verify happens
+		},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			assert.Equal(t, test.expected, ErrorScrub(fmt.Errorf(test.input)))
+		})
+	}
+}


### PR DESCRIPTION
…ile loops.

Removes the AWS request ID from many possible errors that go into the
CredentialsRequest conditions.

/assign @joelddiaz 
/cc @akhil-rane 