### PR TITLE
Bug 1962602: Remove log statement in frequently called function.

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -401,7 +401,6 @@ func getWatchedSecrets(platformType configv1.PlatformType) []types.NamespacedNam
 	case configv1.VSpherePlatformType:
 		rootSecret.Name = constants.VSphereCloudCredSecretName
 	default:
-		log.Infof("unable to provide upcoming secrets for unknown platform: %v", platformType)
 		return []types.NamespacedName{}
 	}
 


### PR DESCRIPTION
This function is called often when watching all Secrets in the cluster
to determine if we should re-reconcile if the cluster platform is none.
As such it should not be logging anything.
