### PR TITLE
Bug 1967531: Fix ccoctl delete not removing iam roles

### DIFF
--- a/pkg/cmd/provisioning/aws/delete.go
+++ b/pkg/cmd/provisioning/aws/delete.go
@@ -82,10 +82,14 @@ func deleteOIDCBucket(client aws.Client, bucketName, namePrefix string) error {
 }
 
 // deleteIAMRoles deletes the IAM Roles created by ccoctl
-func deleteIAMRoles(client aws.Client, namePrefix string) error {
-	roleList, err := client.ListRoles(&iam.ListRolesInput{})
+func deleteIAMRoles(client aws.Client, namePrefix string, paginationMarker *string) error {
+	// iam.ListRolesInput results are paginated to 100 items by default, if result is truncated we need to
+	// fetch next set of items and perform delete operation
+	roleList, err := client.ListRoles(&iam.ListRolesInput{
+		Marker: paginationMarker,
+	})
 	if err != nil {
-		return errors.Wrapf(err, "failed to fetch a list of IAM roles")
+		return errors.Wrapf(err, "failed to fetch a list of IAM roles, pagination marker: %v", paginationMarker)
 	}
 
 	for _, roleMetadata := range roleList.Roles {
@@ -112,6 +116,10 @@ func deleteIAMRoles(client aws.Client, namePrefix string) error {
 				break
 			}
 		}
+	}
+
+	if *roleList.IsTruncated {
+		return deleteIAMRoles(client, namePrefix, roleList.Marker)
 	}
 
 	return nil
@@ -189,7 +197,7 @@ func deleteCmd(cmd *cobra.Command, args []string) {
 		log.Print(err)
 	}
 
-	if err := deleteIAMRoles(awsClient, DeleteOpts.Name); err != nil {
+	if err := deleteIAMRoles(awsClient, DeleteOpts.Name, nil); err != nil {
 		log.Print(err)
 	}
 


### PR DESCRIPTION
iam.ListRoles results are paginated to 100 items by default. If
an account had more then 100 roles, delete command did not work in
some cases. This commit fixes it by checking if iam.ListRoles
result is truncated, fetching next batch of results and deleting
the roles.

x-ref: https://issues.redhat.com/browse/OCPBUGSM-29969