### PR TITLE
Bug 1970062: enable shared config files for AWS SDK

### DIFF
--- a/pkg/cmd/provisioning/aws/aws.go
+++ b/pkg/cmd/provisioning/aws/aws.go
@@ -2,6 +2,9 @@ package aws
 
 import (
 	"github.com/spf13/cobra"
+
+	awssdk "github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
 )
 
 type options struct {
@@ -29,4 +32,15 @@ func NewAWSCmd() *cobra.Command {
 	createCmd.AddCommand(NewDeleteCmd())
 
 	return createCmd
+}
+
+func awsSession(region string) (*session.Session, error) {
+	cfg := awssdk.Config{
+		Region: awssdk.String(region),
+	}
+
+	return session.NewSessionWithOptions(session.Options{
+		Config:            cfg,
+		SharedConfigState: session.SharedConfigEnable,
+	})
 }

--- a/pkg/cmd/provisioning/aws/create-iam-roles.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles.go
@@ -15,7 +15,6 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 
 	"k8s.io/apimachinery/pkg/util/yaml"
@@ -286,11 +285,7 @@ func getIssuerURLFromIdentityProvider(awsClient aws.Client, idProviderARN string
 }
 
 func createIAMRolesCmd(cmd *cobra.Command, args []string) {
-	cfg := &awssdk.Config{
-		Region: awssdk.String(CreateIAMRolesOpts.Region),
-	}
-
-	s, err := session.NewSession(cfg)
+	s, err := awsSession(CreateIAMRolesOpts.Region)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/provisioning/aws/create_identity_provider.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider.go
@@ -20,7 +20,6 @@ import (
 
 	awssdk "github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/awserr"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/iam"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/pkg/errors"
@@ -458,11 +457,7 @@ spec:
 }
 
 func createIdentityProviderCmd(cmd *cobra.Command, args []string) {
-	cfg := &awssdk.Config{
-		Region: awssdk.String(CreateIdentityProviderOpts.Region),
-	}
-
-	s, err := session.NewSession(cfg)
+	s, err := awsSession(CreateIdentityProviderOpts.Region)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This should more closely mimic the credentials fetching behavior of the
AWS CLI (which already does read from ~/.aws/config in addition to
~/.aws/credentials).