### PR TITLE
Bug 1970062: use shared session setup in ccoctl create-all

### DIFF
--- a/pkg/cmd/provisioning/aws/create_all.go
+++ b/pkg/cmd/provisioning/aws/create_all.go
@@ -8,9 +8,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	awssdk "github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-
 	"github.com/openshift/cloud-credential-operator/pkg/aws"
 	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 )
@@ -24,11 +21,7 @@ var (
 )
 
 func createAllCmd(cmd *cobra.Command, args []string) {
-	cfg := &awssdk.Config{
-		Region: awssdk.String(CreateAllOpts.Region),
-	}
-
-	s, err := session.NewSession(cfg)
+	s, err := awsSession(CreateAllOpts.Region)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This fixes create-all not reading in creds from ~/.aws/config.