### PR TITLE
Rename ibmcloud command to create-shared-secrets

### DIFF
--- a/pkg/cmd/provisioning/ibmcloud/create_shared_secrets.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_shared_secrets.go
@@ -40,13 +40,13 @@ var (
 	}
 )
 
-// NewCreateSecretsCmd implements the "create-secrets" command for the credentials provisioning
-func NewCreateSecretsCmd() *cobra.Command {
+// NewCreateSharedSecretsCmd implements the "create-shared-secrets" command for the credentials provisioning
+func NewCreateSharedSecretsCmd() *cobra.Command {
 	createSecretsCmd := &cobra.Command{
-		Use:              "create-secrets",
+		Use:              "create-shared-secrets",
 		Short:            "Create credentials objects",
-		Long:             "Creating objects related to cloud credentials",
-		RunE:             createSecretsCmd,
+		Long:             "Creating secrets from credentials requests using the API key in the IC_API_KEY environment variable",
+		RunE:             createSharedSecretsCmd,
 		PersistentPreRun: initEnvForCreateCmd,
 	}
 
@@ -57,20 +57,20 @@ func NewCreateSecretsCmd() *cobra.Command {
 	return createSecretsCmd
 }
 
-func createSecretsCmd(cmd *cobra.Command, args []string) error {
+func createSharedSecretsCmd(cmd *cobra.Command, args []string) error {
 	apiKey := os.Getenv(APIKeyEnvVar)
 	if apiKey == "" {
 		return fmt.Errorf("%s environment variable not set", APIKeyEnvVar)
 	}
 
-	err := createSecrets(CreateOpts.CredRequestDir, CreateOpts.TargetDir, apiKey)
+	err := createSharedSecrets(CreateOpts.CredRequestDir, CreateOpts.TargetDir, apiKey)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func createSecrets(credReqDir string, targetDir string, apiKey string) error {
+func createSharedSecrets(credReqDir string, targetDir string, apiKey string) error {
 	credRequests, err := getListOfCredentialsRequests(credReqDir)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")

--- a/pkg/cmd/provisioning/ibmcloud/create_shared_secrets_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_shared_secrets_test.go
@@ -65,7 +65,7 @@ func TestCreateSecretsCmd(t *testing.T) {
 			expectError: false,
 		},
 		{
-			name: "CreateSecretsCmd with unset API key environment variable should fail",
+			name: "CreateSharedSecretsCmd with unset API key environment variable should fail",
 			setup: func(t *testing.T) string {
 				os.Setenv(APIKeyEnvVar, "")
 				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
@@ -104,7 +104,7 @@ func TestCreateSecretsCmd(t *testing.T) {
 			}
 			CreateOpts.CredRequestDir = credReqDir
 			CreateOpts.TargetDir = targetDir
-			err = createSecretsCmd(&cobra.Command{}, args)
+			err = createSharedSecretsCmd(&cobra.Command{}, args)
 
 			if test.expectError {
 				require.Error(t, err, "Expected error returned")

--- a/pkg/cmd/provisioning/ibmcloud/ibmcloud.go
+++ b/pkg/cmd/provisioning/ibmcloud/ibmcloud.go
@@ -17,7 +17,7 @@ func NewIBMCloudCmd() *cobra.Command {
 		Long:  "Creating/deleting cloud credentials objects for IBM Cloud",
 	}
 
-	createCmd.AddCommand(NewCreateSecretsCmd())
+	createCmd.AddCommand(NewCreateSharedSecretsCmd())
 
 	return createCmd
 }


### PR DESCRIPTION
Related to this PR: https://github.com/openshift/cloud-credential-operator/pull/356

Addresses @joelddiaz 's comment: https://github.com/openshift/cloud-credential-operator/pull/356#discussion_r655475848