### PR TITLE
Update CI build root image to golang-1.16

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,4 +1,4 @@
 build_root_image:
   name: release
   namespace: openshift
-  tag: golang-1.15
+  tag: golang-1.16


### PR DESCRIPTION
Currently we are using golang-1.15 image in CI, but go.mod is set to go1.16. This is causing verify-deps test to fail.