### PR TITLE
Bug 2002152: Stop putting CCO in degraded state when stale credentials are found

### DIFF
--- a/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
+++ b/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
@@ -42,3 +42,11 @@ spec:
       for: 5m
       labels:
         severity: warning
+    - alert: CloudCredentialOperatorStaleCredentials
+      annotations:
+        message: 1 or more credentials requests are stale and should be deleted. Check the status.conditions on CredentialsRequest CRs to identify the stale one(s).
+      expr: cco_credentials_requests_conditions{condition="StaleCredentials"}
+        > 0
+      for: 5m
+      labels:
+        severity: warning

--- a/pkg/operator/credentialsrequest/status_test.go
+++ b/pkg/operator/credentialsrequest/status_test.go
@@ -157,21 +157,6 @@ func TestClusterOperatorStatus(t *testing.T) {
 			},
 		},
 		{
-			name: "stale credentials request that is no longer required",
-			credRequests: []minterv1.CredentialsRequest{
-				testCredentialsRequestWithStatus("cred1", true, []minterv1.CredentialsRequestCondition{}, nil),
-				testCredentialsRequestWithStatus("cred2", true, []minterv1.CredentialsRequestCondition{
-					testCRCondition(minterv1.StaleCredentials, corev1.ConditionTrue),
-				}, nil),
-				testCredentialsRequestWithStatus("cred3", true, []minterv1.CredentialsRequestCondition{}, nil),
-			},
-			cloudPlatform:    configv1.AWSPlatformType,
-			operatorDisabled: true,
-			expectedConditions: []configv1.ClusterOperatorStatusCondition{
-				testCondition(configv1.OperatorDegraded, configv1.ConditionTrue, reasonStaleCredentials),
-			},
-		},
-		{
 			name: "ignore nonAWS credreqs",
 			credRequests: []minterv1.CredentialsRequest{
 				testCredentialsRequestWithStatus("cred1", true, []minterv1.CredentialsRequestCondition{}, nil),


### PR DESCRIPTION
Currently, we put CCO in the degraded state when stale credentials are found. When in manual mode, stale credentials are not removed by the cleanup controller and thus upgrade is blocked. This commit stops it and instead we raise an alert warning that cluster admin can see and take necessary action.