### PR TITLE
Bug 2006364: fix(ibmcloud): Set policy attribute name properly for RG access

### DIFF
--- a/pkg/cmd/provisioning/ibmcloud/service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/service_id.go
@@ -172,8 +172,15 @@ func (s *ServiceID) createPolicy(policy *credreqv1.AccessPolicy) error {
 
 	// Append the resource group attribute if specified as a command line argument.
 	if s.resourceGroupID != "" {
+		resourceGroupAttrName := "resourceGroupId"
+		for _, attr := range resourceAttributes {
+			if *attr.Name == "resourceType" && *attr.Value == "resource-group" {
+				resourceGroupAttrName = "resource"
+				break
+			}
+		}
 		resourceAttributes = append(resourceAttributes, iampolicymanagementv1.ResourceAttribute{
-			Name:  core.StringPtr("resourceGroupId"),
+			Name:  &resourceGroupAttrName,
 			Value: &s.resourceGroupID,
 		})
 	}


### PR DESCRIPTION
This change allows `ccoctl` to set access policy attributes properly for a specific resource group access. In cases where we want to assign access to just the resource group, the policy attributes should look like the following:
```
{
  "attributes":[
    {
      "name":"accountId",
      "value":"my-account-id",
    },
    {
      "name":"resourceType",
      "value":"resource-group",
    },
    {
      "name":"resource",
      "value":"my-resource-group-id"
    }
  ],
}
```

To compare, the attributes generated without this fix will result in..
```
{
  "attributes":[
    {
      "name":"accountId",
      "value":"my-account-id",
    },
    {
      "name":"resourceType",
      "value":"resource-group",
    },
    {
      "name":"resourceGroupId",
      "value":"my-resource-group-id"
    }
  ],
}
```

.. which does not grant access to the resource group as expected.

This fix will determine if `resourceType == "resource-group"`, then set the additional attribute of `resourceGroupId || resource` appropriately.