### PR TITLE
Bug 1977319: cleanup orphaned Service 'controller-manager-service'

### DIFF
--- a/manifests/01-service-delete.yaml
+++ b/manifests/01-service-delete.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/delete: "true"
+  labels:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"
+  name: controller-manager-service
+  namespace: openshift-cloud-credential-operator
+spec:
+  ports:
+  - port: 443
+  selector:
+    control-plane: controller-manager
+    controller-tools.k8s.io: "1.0"


### PR DESCRIPTION
Back in 4.1 we installed a Service named 'controller-manager-service'.
That was subsequently dropped, but any cluster that has upgraded from
4.1 to present keeps the needless Service arround. Re-create the Service
  with the delete annotation so that the CVO can properly clean this up.