### PR TITLE
Bug 2010341: update alerts with summary and descriptions

### DIFF
--- a/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
+++ b/manifests/0000_90_cloud-credential-operator_04_alertrules.yaml
@@ -13,6 +13,8 @@ spec:
     - alert: CloudCredentialOperatorTargetNamespaceMissing
       annotations:
         message: CredentialsRequest(s) pointing to non-existent namespace
+        summary: One ore more CredentialsRequest CRs are asking to save credentials to a non-existent namespace.
+        description: At least one CredentialsRequest custom resource has specified in its .spec.secretRef.namespace field a namespace which does not presently exist. This means the Cloud Credential Operator in the openshift-cloud-credential-operator namespace cannot process the CredentialsRequest resource. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .status.condition showing a condition type of MissingTargetNamespace set to True.
       expr: cco_credentials_requests_conditions{condition="MissingTargetNamespace"}
         > 0
       for: 5m
@@ -21,6 +23,8 @@ spec:
     - alert: CloudCredentialOperatorProvisioningFailed
       annotations:
         message: CredentialsRequest(s) unable to be fulfilled
+        summary: One or more CredentialsRequest CRs are unable to be processed.
+        description: While processing a CredentialsRequest, the Cloud Credential Operator encountered an issue. Check the conditions of all CredentialsRequets with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .stats.condition showing a condition type of CredentialsProvisionFailure set to True for more details on the issue.
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
         > 0
       for: 5m
@@ -29,6 +33,8 @@ spec:
     - alert: CloudCredentialOperatorDeprovisioningFailed
       annotations:
         message: CredentialsRequest(s) unable to be cleaned up
+        summary: One or more CredentialsRequest CRs are unable to be deleted.
+        description: While processing a CredentialsRequest marked for deletion, the Cloud Credential Operator encountered an issue. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .status.condition showing a condition type of CredentialsDeprovisionFailure set to True for more details on the issue.
       expr: cco_credentials_requests_conditions{condition="CredentialsDeprovisionFailure"}
         > 0
       for: 5m
@@ -37,6 +43,8 @@ spec:
     - alert: CloudCredentialOperatorInsufficientCloudCreds
       annotations:
         message: Cluster's cloud credentials insufficient for minting or passthrough
+        summary: Problem with the available platform credentials.
+        description: The Cloud Credential Operator has determined that there are insufficient permissions to process one or more CredentialsRequest CRs. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .status.condition showing a condition type of InsufficientCloudCreds set to True for more details.
       expr: cco_credentials_requests_conditions{condition="InsufficientCloudCreds"}
         > 0
       for: 5m
@@ -45,6 +53,8 @@ spec:
     - alert: CloudCredentialOperatorStaleCredentials
       annotations:
         message: 1 or more credentials requests are stale and should be deleted. Check the status.conditions on CredentialsRequest CRs to identify the stale one(s).
+        summary: One or more CredentialsRequest CRs are stale and should be deleted.
+        description: The Cloud Credential Operator (CCO) has detected one or more stale CredentialsRequest CRs that need to be manually deleted. When the CCO is in Manual credentials mode, it will not automatially clean up stale CredentialsRequest CRs (that may no longer be necessary in the present version of OpenShift because it could involve needing to clean up manually created cloud resources. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .status.condition showing a condition type of StaleCredentials set to True. Determine the appropriate steps to clean up/deprovision any previously provisioned cloud resources. Finally, delete the CredentialsRequest with an 'oc delete'.
       expr: cco_credentials_requests_conditions{condition="StaleCredentials"}
         > 0
       for: 5m

--- a/pkg/aws/mock/client_generated.go
+++ b/pkg/aws/mock/client_generated.go
@@ -5,37 +5,36 @@
 package mock
 
 import (
-	reflect "reflect"
-
 	iam "github.com/aws/aws-sdk-go/service/iam"
 	s3 "github.com/aws/aws-sdk-go/service/s3"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateAccessKey mocks base method.
+// CreateAccessKey mocks base method
 func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.CreateAccessKeyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAccessKey", arg0)
@@ -44,28 +43,13 @@ func (m *MockClient) CreateAccessKey(arg0 *iam.CreateAccessKeyInput) (*iam.Creat
 	return ret0, ret1
 }
 
-// CreateAccessKey indicates an expected call of CreateAccessKey.
+// CreateAccessKey indicates an expected call of CreateAccessKey
 func (mr *MockClientMockRecorder) CreateAccessKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAccessKey", reflect.TypeOf((*MockClient)(nil).CreateAccessKey), arg0)
 }
 
-// CreateBucket mocks base method.
-func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateBucket", arg0)
-	ret0, _ := ret[0].(*s3.CreateBucketOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateBucket indicates an expected call of CreateBucket.
-func (mr *MockClientMockRecorder) CreateBucket(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockClient)(nil).CreateBucket), arg0)
-}
-
-// CreateOpenIDConnectProvider mocks base method.
+// CreateOpenIDConnectProvider mocks base method
 func (m *MockClient) CreateOpenIDConnectProvider(arg0 *iam.CreateOpenIDConnectProviderInput) (*iam.CreateOpenIDConnectProviderOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateOpenIDConnectProvider", arg0)
@@ -74,13 +58,13 @@ func (m *MockClient) CreateOpenIDConnectProvider(arg0 *iam.CreateOpenIDConnectPr
 	return ret0, ret1
 }
 
-// CreateOpenIDConnectProvider indicates an expected call of CreateOpenIDConnectProvider.
+// CreateOpenIDConnectProvider indicates an expected call of CreateOpenIDConnectProvider
 func (mr *MockClientMockRecorder) CreateOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).CreateOpenIDConnectProvider), arg0)
 }
 
-// CreateRole mocks base method.
+// CreateRole mocks base method
 func (m *MockClient) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateRole", arg0)
@@ -89,13 +73,13 @@ func (m *MockClient) CreateRole(arg0 *iam.CreateRoleInput) (*iam.CreateRoleOutpu
 	return ret0, ret1
 }
 
-// CreateRole indicates an expected call of CreateRole.
+// CreateRole indicates an expected call of CreateRole
 func (mr *MockClientMockRecorder) CreateRole(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockClient)(nil).CreateRole), arg0)
 }
 
-// CreateUser mocks base method.
+// CreateUser mocks base method
 func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateUser", arg0)
@@ -104,13 +88,13 @@ func (m *MockClient) CreateUser(arg0 *iam.CreateUserInput) (*iam.CreateUserOutpu
 	return ret0, ret1
 }
 
-// CreateUser indicates an expected call of CreateUser.
+// CreateUser indicates an expected call of CreateUser
 func (mr *MockClientMockRecorder) CreateUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateUser", reflect.TypeOf((*MockClient)(nil).CreateUser), arg0)
 }
 
-// DeleteAccessKey mocks base method.
+// DeleteAccessKey mocks base method
 func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.DeleteAccessKeyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteAccessKey", arg0)
@@ -119,88 +103,13 @@ func (m *MockClient) DeleteAccessKey(arg0 *iam.DeleteAccessKeyInput) (*iam.Delet
 	return ret0, ret1
 }
 
-// DeleteAccessKey indicates an expected call of DeleteAccessKey.
+// DeleteAccessKey indicates an expected call of DeleteAccessKey
 func (mr *MockClientMockRecorder) DeleteAccessKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAccessKey", reflect.TypeOf((*MockClient)(nil).DeleteAccessKey), arg0)
 }
 
-// DeleteBucket mocks base method.
-func (m *MockClient) DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteBucket", input)
-	ret0, _ := ret[0].(*s3.DeleteBucketOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteBucket indicates an expected call of DeleteBucket.
-func (mr *MockClientMockRecorder) DeleteBucket(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), input)
-}
-
-// DeleteObject mocks base method.
-func (m *MockClient) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteObject", input)
-	ret0, _ := ret[0].(*s3.DeleteObjectOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteObject indicates an expected call of DeleteObject.
-func (mr *MockClientMockRecorder) DeleteObject(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockClient)(nil).DeleteObject), input)
-}
-
-// DeleteOpenIDConnectProvider mocks base method.
-func (m *MockClient) DeleteOpenIDConnectProvider(input *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteOpenIDConnectProvider", input)
-	ret0, _ := ret[0].(*iam.DeleteOpenIDConnectProviderOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteOpenIDConnectProvider indicates an expected call of DeleteOpenIDConnectProvider.
-func (mr *MockClientMockRecorder) DeleteOpenIDConnectProvider(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).DeleteOpenIDConnectProvider), input)
-}
-
-// DeleteRole mocks base method.
-func (m *MockClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRole", input)
-	ret0, _ := ret[0].(*iam.DeleteRoleOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteRole indicates an expected call of DeleteRole.
-func (mr *MockClientMockRecorder) DeleteRole(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockClient)(nil).DeleteRole), input)
-}
-
-// DeleteRolePolicy mocks base method.
-func (m *MockClient) DeleteRolePolicy(input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteRolePolicy", input)
-	ret0, _ := ret[0].(*iam.DeleteRolePolicyOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteRolePolicy indicates an expected call of DeleteRolePolicy.
-func (mr *MockClientMockRecorder) DeleteRolePolicy(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePolicy", reflect.TypeOf((*MockClient)(nil).DeleteRolePolicy), input)
-}
-
-// DeleteUser mocks base method.
+// DeleteUser mocks base method
 func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUser", arg0)
@@ -209,13 +118,13 @@ func (m *MockClient) DeleteUser(arg0 *iam.DeleteUserInput) (*iam.DeleteUserOutpu
 	return ret0, ret1
 }
 
-// DeleteUser indicates an expected call of DeleteUser.
+// DeleteUser indicates an expected call of DeleteUser
 func (mr *MockClientMockRecorder) DeleteUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUser", reflect.TypeOf((*MockClient)(nil).DeleteUser), arg0)
 }
 
-// DeleteUserPolicy mocks base method.
+// DeleteUserPolicy mocks base method
 func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.DeleteUserPolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteUserPolicy", arg0)
@@ -224,43 +133,13 @@ func (m *MockClient) DeleteUserPolicy(arg0 *iam.DeleteUserPolicyInput) (*iam.Del
 	return ret0, ret1
 }
 
-// DeleteUserPolicy indicates an expected call of DeleteUserPolicy.
+// DeleteUserPolicy indicates an expected call of DeleteUserPolicy
 func (mr *MockClientMockRecorder) DeleteUserPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteUserPolicy", reflect.TypeOf((*MockClient)(nil).DeleteUserPolicy), arg0)
 }
 
-// GetBucketTagging mocks base method.
-func (m *MockClient) GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetBucketTagging", input)
-	ret0, _ := ret[0].(*s3.GetBucketTaggingOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetBucketTagging indicates an expected call of GetBucketTagging.
-func (mr *MockClientMockRecorder) GetBucketTagging(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTagging", reflect.TypeOf((*MockClient)(nil).GetBucketTagging), input)
-}
-
-// GetObjectTagging mocks base method.
-func (m *MockClient) GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetObjectTagging", input)
-	ret0, _ := ret[0].(*s3.GetObjectTaggingOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetObjectTagging indicates an expected call of GetObjectTagging.
-func (mr *MockClientMockRecorder) GetObjectTagging(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectTagging", reflect.TypeOf((*MockClient)(nil).GetObjectTagging), input)
-}
-
-// GetOpenIDConnectProvider mocks base method.
+// GetOpenIDConnectProvider mocks base method
 func (m *MockClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProviderInput) (*iam.GetOpenIDConnectProviderOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetOpenIDConnectProvider", input)
@@ -269,13 +148,13 @@ func (m *MockClient) GetOpenIDConnectProvider(input *iam.GetOpenIDConnectProvide
 	return ret0, ret1
 }
 
-// GetOpenIDConnectProvider indicates an expected call of GetOpenIDConnectProvider.
+// GetOpenIDConnectProvider indicates an expected call of GetOpenIDConnectProvider
 func (mr *MockClientMockRecorder) GetOpenIDConnectProvider(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).GetOpenIDConnectProvider), input)
 }
 
-// GetRole mocks base method.
+// GetRole mocks base method
 func (m *MockClient) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRole", input)
@@ -284,103 +163,13 @@ func (m *MockClient) GetRole(input *iam.GetRoleInput) (*iam.GetRoleOutput, error
 	return ret0, ret1
 }
 
-// GetRole indicates an expected call of GetRole.
+// GetRole indicates an expected call of GetRole
 func (mr *MockClientMockRecorder) GetRole(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockClient)(nil).GetRole), input)
 }
 
-// GetUser mocks base method.
-func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUser", arg0)
-	ret0, _ := ret[0].(*iam.GetUserOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUser indicates an expected call of GetUser.
-func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
-}
-
-// GetUserPolicy mocks base method.
-func (m *MockClient) GetUserPolicy(arg0 *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUserPolicy", arg0)
-	ret0, _ := ret[0].(*iam.GetUserPolicyOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetUserPolicy indicates an expected call of GetUserPolicy.
-func (mr *MockClientMockRecorder) GetUserPolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicy", reflect.TypeOf((*MockClient)(nil).GetUserPolicy), arg0)
-}
-
-// ListAccessKeys mocks base method.
-func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
-	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListAccessKeys indicates an expected call of ListAccessKeys.
-func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
-}
-
-// ListObjects mocks base method.
-func (m *MockClient) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListObjects", input)
-	ret0, _ := ret[0].(*s3.ListObjectsOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListObjects indicates an expected call of ListObjects.
-func (mr *MockClientMockRecorder) ListObjects(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockClient)(nil).ListObjects), input)
-}
-
-// ListOpenIDConnectProviders mocks base method.
-func (m *MockClient) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListOpenIDConnectProviders", arg0)
-	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListOpenIDConnectProviders indicates an expected call of ListOpenIDConnectProviders.
-func (mr *MockClientMockRecorder) ListOpenIDConnectProviders(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProviders", reflect.TypeOf((*MockClient)(nil).ListOpenIDConnectProviders), arg0)
-}
-
-// ListRolePolicies mocks base method.
-func (m *MockClient) ListRolePolicies(input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListRolePolicies", input)
-	ret0, _ := ret[0].(*iam.ListRolePoliciesOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListRolePolicies indicates an expected call of ListRolePolicies.
-func (mr *MockClientMockRecorder) ListRolePolicies(input interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePolicies", reflect.TypeOf((*MockClient)(nil).ListRolePolicies), input)
-}
-
-// ListRoles mocks base method.
+// ListRoles mocks base method
 func (m *MockClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListRoles", input)
@@ -389,13 +178,133 @@ func (m *MockClient) ListRoles(input *iam.ListRolesInput) (*iam.ListRolesOutput,
 	return ret0, ret1
 }
 
-// ListRoles indicates an expected call of ListRoles.
+// ListRoles indicates an expected call of ListRoles
 func (mr *MockClientMockRecorder) ListRoles(input interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoles", reflect.TypeOf((*MockClient)(nil).ListRoles), input)
 }
 
-// ListUserPolicies mocks base method.
+// DeleteRole mocks base method
+func (m *MockClient) DeleteRole(input *iam.DeleteRoleInput) (*iam.DeleteRoleOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRole", input)
+	ret0, _ := ret[0].(*iam.DeleteRoleOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRole indicates an expected call of DeleteRole
+func (mr *MockClientMockRecorder) DeleteRole(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockClient)(nil).DeleteRole), input)
+}
+
+// ListRolePolicies mocks base method
+func (m *MockClient) ListRolePolicies(input *iam.ListRolePoliciesInput) (*iam.ListRolePoliciesOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRolePolicies", input)
+	ret0, _ := ret[0].(*iam.ListRolePoliciesOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRolePolicies indicates an expected call of ListRolePolicies
+func (mr *MockClientMockRecorder) ListRolePolicies(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRolePolicies", reflect.TypeOf((*MockClient)(nil).ListRolePolicies), input)
+}
+
+// DeleteRolePolicy mocks base method
+func (m *MockClient) DeleteRolePolicy(input *iam.DeleteRolePolicyInput) (*iam.DeleteRolePolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRolePolicy", input)
+	ret0, _ := ret[0].(*iam.DeleteRolePolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRolePolicy indicates an expected call of DeleteRolePolicy
+func (mr *MockClientMockRecorder) DeleteRolePolicy(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRolePolicy", reflect.TypeOf((*MockClient)(nil).DeleteRolePolicy), input)
+}
+
+// GetUser mocks base method
+func (m *MockClient) GetUser(arg0 *iam.GetUserInput) (*iam.GetUserOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUser", arg0)
+	ret0, _ := ret[0].(*iam.GetUserOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUser indicates an expected call of GetUser
+func (mr *MockClientMockRecorder) GetUser(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUser", reflect.TypeOf((*MockClient)(nil).GetUser), arg0)
+}
+
+// GetUserPolicy mocks base method
+func (m *MockClient) GetUserPolicy(arg0 *iam.GetUserPolicyInput) (*iam.GetUserPolicyOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserPolicy", arg0)
+	ret0, _ := ret[0].(*iam.GetUserPolicyOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserPolicy indicates an expected call of GetUserPolicy
+func (mr *MockClientMockRecorder) GetUserPolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPolicy", reflect.TypeOf((*MockClient)(nil).GetUserPolicy), arg0)
+}
+
+// ListAccessKeys mocks base method
+func (m *MockClient) ListAccessKeys(arg0 *iam.ListAccessKeysInput) (*iam.ListAccessKeysOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAccessKeys", arg0)
+	ret0, _ := ret[0].(*iam.ListAccessKeysOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAccessKeys indicates an expected call of ListAccessKeys
+func (mr *MockClientMockRecorder) ListAccessKeys(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAccessKeys", reflect.TypeOf((*MockClient)(nil).ListAccessKeys), arg0)
+}
+
+// ListOpenIDConnectProviders mocks base method
+func (m *MockClient) ListOpenIDConnectProviders(arg0 *iam.ListOpenIDConnectProvidersInput) (*iam.ListOpenIDConnectProvidersOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListOpenIDConnectProviders", arg0)
+	ret0, _ := ret[0].(*iam.ListOpenIDConnectProvidersOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListOpenIDConnectProviders indicates an expected call of ListOpenIDConnectProviders
+func (mr *MockClientMockRecorder) ListOpenIDConnectProviders(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOpenIDConnectProviders", reflect.TypeOf((*MockClient)(nil).ListOpenIDConnectProviders), arg0)
+}
+
+// DeleteOpenIDConnectProvider mocks base method
+func (m *MockClient) DeleteOpenIDConnectProvider(input *iam.DeleteOpenIDConnectProviderInput) (*iam.DeleteOpenIDConnectProviderOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteOpenIDConnectProvider", input)
+	ret0, _ := ret[0].(*iam.DeleteOpenIDConnectProviderOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteOpenIDConnectProvider indicates an expected call of DeleteOpenIDConnectProvider
+func (mr *MockClientMockRecorder) DeleteOpenIDConnectProvider(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).DeleteOpenIDConnectProvider), input)
+}
+
+// ListUserPolicies mocks base method
 func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.ListUserPoliciesOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListUserPolicies", arg0)
@@ -404,43 +313,13 @@ func (m *MockClient) ListUserPolicies(arg0 *iam.ListUserPoliciesInput) (*iam.Lis
 	return ret0, ret1
 }
 
-// ListUserPolicies indicates an expected call of ListUserPolicies.
+// ListUserPolicies indicates an expected call of ListUserPolicies
 func (mr *MockClientMockRecorder) ListUserPolicies(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUserPolicies", reflect.TypeOf((*MockClient)(nil).ListUserPolicies), arg0)
 }
 
-// PutBucketTagging mocks base method.
-func (m *MockClient) PutBucketTagging(arg0 *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutBucketTagging", arg0)
-	ret0, _ := ret[0].(*s3.PutBucketTaggingOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PutBucketTagging indicates an expected call of PutBucketTagging.
-func (mr *MockClientMockRecorder) PutBucketTagging(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBucketTagging", reflect.TypeOf((*MockClient)(nil).PutBucketTagging), arg0)
-}
-
-// PutObject mocks base method.
-func (m *MockClient) PutObject(arg0 *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "PutObject", arg0)
-	ret0, _ := ret[0].(*s3.PutObjectOutput)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// PutObject indicates an expected call of PutObject.
-func (mr *MockClientMockRecorder) PutObject(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutObject", reflect.TypeOf((*MockClient)(nil).PutObject), arg0)
-}
-
-// PutRolePolicy mocks base method.
+// PutRolePolicy mocks base method
 func (m *MockClient) PutRolePolicy(arg0 *iam.PutRolePolicyInput) (*iam.PutRolePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutRolePolicy", arg0)
@@ -449,13 +328,13 @@ func (m *MockClient) PutRolePolicy(arg0 *iam.PutRolePolicyInput) (*iam.PutRolePo
 	return ret0, ret1
 }
 
-// PutRolePolicy indicates an expected call of PutRolePolicy.
+// PutRolePolicy indicates an expected call of PutRolePolicy
 func (mr *MockClientMockRecorder) PutRolePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutRolePolicy", reflect.TypeOf((*MockClient)(nil).PutRolePolicy), arg0)
 }
 
-// PutUserPolicy mocks base method.
+// PutUserPolicy mocks base method
 func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "PutUserPolicy", arg0)
@@ -464,13 +343,13 @@ func (m *MockClient) PutUserPolicy(arg0 *iam.PutUserPolicyInput) (*iam.PutUserPo
 	return ret0, ret1
 }
 
-// PutUserPolicy indicates an expected call of PutUserPolicy.
+// PutUserPolicy indicates an expected call of PutUserPolicy
 func (mr *MockClientMockRecorder) PutUserPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutUserPolicy", reflect.TypeOf((*MockClient)(nil).PutUserPolicy), arg0)
 }
 
-// SimulatePrincipalPolicy mocks base method.
+// SimulatePrincipalPolicy mocks base method
 func (m *MockClient) SimulatePrincipalPolicy(arg0 *iam.SimulatePrincipalPolicyInput) (*iam.SimulatePolicyResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulatePrincipalPolicy", arg0)
@@ -479,13 +358,13 @@ func (m *MockClient) SimulatePrincipalPolicy(arg0 *iam.SimulatePrincipalPolicyIn
 	return ret0, ret1
 }
 
-// SimulatePrincipalPolicy indicates an expected call of SimulatePrincipalPolicy.
+// SimulatePrincipalPolicy indicates an expected call of SimulatePrincipalPolicy
 func (mr *MockClientMockRecorder) SimulatePrincipalPolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicy", reflect.TypeOf((*MockClient)(nil).SimulatePrincipalPolicy), arg0)
 }
 
-// SimulatePrincipalPolicyPages mocks base method.
+// SimulatePrincipalPolicyPages mocks base method
 func (m *MockClient) SimulatePrincipalPolicyPages(arg0 *iam.SimulatePrincipalPolicyInput, arg1 func(*iam.SimulatePolicyResponse, bool) bool) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SimulatePrincipalPolicyPages", arg0, arg1)
@@ -493,13 +372,13 @@ func (m *MockClient) SimulatePrincipalPolicyPages(arg0 *iam.SimulatePrincipalPol
 	return ret0
 }
 
-// SimulatePrincipalPolicyPages indicates an expected call of SimulatePrincipalPolicyPages.
+// SimulatePrincipalPolicyPages indicates an expected call of SimulatePrincipalPolicyPages
 func (mr *MockClientMockRecorder) SimulatePrincipalPolicyPages(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SimulatePrincipalPolicyPages", reflect.TypeOf((*MockClient)(nil).SimulatePrincipalPolicyPages), arg0, arg1)
 }
 
-// TagOpenIDConnectProvider mocks base method.
+// TagOpenIDConnectProvider mocks base method
 func (m *MockClient) TagOpenIDConnectProvider(arg0 *iam.TagOpenIDConnectProviderInput) (*iam.TagOpenIDConnectProviderOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagOpenIDConnectProvider", arg0)
@@ -508,13 +387,13 @@ func (m *MockClient) TagOpenIDConnectProvider(arg0 *iam.TagOpenIDConnectProvider
 	return ret0, ret1
 }
 
-// TagOpenIDConnectProvider indicates an expected call of TagOpenIDConnectProvider.
+// TagOpenIDConnectProvider indicates an expected call of TagOpenIDConnectProvider
 func (mr *MockClientMockRecorder) TagOpenIDConnectProvider(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagOpenIDConnectProvider", reflect.TypeOf((*MockClient)(nil).TagOpenIDConnectProvider), arg0)
 }
 
-// TagUser mocks base method.
+// TagUser mocks base method
 func (m *MockClient) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TagUser", arg0)
@@ -523,13 +402,13 @@ func (m *MockClient) TagUser(arg0 *iam.TagUserInput) (*iam.TagUserOutput, error)
 	return ret0, ret1
 }
 
-// TagUser indicates an expected call of TagUser.
+// TagUser indicates an expected call of TagUser
 func (mr *MockClientMockRecorder) TagUser(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TagUser", reflect.TypeOf((*MockClient)(nil).TagUser), arg0)
 }
 
-// UpdateAssumeRolePolicy mocks base method.
+// UpdateAssumeRolePolicy mocks base method
 func (m *MockClient) UpdateAssumeRolePolicy(arg0 *iam.UpdateAssumeRolePolicyInput) (*iam.UpdateAssumeRolePolicyOutput, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdateAssumeRolePolicy", arg0)
@@ -538,8 +417,128 @@ func (m *MockClient) UpdateAssumeRolePolicy(arg0 *iam.UpdateAssumeRolePolicyInpu
 	return ret0, ret1
 }
 
-// UpdateAssumeRolePolicy indicates an expected call of UpdateAssumeRolePolicy.
+// UpdateAssumeRolePolicy indicates an expected call of UpdateAssumeRolePolicy
 func (mr *MockClientMockRecorder) UpdateAssumeRolePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAssumeRolePolicy", reflect.TypeOf((*MockClient)(nil).UpdateAssumeRolePolicy), arg0)
+}
+
+// CreateBucket mocks base method
+func (m *MockClient) CreateBucket(arg0 *s3.CreateBucketInput) (*s3.CreateBucketOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBucket", arg0)
+	ret0, _ := ret[0].(*s3.CreateBucketOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateBucket indicates an expected call of CreateBucket
+func (mr *MockClientMockRecorder) CreateBucket(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockClient)(nil).CreateBucket), arg0)
+}
+
+// PutBucketTagging mocks base method
+func (m *MockClient) PutBucketTagging(arg0 *s3.PutBucketTaggingInput) (*s3.PutBucketTaggingOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutBucketTagging", arg0)
+	ret0, _ := ret[0].(*s3.PutBucketTaggingOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutBucketTagging indicates an expected call of PutBucketTagging
+func (mr *MockClientMockRecorder) PutBucketTagging(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutBucketTagging", reflect.TypeOf((*MockClient)(nil).PutBucketTagging), arg0)
+}
+
+// GetBucketTagging mocks base method
+func (m *MockClient) GetBucketTagging(input *s3.GetBucketTaggingInput) (*s3.GetBucketTaggingOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBucketTagging", input)
+	ret0, _ := ret[0].(*s3.GetBucketTaggingOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBucketTagging indicates an expected call of GetBucketTagging
+func (mr *MockClientMockRecorder) GetBucketTagging(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBucketTagging", reflect.TypeOf((*MockClient)(nil).GetBucketTagging), input)
+}
+
+// DeleteBucket mocks base method
+func (m *MockClient) DeleteBucket(input *s3.DeleteBucketInput) (*s3.DeleteBucketOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteBucket", input)
+	ret0, _ := ret[0].(*s3.DeleteBucketOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteBucket indicates an expected call of DeleteBucket
+func (mr *MockClientMockRecorder) DeleteBucket(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteBucket", reflect.TypeOf((*MockClient)(nil).DeleteBucket), input)
+}
+
+// PutObject mocks base method
+func (m *MockClient) PutObject(arg0 *s3.PutObjectInput) (*s3.PutObjectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PutObject", arg0)
+	ret0, _ := ret[0].(*s3.PutObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// PutObject indicates an expected call of PutObject
+func (mr *MockClientMockRecorder) PutObject(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PutObject", reflect.TypeOf((*MockClient)(nil).PutObject), arg0)
+}
+
+// ListObjects mocks base method
+func (m *MockClient) ListObjects(input *s3.ListObjectsInput) (*s3.ListObjectsOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListObjects", input)
+	ret0, _ := ret[0].(*s3.ListObjectsOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListObjects indicates an expected call of ListObjects
+func (mr *MockClientMockRecorder) ListObjects(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockClient)(nil).ListObjects), input)
+}
+
+// GetObjectTagging mocks base method
+func (m *MockClient) GetObjectTagging(input *s3.GetObjectTaggingInput) (*s3.GetObjectTaggingOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetObjectTagging", input)
+	ret0, _ := ret[0].(*s3.GetObjectTaggingOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetObjectTagging indicates an expected call of GetObjectTagging
+func (mr *MockClientMockRecorder) GetObjectTagging(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetObjectTagging", reflect.TypeOf((*MockClient)(nil).GetObjectTagging), input)
+}
+
+// DeleteObject mocks base method
+func (m *MockClient) DeleteObject(input *s3.DeleteObjectInput) (*s3.DeleteObjectOutput, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteObject", input)
+	ret0, _ := ret[0].(*s3.DeleteObjectOutput)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteObject indicates an expected call of DeleteObject
+func (mr *MockClientMockRecorder) DeleteObject(input interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockClient)(nil).DeleteObject), input)
 }

--- a/pkg/azure/mock/client_generated.go
+++ b/pkg/azure/mock/client_generated.go
@@ -6,66 +6,36 @@ package mock
 
 import (
 	context "context"
-	reflect "reflect"
-
 	authorization "github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	graphrbac "github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockAppClient is a mock of AppClient interface.
+// MockAppClient is a mock of AppClient interface
 type MockAppClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockAppClientMockRecorder
 }
 
-// MockAppClientMockRecorder is the mock recorder for MockAppClient.
+// MockAppClientMockRecorder is the mock recorder for MockAppClient
 type MockAppClientMockRecorder struct {
 	mock *MockAppClient
 }
 
-// NewMockAppClient creates a new mock instance.
+// NewMockAppClient creates a new mock instance
 func NewMockAppClient(ctrl *gomock.Controller) *MockAppClient {
 	mock := &MockAppClient{ctrl: ctrl}
 	mock.recorder = &MockAppClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAppClient) EXPECT() *MockAppClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
-func (m *MockAppClient) Create(ctx context.Context, parameters graphrbac.ApplicationCreateParameters) (graphrbac.Application, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, parameters)
-	ret0, _ := ret[0].(graphrbac.Application)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Create indicates an expected call of Create.
-func (mr *MockAppClientMockRecorder) Create(ctx, parameters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockAppClient)(nil).Create), ctx, parameters)
-}
-
-// Delete mocks base method.
-func (m *MockAppClient) Delete(ctx context.Context, applicationObjectID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, applicationObjectID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockAppClientMockRecorder) Delete(ctx, applicationObjectID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAppClient)(nil).Delete), ctx, applicationObjectID)
-}
-
-// List mocks base method.
+// List mocks base method
 func (m *MockAppClient) List(ctx context.Context, filter string) ([]graphrbac.Application, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, filter)
@@ -74,13 +44,28 @@ func (m *MockAppClient) List(ctx context.Context, filter string) ([]graphrbac.Ap
 	return ret0, ret1
 }
 
-// List indicates an expected call of List.
+// List indicates an expected call of List
 func (mr *MockAppClientMockRecorder) List(ctx, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAppClient)(nil).List), ctx, filter)
 }
 
-// UpdatePasswordCredentials mocks base method.
+// Create mocks base method
+func (m *MockAppClient) Create(ctx context.Context, parameters graphrbac.ApplicationCreateParameters) (graphrbac.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, parameters)
+	ret0, _ := ret[0].(graphrbac.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create
+func (mr *MockAppClientMockRecorder) Create(ctx, parameters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockAppClient)(nil).Create), ctx, parameters)
+}
+
+// UpdatePasswordCredentials mocks base method
 func (m *MockAppClient) UpdatePasswordCredentials(ctx context.Context, applicationObjectID string, parameters graphrbac.PasswordCredentialsUpdateParameters) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpdatePasswordCredentials", ctx, applicationObjectID, parameters)
@@ -88,51 +73,50 @@ func (m *MockAppClient) UpdatePasswordCredentials(ctx context.Context, applicati
 	return ret0
 }
 
-// UpdatePasswordCredentials indicates an expected call of UpdatePasswordCredentials.
+// UpdatePasswordCredentials indicates an expected call of UpdatePasswordCredentials
 func (mr *MockAppClientMockRecorder) UpdatePasswordCredentials(ctx, applicationObjectID, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePasswordCredentials", reflect.TypeOf((*MockAppClient)(nil).UpdatePasswordCredentials), ctx, applicationObjectID, parameters)
 }
 
-// MockServicePrincipalClient is a mock of ServicePrincipalClient interface.
+// Delete mocks base method
+func (m *MockAppClient) Delete(ctx context.Context, applicationObjectID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, applicationObjectID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockAppClientMockRecorder) Delete(ctx, applicationObjectID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAppClient)(nil).Delete), ctx, applicationObjectID)
+}
+
+// MockServicePrincipalClient is a mock of ServicePrincipalClient interface
 type MockServicePrincipalClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockServicePrincipalClientMockRecorder
 }
 
-// MockServicePrincipalClientMockRecorder is the mock recorder for MockServicePrincipalClient.
+// MockServicePrincipalClientMockRecorder is the mock recorder for MockServicePrincipalClient
 type MockServicePrincipalClientMockRecorder struct {
 	mock *MockServicePrincipalClient
 }
 
-// NewMockServicePrincipalClient creates a new mock instance.
+// NewMockServicePrincipalClient creates a new mock instance
 func NewMockServicePrincipalClient(ctrl *gomock.Controller) *MockServicePrincipalClient {
 	mock := &MockServicePrincipalClient{ctrl: ctrl}
 	mock.recorder = &MockServicePrincipalClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockServicePrincipalClient) EXPECT() *MockServicePrincipalClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
-func (m *MockServicePrincipalClient) Create(ctx context.Context, parameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, parameters)
-	ret0, _ := ret[0].(graphrbac.ServicePrincipal)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Create indicates an expected call of Create.
-func (mr *MockServicePrincipalClientMockRecorder) Create(ctx, parameters interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockServicePrincipalClient)(nil).Create), ctx, parameters)
-}
-
-// List mocks base method.
+// List mocks base method
 func (m *MockServicePrincipalClient) List(ctx context.Context, filter string) ([]graphrbac.ServicePrincipal, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, filter)
@@ -141,36 +125,51 @@ func (m *MockServicePrincipalClient) List(ctx context.Context, filter string) ([
 	return ret0, ret1
 }
 
-// List indicates an expected call of List.
+// List indicates an expected call of List
 func (mr *MockServicePrincipalClientMockRecorder) List(ctx, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockServicePrincipalClient)(nil).List), ctx, filter)
 }
 
-// MockRoleAssignmentsClient is a mock of RoleAssignmentsClient interface.
+// Create mocks base method
+func (m *MockServicePrincipalClient) Create(ctx context.Context, parameters graphrbac.ServicePrincipalCreateParameters) (graphrbac.ServicePrincipal, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, parameters)
+	ret0, _ := ret[0].(graphrbac.ServicePrincipal)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create
+func (mr *MockServicePrincipalClientMockRecorder) Create(ctx, parameters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockServicePrincipalClient)(nil).Create), ctx, parameters)
+}
+
+// MockRoleAssignmentsClient is a mock of RoleAssignmentsClient interface
 type MockRoleAssignmentsClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockRoleAssignmentsClientMockRecorder
 }
 
-// MockRoleAssignmentsClientMockRecorder is the mock recorder for MockRoleAssignmentsClient.
+// MockRoleAssignmentsClientMockRecorder is the mock recorder for MockRoleAssignmentsClient
 type MockRoleAssignmentsClientMockRecorder struct {
 	mock *MockRoleAssignmentsClient
 }
 
-// NewMockRoleAssignmentsClient creates a new mock instance.
+// NewMockRoleAssignmentsClient creates a new mock instance
 func NewMockRoleAssignmentsClient(ctrl *gomock.Controller) *MockRoleAssignmentsClient {
 	mock := &MockRoleAssignmentsClient{ctrl: ctrl}
 	mock.recorder = &MockRoleAssignmentsClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRoleAssignmentsClient) EXPECT() *MockRoleAssignmentsClientMockRecorder {
 	return m.recorder
 }
 
-// Create mocks base method.
+// Create mocks base method
 func (m *MockRoleAssignmentsClient) Create(ctx context.Context, scope, roleAssignmentName string, parameters authorization.RoleAssignmentCreateParameters) (authorization.RoleAssignment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Create", ctx, scope, roleAssignmentName, parameters)
@@ -179,27 +178,13 @@ func (m *MockRoleAssignmentsClient) Create(ctx context.Context, scope, roleAssig
 	return ret0, ret1
 }
 
-// Create indicates an expected call of Create.
+// Create indicates an expected call of Create
 func (mr *MockRoleAssignmentsClientMockRecorder) Create(ctx, scope, roleAssignmentName, parameters interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).Create), ctx, scope, roleAssignmentName, parameters)
 }
 
-// DeleteByID mocks base method.
-func (m *MockRoleAssignmentsClient) DeleteByID(ctx context.Context, roleAssignmentID string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteByID", ctx, roleAssignmentID)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// DeleteByID indicates an expected call of DeleteByID.
-func (mr *MockRoleAssignmentsClientMockRecorder) DeleteByID(ctx, roleAssignmentID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).DeleteByID), ctx, roleAssignmentID)
-}
-
-// List mocks base method.
+// List mocks base method
 func (m *MockRoleAssignmentsClient) List(ctx context.Context, filter string) ([]authorization.RoleAssignment, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, filter)
@@ -208,36 +193,50 @@ func (m *MockRoleAssignmentsClient) List(ctx context.Context, filter string) ([]
 	return ret0, ret1
 }
 
-// List indicates an expected call of List.
+// List indicates an expected call of List
 func (mr *MockRoleAssignmentsClientMockRecorder) List(ctx, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).List), ctx, filter)
 }
 
-// MockRoleDefinitionClient is a mock of RoleDefinitionClient interface.
+// DeleteByID mocks base method
+func (m *MockRoleAssignmentsClient) DeleteByID(ctx context.Context, roleAssignmentID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteByID", ctx, roleAssignmentID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteByID indicates an expected call of DeleteByID
+func (mr *MockRoleAssignmentsClientMockRecorder) DeleteByID(ctx, roleAssignmentID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockRoleAssignmentsClient)(nil).DeleteByID), ctx, roleAssignmentID)
+}
+
+// MockRoleDefinitionClient is a mock of RoleDefinitionClient interface
 type MockRoleDefinitionClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockRoleDefinitionClientMockRecorder
 }
 
-// MockRoleDefinitionClientMockRecorder is the mock recorder for MockRoleDefinitionClient.
+// MockRoleDefinitionClientMockRecorder is the mock recorder for MockRoleDefinitionClient
 type MockRoleDefinitionClientMockRecorder struct {
 	mock *MockRoleDefinitionClient
 }
 
-// NewMockRoleDefinitionClient creates a new mock instance.
+// NewMockRoleDefinitionClient creates a new mock instance
 func NewMockRoleDefinitionClient(ctrl *gomock.Controller) *MockRoleDefinitionClient {
 	mock := &MockRoleDefinitionClient{ctrl: ctrl}
 	mock.recorder = &MockRoleDefinitionClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockRoleDefinitionClient) EXPECT() *MockRoleDefinitionClientMockRecorder {
 	return m.recorder
 }
 
-// List mocks base method.
+// List mocks base method
 func (m *MockRoleDefinitionClient) List(ctx context.Context, scope, filter string) ([]authorization.RoleDefinition, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, scope, filter)
@@ -246,7 +245,7 @@ func (m *MockRoleDefinitionClient) List(ctx context.Context, scope, filter strin
 	return ret0, ret1
 }
 
-// List indicates an expected call of List.
+// List indicates an expected call of List
 func (mr *MockRoleDefinitionClientMockRecorder) List(ctx, scope, filter interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRoleDefinitionClient)(nil).List), ctx, scope, filter)

--- a/pkg/gcp/mock/client_generated.go
+++ b/pkg/gcp/mock/client_generated.go
@@ -6,38 +6,37 @@ package mock
 
 import (
 	context "context"
-	reflect "reflect"
-
 	gomock "github.com/golang/mock/gomock"
 	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
 	iam "google.golang.org/api/iam/v1"
 	admin "google.golang.org/genproto/googleapis/iam/admin/v1"
+	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateServiceAccount mocks base method.
+// CreateServiceAccount mocks base method
 func (m *MockClient) CreateServiceAccount(arg0 context.Context, arg1 *admin.CreateServiceAccountRequest) (*admin.ServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceAccount", arg0, arg1)
@@ -46,13 +45,13 @@ func (m *MockClient) CreateServiceAccount(arg0 context.Context, arg1 *admin.Crea
 	return ret0, ret1
 }
 
-// CreateServiceAccount indicates an expected call of CreateServiceAccount.
+// CreateServiceAccount indicates an expected call of CreateServiceAccount
 func (mr *MockClientMockRecorder) CreateServiceAccount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceAccount", reflect.TypeOf((*MockClient)(nil).CreateServiceAccount), arg0, arg1)
 }
 
-// CreateServiceAccountKey mocks base method.
+// CreateServiceAccountKey mocks base method
 func (m *MockClient) CreateServiceAccountKey(arg0 context.Context, arg1 *admin.CreateServiceAccountKeyRequest) (*admin.ServiceAccountKey, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceAccountKey", arg0, arg1)
@@ -61,28 +60,13 @@ func (m *MockClient) CreateServiceAccountKey(arg0 context.Context, arg1 *admin.C
 	return ret0, ret1
 }
 
-// CreateServiceAccountKey indicates an expected call of CreateServiceAccountKey.
+// CreateServiceAccountKey indicates an expected call of CreateServiceAccountKey
 func (mr *MockClientMockRecorder) CreateServiceAccountKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceAccountKey", reflect.TypeOf((*MockClient)(nil).CreateServiceAccountKey), arg0, arg1)
 }
 
-// CreateWorkloadIdentityPool mocks base method.
-func (m *MockClient) CreateWorkloadIdentityPool(arg0 context.Context, arg1, arg2 string, arg3 *iam.WorkloadIdentityPool) (*iam.Operation, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateWorkloadIdentityPool", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*iam.Operation)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CreateWorkloadIdentityPool indicates an expected call of CreateWorkloadIdentityPool.
-func (mr *MockClientMockRecorder) CreateWorkloadIdentityPool(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkloadIdentityPool", reflect.TypeOf((*MockClient)(nil).CreateWorkloadIdentityPool), arg0, arg1, arg2, arg3)
-}
-
-// DeleteServiceAccount mocks base method.
+// DeleteServiceAccount mocks base method
 func (m *MockClient) DeleteServiceAccount(arg0 context.Context, arg1 *admin.DeleteServiceAccountRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceAccount", arg0, arg1)
@@ -90,13 +74,13 @@ func (m *MockClient) DeleteServiceAccount(arg0 context.Context, arg1 *admin.Dele
 	return ret0
 }
 
-// DeleteServiceAccount indicates an expected call of DeleteServiceAccount.
+// DeleteServiceAccount indicates an expected call of DeleteServiceAccount
 func (mr *MockClientMockRecorder) DeleteServiceAccount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceAccount", reflect.TypeOf((*MockClient)(nil).DeleteServiceAccount), arg0, arg1)
 }
 
-// DeleteServiceAccountKey mocks base method.
+// DeleteServiceAccountKey mocks base method
 func (m *MockClient) DeleteServiceAccountKey(arg0 context.Context, arg1 *admin.DeleteServiceAccountKeyRequest) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "DeleteServiceAccountKey", arg0, arg1)
@@ -104,42 +88,13 @@ func (m *MockClient) DeleteServiceAccountKey(arg0 context.Context, arg1 *admin.D
 	return ret0
 }
 
-// DeleteServiceAccountKey indicates an expected call of DeleteServiceAccountKey.
+// DeleteServiceAccountKey indicates an expected call of DeleteServiceAccountKey
 func (mr *MockClientMockRecorder) DeleteServiceAccountKey(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceAccountKey", reflect.TypeOf((*MockClient)(nil).DeleteServiceAccountKey), arg0, arg1)
 }
 
-// GetProjectIamPolicy mocks base method.
-func (m *MockClient) GetProjectIamPolicy(projectName string, request *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectIamPolicy", projectName, request)
-	ret0, _ := ret[0].(*cloudresourcemanager.Policy)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// GetProjectIamPolicy indicates an expected call of GetProjectIamPolicy.
-func (mr *MockClientMockRecorder) GetProjectIamPolicy(projectName, request interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectIamPolicy", reflect.TypeOf((*MockClient)(nil).GetProjectIamPolicy), projectName, request)
-}
-
-// GetProjectName mocks base method.
-func (m *MockClient) GetProjectName() string {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetProjectName")
-	ret0, _ := ret[0].(string)
-	return ret0
-}
-
-// GetProjectName indicates an expected call of GetProjectName.
-func (mr *MockClientMockRecorder) GetProjectName() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectName", reflect.TypeOf((*MockClient)(nil).GetProjectName))
-}
-
-// GetRole mocks base method.
+// GetRole mocks base method
 func (m *MockClient) GetRole(arg0 context.Context, arg1 *admin.GetRoleRequest) (*admin.Role, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRole", arg0, arg1)
@@ -148,13 +103,13 @@ func (m *MockClient) GetRole(arg0 context.Context, arg1 *admin.GetRoleRequest) (
 	return ret0, ret1
 }
 
-// GetRole indicates an expected call of GetRole.
+// GetRole indicates an expected call of GetRole
 func (mr *MockClientMockRecorder) GetRole(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRole", reflect.TypeOf((*MockClient)(nil).GetRole), arg0, arg1)
 }
 
-// GetServiceAccount mocks base method.
+// GetServiceAccount mocks base method
 func (m *MockClient) GetServiceAccount(arg0 context.Context, arg1 *admin.GetServiceAccountRequest) (*admin.ServiceAccount, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetServiceAccount", arg0, arg1)
@@ -163,13 +118,13 @@ func (m *MockClient) GetServiceAccount(arg0 context.Context, arg1 *admin.GetServ
 	return ret0, ret1
 }
 
-// GetServiceAccount indicates an expected call of GetServiceAccount.
+// GetServiceAccount indicates an expected call of GetServiceAccount
 func (mr *MockClientMockRecorder) GetServiceAccount(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetServiceAccount", reflect.TypeOf((*MockClient)(nil).GetServiceAccount), arg0, arg1)
 }
 
-// ListServiceAccountKeys mocks base method.
+// ListServiceAccountKeys mocks base method
 func (m *MockClient) ListServiceAccountKeys(arg0 context.Context, arg1 *admin.ListServiceAccountKeysRequest) (*admin.ListServiceAccountKeysResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceAccountKeys", arg0, arg1)
@@ -178,28 +133,13 @@ func (m *MockClient) ListServiceAccountKeys(arg0 context.Context, arg1 *admin.Li
 	return ret0, ret1
 }
 
-// ListServiceAccountKeys indicates an expected call of ListServiceAccountKeys.
+// ListServiceAccountKeys indicates an expected call of ListServiceAccountKeys
 func (mr *MockClientMockRecorder) ListServiceAccountKeys(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceAccountKeys", reflect.TypeOf((*MockClient)(nil).ListServiceAccountKeys), arg0, arg1)
 }
 
-// ListServicesEnabled mocks base method.
-func (m *MockClient) ListServicesEnabled() (map[string]bool, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServicesEnabled")
-	ret0, _ := ret[0].(map[string]bool)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ListServicesEnabled indicates an expected call of ListServicesEnabled.
-func (mr *MockClientMockRecorder) ListServicesEnabled() *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServicesEnabled", reflect.TypeOf((*MockClient)(nil).ListServicesEnabled))
-}
-
-// QueryTestablePermissions mocks base method.
+// QueryTestablePermissions mocks base method
 func (m *MockClient) QueryTestablePermissions(arg0 context.Context, arg1 *admin.QueryTestablePermissionsRequest) (*admin.QueryTestablePermissionsResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "QueryTestablePermissions", arg0, arg1)
@@ -208,13 +148,57 @@ func (m *MockClient) QueryTestablePermissions(arg0 context.Context, arg1 *admin.
 	return ret0, ret1
 }
 
-// QueryTestablePermissions indicates an expected call of QueryTestablePermissions.
+// QueryTestablePermissions indicates an expected call of QueryTestablePermissions
 func (mr *MockClientMockRecorder) QueryTestablePermissions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "QueryTestablePermissions", reflect.TypeOf((*MockClient)(nil).QueryTestablePermissions), arg0, arg1)
 }
 
-// SetProjectIamPolicy mocks base method.
+// CreateWorkloadIdentityPool mocks base method
+func (m *MockClient) CreateWorkloadIdentityPool(arg0 context.Context, arg1, arg2 string, arg3 *iam.WorkloadIdentityPool) (*iam.Operation, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWorkloadIdentityPool", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*iam.Operation)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWorkloadIdentityPool indicates an expected call of CreateWorkloadIdentityPool
+func (mr *MockClientMockRecorder) CreateWorkloadIdentityPool(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkloadIdentityPool", reflect.TypeOf((*MockClient)(nil).CreateWorkloadIdentityPool), arg0, arg1, arg2, arg3)
+}
+
+// GetProjectIamPolicy mocks base method
+func (m *MockClient) GetProjectIamPolicy(projectName string, request *cloudresourcemanager.GetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProjectIamPolicy", projectName, request)
+	ret0, _ := ret[0].(*cloudresourcemanager.Policy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetProjectIamPolicy indicates an expected call of GetProjectIamPolicy
+func (mr *MockClientMockRecorder) GetProjectIamPolicy(projectName, request interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectIamPolicy", reflect.TypeOf((*MockClient)(nil).GetProjectIamPolicy), projectName, request)
+}
+
+// GetProjectName mocks base method
+func (m *MockClient) GetProjectName() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetProjectName")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// GetProjectName indicates an expected call of GetProjectName
+func (mr *MockClientMockRecorder) GetProjectName() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProjectName", reflect.TypeOf((*MockClient)(nil).GetProjectName))
+}
+
+// SetProjectIamPolicy mocks base method
 func (m *MockClient) SetProjectIamPolicy(projectName string, request *cloudresourcemanager.SetIamPolicyRequest) (*cloudresourcemanager.Policy, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetProjectIamPolicy", projectName, request)
@@ -223,13 +207,13 @@ func (m *MockClient) SetProjectIamPolicy(projectName string, request *cloudresou
 	return ret0, ret1
 }
 
-// SetProjectIamPolicy indicates an expected call of SetProjectIamPolicy.
+// SetProjectIamPolicy indicates an expected call of SetProjectIamPolicy
 func (mr *MockClientMockRecorder) SetProjectIamPolicy(projectName, request interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetProjectIamPolicy", reflect.TypeOf((*MockClient)(nil).SetProjectIamPolicy), projectName, request)
 }
 
-// TestIamPermissions mocks base method.
+// TestIamPermissions mocks base method
 func (m *MockClient) TestIamPermissions(arg0 string, arg1 *cloudresourcemanager.TestIamPermissionsRequest) (*cloudresourcemanager.TestIamPermissionsResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "TestIamPermissions", arg0, arg1)
@@ -238,8 +222,23 @@ func (m *MockClient) TestIamPermissions(arg0 string, arg1 *cloudresourcemanager.
 	return ret0, ret1
 }
 
-// TestIamPermissions indicates an expected call of TestIamPermissions.
+// TestIamPermissions indicates an expected call of TestIamPermissions
 func (mr *MockClientMockRecorder) TestIamPermissions(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestIamPermissions", reflect.TypeOf((*MockClient)(nil).TestIamPermissions), arg0, arg1)
+}
+
+// ListServicesEnabled mocks base method
+func (m *MockClient) ListServicesEnabled() (map[string]bool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServicesEnabled")
+	ret0, _ := ret[0].(map[string]bool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListServicesEnabled indicates an expected call of ListServicesEnabled
+func (mr *MockClientMockRecorder) ListServicesEnabled() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServicesEnabled", reflect.TypeOf((*MockClient)(nil).ListServicesEnabled))
 }

--- a/pkg/ibmcloud/mock/client_generated.go
+++ b/pkg/ibmcloud/mock/client_generated.go
@@ -5,55 +5,38 @@
 package mock
 
 import (
-	reflect "reflect"
-
 	core "github.com/IBM/go-sdk-core/v5/core"
 	iamidentityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	iampolicymanagementv1 "github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
 	resourcemanagerv2 "github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface.
+// MockClient is a mock of Client interface
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient.
+// MockClientMockRecorder is the mock recorder for MockClient
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance.
+// NewMockClient creates a new mock instance
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreateAPIKey mocks base method.
-func (m *MockClient) CreateAPIKey(arg0 *iamidentityv1.CreateAPIKeyOptions) (*iamidentityv1.APIKey, *core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateAPIKey", arg0)
-	ret0, _ := ret[0].(*iamidentityv1.APIKey)
-	ret1, _ := ret[1].(*core.DetailedResponse)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CreateAPIKey indicates an expected call of CreateAPIKey.
-func (mr *MockClientMockRecorder) CreateAPIKey(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAPIKey", reflect.TypeOf((*MockClient)(nil).CreateAPIKey), arg0)
-}
-
-// CreatePolicy mocks base method.
+// CreatePolicy mocks base method
 func (m *MockClient) CreatePolicy(arg0 *iampolicymanagementv1.CreatePolicyOptions) (*iampolicymanagementv1.Policy, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreatePolicy", arg0)
@@ -63,13 +46,13 @@ func (m *MockClient) CreatePolicy(arg0 *iampolicymanagementv1.CreatePolicyOption
 	return ret0, ret1, ret2
 }
 
-// CreatePolicy indicates an expected call of CreatePolicy.
+// CreatePolicy indicates an expected call of CreatePolicy
 func (mr *MockClientMockRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockClient)(nil).CreatePolicy), arg0)
 }
 
-// CreateServiceID mocks base method.
+// CreateServiceID mocks base method
 func (m *MockClient) CreateServiceID(arg0 *iamidentityv1.CreateServiceIDOptions) (*iamidentityv1.ServiceID, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateServiceID", arg0)
@@ -79,60 +62,13 @@ func (m *MockClient) CreateServiceID(arg0 *iamidentityv1.CreateServiceIDOptions)
 	return ret0, ret1, ret2
 }
 
-// CreateServiceID indicates an expected call of CreateServiceID.
+// CreateServiceID indicates an expected call of CreateServiceID
 func (mr *MockClientMockRecorder) CreateServiceID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceID", reflect.TypeOf((*MockClient)(nil).CreateServiceID), arg0)
 }
 
-// DeleteServiceID mocks base method.
-func (m *MockClient) DeleteServiceID(arg0 *iamidentityv1.DeleteServiceIDOptions) (*core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteServiceID", arg0)
-	ret0, _ := ret[0].(*core.DetailedResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteServiceID indicates an expected call of DeleteServiceID.
-func (mr *MockClientMockRecorder) DeleteServiceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceID", reflect.TypeOf((*MockClient)(nil).DeleteServiceID), arg0)
-}
-
-// GetAPIKeysDetails mocks base method.
-func (m *MockClient) GetAPIKeysDetails(arg0 *iamidentityv1.GetAPIKeysDetailsOptions) (*iamidentityv1.APIKey, *core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAPIKeysDetails", arg0)
-	ret0, _ := ret[0].(*iamidentityv1.APIKey)
-	ret1, _ := ret[1].(*core.DetailedResponse)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// GetAPIKeysDetails indicates an expected call of GetAPIKeysDetails.
-func (mr *MockClientMockRecorder) GetAPIKeysDetails(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKeysDetails", reflect.TypeOf((*MockClient)(nil).GetAPIKeysDetails), arg0)
-}
-
-// ListResourceGroups mocks base method.
-func (m *MockClient) ListResourceGroups(arg0 *resourcemanagerv2.ListResourceGroupsOptions) (*resourcemanagerv2.ResourceGroupList, *core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListResourceGroups", arg0)
-	ret0, _ := ret[0].(*resourcemanagerv2.ResourceGroupList)
-	ret1, _ := ret[1].(*core.DetailedResponse)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ListResourceGroups indicates an expected call of ListResourceGroups.
-func (mr *MockClientMockRecorder) ListResourceGroups(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceGroups", reflect.TypeOf((*MockClient)(nil).ListResourceGroups), arg0)
-}
-
-// ListServiceID mocks base method.
+// ListServiceID mocks base method
 func (m *MockClient) ListServiceID(arg0 *iamidentityv1.ListServiceIdsOptions) (*iamidentityv1.ServiceIDList, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListServiceID", arg0)
@@ -142,13 +78,60 @@ func (m *MockClient) ListServiceID(arg0 *iamidentityv1.ListServiceIdsOptions) (*
 	return ret0, ret1, ret2
 }
 
-// ListServiceID indicates an expected call of ListServiceID.
+// ListServiceID indicates an expected call of ListServiceID
 func (mr *MockClientMockRecorder) ListServiceID(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceID", reflect.TypeOf((*MockClient)(nil).ListServiceID), arg0)
 }
 
-// NewGetAPIKeysDetailsOptions mocks base method.
+// DeleteServiceID mocks base method
+func (m *MockClient) DeleteServiceID(arg0 *iamidentityv1.DeleteServiceIDOptions) (*core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteServiceID", arg0)
+	ret0, _ := ret[0].(*core.DetailedResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteServiceID indicates an expected call of DeleteServiceID
+func (mr *MockClientMockRecorder) DeleteServiceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceID", reflect.TypeOf((*MockClient)(nil).DeleteServiceID), arg0)
+}
+
+// CreateAPIKey mocks base method
+func (m *MockClient) CreateAPIKey(arg0 *iamidentityv1.CreateAPIKeyOptions) (*iamidentityv1.APIKey, *core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateAPIKey", arg0)
+	ret0, _ := ret[0].(*iamidentityv1.APIKey)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateAPIKey indicates an expected call of CreateAPIKey
+func (mr *MockClientMockRecorder) CreateAPIKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAPIKey", reflect.TypeOf((*MockClient)(nil).CreateAPIKey), arg0)
+}
+
+// GetAPIKeysDetails mocks base method
+func (m *MockClient) GetAPIKeysDetails(arg0 *iamidentityv1.GetAPIKeysDetailsOptions) (*iamidentityv1.APIKey, *core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetAPIKeysDetails", arg0)
+	ret0, _ := ret[0].(*iamidentityv1.APIKey)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// GetAPIKeysDetails indicates an expected call of GetAPIKeysDetails
+func (mr *MockClientMockRecorder) GetAPIKeysDetails(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKeysDetails", reflect.TypeOf((*MockClient)(nil).GetAPIKeysDetails), arg0)
+}
+
+// NewGetAPIKeysDetailsOptions mocks base method
 func (m *MockClient) NewGetAPIKeysDetailsOptions() *iamidentityv1.GetAPIKeysDetailsOptions {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewGetAPIKeysDetailsOptions")
@@ -156,8 +139,24 @@ func (m *MockClient) NewGetAPIKeysDetailsOptions() *iamidentityv1.GetAPIKeysDeta
 	return ret0
 }
 
-// NewGetAPIKeysDetailsOptions indicates an expected call of NewGetAPIKeysDetailsOptions.
+// NewGetAPIKeysDetailsOptions indicates an expected call of NewGetAPIKeysDetailsOptions
 func (mr *MockClientMockRecorder) NewGetAPIKeysDetailsOptions() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGetAPIKeysDetailsOptions", reflect.TypeOf((*MockClient)(nil).NewGetAPIKeysDetailsOptions))
+}
+
+// ListResourceGroups mocks base method
+func (m *MockClient) ListResourceGroups(arg0 *resourcemanagerv2.ListResourceGroupsOptions) (*resourcemanagerv2.ResourceGroupList, *core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListResourceGroups", arg0)
+	ret0, _ := ret[0].(*resourcemanagerv2.ResourceGroupList)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListResourceGroups indicates an expected call of ListResourceGroups
+func (mr *MockClientMockRecorder) ListResourceGroups(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceGroups", reflect.TypeOf((*MockClient)(nil).ListResourceGroups), arg0)
 }

--- a/pkg/operator/secretannotator/azure/mock/adal_generated.go
+++ b/pkg/operator/secretannotator/azure/mock/adal_generated.go
@@ -5,36 +5,35 @@
 package mock
 
 import (
-	reflect "reflect"
-
 	adal "github.com/Azure/go-autorest/autorest/adal"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
-// MockAdalService is a mock of AdalService interface.
+// MockAdalService is a mock of AdalService interface
 type MockAdalService struct {
 	ctrl     *gomock.Controller
 	recorder *MockAdalServiceMockRecorder
 }
 
-// MockAdalServiceMockRecorder is the mock recorder for MockAdalService.
+// MockAdalServiceMockRecorder is the mock recorder for MockAdalService
 type MockAdalServiceMockRecorder struct {
 	mock *MockAdalService
 }
 
-// NewMockAdalService creates a new mock instance.
+// NewMockAdalService creates a new mock instance
 func NewMockAdalService(ctrl *gomock.Controller) *MockAdalService {
 	mock := &MockAdalService{ctrl: ctrl}
 	mock.recorder = &MockAdalServiceMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use.
+// EXPECT returns an object that allows the caller to indicate expected use
 func (m *MockAdalService) EXPECT() *MockAdalServiceMockRecorder {
 	return m.recorder
 }
 
-// NewOAuthConfig mocks base method.
+// NewOAuthConfig mocks base method
 func (m *MockAdalService) NewOAuthConfig(activeDirectoryEndpoint, tenantID string) (*adal.OAuthConfig, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "NewOAuthConfig", activeDirectoryEndpoint, tenantID)
@@ -43,13 +42,13 @@ func (m *MockAdalService) NewOAuthConfig(activeDirectoryEndpoint, tenantID strin
 	return ret0, ret1
 }
 
-// NewOAuthConfig indicates an expected call of NewOAuthConfig.
+// NewOAuthConfig indicates an expected call of NewOAuthConfig
 func (mr *MockAdalServiceMockRecorder) NewOAuthConfig(activeDirectoryEndpoint, tenantID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewOAuthConfig", reflect.TypeOf((*MockAdalService)(nil).NewOAuthConfig), activeDirectoryEndpoint, tenantID)
 }
 
-// NewServicePrincipalToken mocks base method.
+// NewServicePrincipalToken mocks base method
 func (m *MockAdalService) NewServicePrincipalToken(oauthConfig adal.OAuthConfig, clientID, secret, resource string, callbacks ...adal.TokenRefreshCallback) (*adal.ServicePrincipalToken, error) {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{oauthConfig, clientID, secret, resource}
@@ -62,7 +61,7 @@ func (m *MockAdalService) NewServicePrincipalToken(oauthConfig adal.OAuthConfig,
 	return ret0, ret1
 }
 
-// NewServicePrincipalToken indicates an expected call of NewServicePrincipalToken.
+// NewServicePrincipalToken indicates an expected call of NewServicePrincipalToken
 func (mr *MockAdalServiceMockRecorder) NewServicePrincipalToken(oauthConfig, clientID, secret, resource interface{}, callbacks ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{oauthConfig, clientID, secret, resource}, callbacks...)


### PR DESCRIPTION
As requested in the alerting consistency enhancement
    https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md, update the prometheus alerts in the repo to add summary and description annotations to each alert.