### PR TITLE
ccoctl ibmcloud refresh-keys command

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -58,4 +58,5 @@ require (
 	k8s.io/code-generator v0.19.2
 	k8s.io/utils v0.0.0-20200729134348-d5654de09c73
 	sigs.k8s.io/controller-runtime v0.6.2
+	sigs.k8s.io/yaml v1.2.0
 )

--- a/pkg/cmd/provisioning/ibmcloud/create_service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_service_id.go
@@ -12,8 +12,6 @@ import (
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/util/yaml"
 
-	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
-
 	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 	"github.com/openshift/cloud-credential-operator/pkg/ibmcloud"
@@ -96,22 +94,9 @@ func createServiceIDCmd(cmd *cobra.Command, args []string) error {
 func createServiceIDs(client ibmcloud.Client, accountID *string,
 	name, resourceGroupName, credReqDir, targetDir string) error {
 
-	var resourceGroupID string
-	if resourceGroupName != "" {
-		// Get the ID for the given resourceGroupName
-		listResourceGroupsOptions := &resourcemanagerv2.ListResourceGroupsOptions{
-			Name: &resourceGroupName,
-		}
-		resourceGroups, _, err := client.ListResourceGroups(listResourceGroupsOptions)
-		if err != nil {
-			return errors.Wrapf(err, "Failed to list resource groups for the name: %s", resourceGroupName)
-		}
-
-		if len(resourceGroups.Resources) == 0 {
-			return errors.Errorf("Resource group %s not found", resourceGroupName)
-		}
-
-		resourceGroupID = *resourceGroups.Resources[0].ID
+	resourceGroupID, err := getResourceGroupID(client, resourceGroupName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to getResourceGroupID")
 	}
 
 	// Process directory

--- a/pkg/cmd/provisioning/ibmcloud/ibmcloud.go
+++ b/pkg/cmd/provisioning/ibmcloud/ibmcloud.go
@@ -10,6 +10,8 @@ type options struct {
 	CredRequestDir    string
 	ResourceGroupName string
 	Force             bool
+	KubeConfigFile    string
+	Create            bool
 }
 
 // NewIBMCloudCmd implements the "ibmcloud" subcommand for the credentials provisioning
@@ -22,6 +24,7 @@ func NewIBMCloudCmd() *cobra.Command {
 
 	cmd.AddCommand(NewCreateServiceIDCmd())
 	cmd.AddCommand(NewDeleteServiceIDCmd())
+	cmd.AddCommand(NewRefreshKeysCmd())
 
 	return cmd
 }

--- a/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
+++ b/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
@@ -1,0 +1,158 @@
+package ibmcloud
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log"
+
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/clientcmd"
+
+	"github.com/openshift/cloud-credential-operator/pkg/ibmcloud"
+)
+
+// NewRefreshKeysCmd provides the "refresh-keys" subcommand
+func NewRefreshKeysCmd() *cobra.Command {
+	refreshKeysCmd := &cobra.Command{
+		Use:   "refresh-keys",
+		Short: "Refresh API Keys for the Service ID",
+		RunE:  refreshKeysCmd,
+	}
+
+	refreshKeysCmd.PersistentFlags().StringVar(&Options.Name, "name", "", "User-defined name for all created IBM Cloud resources (can be separate from the cluster's infra-id)")
+	refreshKeysCmd.MarkPersistentFlagRequired("name")
+	refreshKeysCmd.PersistentFlags().StringVar(&Options.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to delete IAM Roles for (can be created by running 'oc adm release extract --credentials-requests --cloud=ibmcloud' against an OpenShift release image)")
+	refreshKeysCmd.MarkPersistentFlagRequired("credentials-requests-dir")
+	refreshKeysCmd.PersistentFlags().StringVar(&Options.KubeConfigFile, "kubeconfig", "", "absolute path to the kubeconfig file")
+	refreshKeysCmd.MarkPersistentFlagRequired("kubeconfig")
+	refreshKeysCmd.PersistentFlags().StringVar(&Options.ResourceGroupName, "resource-group-name", "", "Name of the resource group used for scoping the access policies")
+	refreshKeysCmd.PersistentFlags().BoolVar(&Options.Create, "create", false, "Create the ServiceID if does not exists")
+
+	return refreshKeysCmd
+}
+
+func refreshKeysCmd(cmd *cobra.Command, args []string) error {
+	apiKey := getEnv(APIKeyEnvVars)
+	if apiKey == "" {
+		return fmt.Errorf("%s environment variable not set", APIKeyEnvVars)
+	}
+
+	params := &ibmcloud.ClientParams{
+		InfraName: Options.Name,
+	}
+
+	ibmclient, err := ibmcloud.NewClient(apiKey, params)
+	if err != nil {
+		return err
+	}
+
+	apiKeyDetailsOptions := ibmclient.NewGetAPIKeysDetailsOptions()
+	apiKeyDetailsOptions.SetIamAPIKey(apiKey)
+	apiKeyDetails, _, err := ibmclient.GetAPIKeysDetails(apiKeyDetailsOptions)
+	if err != nil {
+		return errors.Wrap(err, "Failed to get details for the given APIKey")
+	}
+
+	cs, err := newClientset(Options.KubeConfigFile)
+	if err != nil {
+		return errors.Wrap(err, "Failed to create the kubernetes clientset")
+	}
+	err = refreshKeys(ibmclient, cs, apiKeyDetails.AccountID, Options.Name, Options.ResourceGroupName, Options.CredRequestDir, Options.Create)
+	if err != nil {
+		return errors.Wrap(err, "Failed to refresh keys")
+	}
+	return nil
+}
+
+func refreshKeys(ibmcloudClient ibmcloud.Client, kubeClient *kubernetes.Clientset, accountID *string, name, resourceGroupName, credReqDir string, create bool) error {
+	resourceGroupID, err := getResourceGroupID(ibmcloudClient, resourceGroupName)
+	if err != nil {
+		return errors.Wrap(err, "Failed to getResourceGroupID")
+	}
+
+	// Process directory
+	credReqs, err := getListOfCredentialsRequests(credReqDir)
+	if err != nil {
+		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
+	}
+
+	var serviceIDs []*ServiceID
+	for _, cr := range credReqs {
+		serviceID := NewServiceID(ibmcloudClient, name, *accountID, resourceGroupID, cr)
+		serviceIDs = append(serviceIDs, serviceID)
+	}
+
+	for _, serviceID := range serviceIDs {
+		list, err := serviceID.List()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to check an existance for the ServiceID: %s", serviceID.name)
+		}
+		if len(list) == 0 && !create {
+			return fmt.Errorf("ServiceID: %s does not exist, rerun with --create flag to create it", serviceID.name)
+		}
+		if len(list) > 1 {
+			return fmt.Errorf("more than one ServiceID found with %s name, please delete the duplicate entries", serviceID.name)
+		}
+	}
+
+	for _, serviceID := range serviceIDs {
+		log.Printf("Refershing the token for ServiceID: %s", serviceID.name)
+		list, err := serviceID.List()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to check an existance for the ServiceID: %s", serviceID.name)
+		}
+		if len(list) != 0 {
+			serviceID.ServiceID = &list[0]
+			if err := serviceID.Refresh(); err != nil {
+				return errors.Wrapf(err, "Failed to create API Key for ServiceID: %s", serviceID.name)
+			}
+		} else {
+			log.Printf("ServiceID does not exist, creating it.")
+			if err := serviceID.Do(); err != nil {
+				return errors.Wrap(err, "Failed to process the serviceID")
+			}
+		}
+
+		secret, err := serviceID.BuildSecret()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to Dump the secret for the serviceID: %s", serviceID.name)
+		}
+		data, err := json.Marshal(secret)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to Marshal")
+		}
+
+		log.Printf("Updating/Creating the secret: %s/%s for the serviceID: %s", secret.Namespace, secret.Name, serviceID.name)
+		//TODO(mkumatag): replace Patch() call with Apply() after k8s.io/client-go update to v1.21.0 or later
+		if _, err := kubeClient.CoreV1().Secrets(secret.Namespace).Patch(context.TODO(), secret.Name, types.ApplyPatchType, data, metav1.PatchOptions{FieldManager: "ccoctl"}); err != nil {
+			return errors.Wrapf(err, "Failed to create/update secret")
+		}
+
+		log.Printf("Removing the stale API Keys.")
+		err = serviceID.RemoveStaleKeys()
+		if err != nil {
+			return errors.Wrapf(err, "Failed to remove the stale API Keys")
+		}
+	}
+
+	return nil
+}
+
+func newClientset(kubeconfig string) (*kubernetes.Clientset, error) {
+	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return nil, err
+	}
+	// create the clientset
+	cs, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		return nil, err
+	}
+	return cs, nil
+}

--- a/pkg/cmd/provisioning/ibmcloud/service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/service_id.go
@@ -12,7 +12,10 @@ import (
 
 	"github.com/pkg/errors"
 
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/yaml"
 
 	"github.com/IBM/go-sdk-core/v5/core"
 	"github.com/IBM/platform-services-go-sdk/iamidentityv1"
@@ -23,19 +26,6 @@ import (
 )
 
 const (
-	//TODO(mkumatag): Remove the entry for ibmcloud_api_key once all the in-cluster components migrate to use the GetAuthenticatorFromEnvironment method
-	secretManifestsTemplate = `apiVersion: v1
-stringData:
-  ibmcloud_api_key: %s
-  ibm-credentials.env: |
-    IBMCLOUD_APIKEY=%s
-    IBMCLOUD_AUTHTYPE=iam
-kind: Secret
-metadata:
-  name: %s
-  namespace: %s
-type: Opaque`
-
 	manifestsDirName      = "manifests"
 	secretFileNamePattern = "%s-%s-credentials.yaml"
 )
@@ -47,6 +37,11 @@ type Provision interface {
 
 	Do() error
 	UnDo(string) error
+
+	List() ([]iamidentityv1.ServiceID, error)
+
+	Refresh() error
+	RemoveStaleKeys() error
 
 	Dump(string) error
 
@@ -62,6 +57,26 @@ type ServiceID struct {
 	resourceGroupID string
 	cr              *credreqv1.CredentialsRequest
 	apiKey          *string
+}
+
+func (s *ServiceID) List() ([]iamidentityv1.ServiceID, error) {
+	_, err := s.extractPolicies()
+	if err != nil {
+		return nil, err
+	}
+
+	options := &iamidentityv1.ListServiceIdsOptions{
+		AccountID: &s.accountID,
+		Name:      &s.name,
+	}
+	list, _, err := s.Client.ListServiceID(options)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to list the serviceIDs")
+	}
+	if len(list.Serviceids) >= 1 {
+		return list.Serviceids, nil
+	}
+	return nil, nil
 }
 
 func (s *ServiceID) Validate() error {
@@ -81,15 +96,11 @@ func (s *ServiceID) Validate() error {
 		return fmt.Errorf("not supported of kind: %s", unknown.Kind)
 	}
 
-	options := &iamidentityv1.ListServiceIdsOptions{
-		AccountID: &s.accountID,
-		Name:      &s.name,
-	}
-	list, _, err := s.Client.ListServiceID(options)
+	list, err := s.List()
 	if err != nil {
-		return errors.Wrapf(err, "failed to list the serviceIDs")
+		return err
 	}
-	if len(list.Serviceids) != 0 {
+	if len(list) != 0 {
 		return errors.Errorf("exists with the same name: %s, please delete the entries or create with a different name", s.name)
 	}
 	return nil
@@ -123,6 +134,28 @@ func (s *ServiceID) Do() error {
 	return nil
 }
 
+func (s *ServiceID) BuildSecret() (*corev1.Secret, error) {
+	if s.apiKey == nil || s.cr == nil {
+		return nil, errors.New("apiKey or credentialRequest can't be nil")
+	}
+	return &corev1.Secret{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: corev1.SchemeGroupVersion.String(),
+			Kind:       "Secret",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      s.cr.Spec.SecretRef.Name,
+			Namespace: s.cr.Spec.SecretRef.Namespace,
+		},
+		StringData: map[string]string{
+			//TODO(mkumatag): Remove the entry for ibmcloud_api_key once all the in-cluster components migrate to use the GetAuthenticatorFromEnvironment method
+			"ibmcloud_api_key":    *s.apiKey,
+			"ibm-credentials.env": fmt.Sprintf("IBMCLOUD_AUTHTYPE=iam\nIBMCLOUD_APIKEY=%s", *s.apiKey),
+		},
+		Type: corev1.SecretTypeOpaque,
+	}, nil
+}
+
 func (s *ServiceID) Dump(targetDir string) error {
 	if s.apiKey == nil || s.cr == nil {
 		return errors.New("apiKey or credentialRequest can't be nil")
@@ -132,9 +165,16 @@ func (s *ServiceID) Dump(targetDir string) error {
 	fileName := fmt.Sprintf(secretFileNamePattern, s.cr.Spec.SecretRef.Namespace, s.cr.Spec.SecretRef.Name)
 	filePath := filepath.Join(manifestsDir, fileName)
 
-	fileData := fmt.Sprintf(secretManifestsTemplate, *s.apiKey, *s.apiKey, s.cr.Spec.SecretRef.Name, s.cr.Spec.SecretRef.Namespace)
+	secret, err := s.BuildSecret()
+	if err != nil {
+		return errors.Wrapf(err, "Failed to Dump the secret for the serviceID: %s", s.name)
+	}
+	data, err := yaml.Marshal(secret)
+	if err != nil {
+		return errors.Wrapf(err, "Failed to marshal the secret for the serviceID: %s", s.name)
+	}
 
-	if err := ioutil.WriteFile(filePath, []byte(fileData), 0600); err != nil {
+	if err := ioutil.WriteFile(filePath, data, 0600); err != nil {
 		return errors.Wrap(err, "Failed to save Secret file")
 	}
 
@@ -284,6 +324,32 @@ func (s *ServiceID) UnDo(targetDir string) error {
 		}
 	}
 
+	return nil
+}
+
+func (s *ServiceID) Refresh() error {
+	return s.createAPIKey()
+}
+
+func (s *ServiceID) RemoveStaleKeys() error {
+	options := &iamidentityv1.ListAPIKeysOptions{
+		IamID:     s.IamID,
+		AccountID: s.AccountID,
+		Sort:      core.StringPtr("created_at"),
+	}
+	keys, _, err := s.Client.ListAPIKeys(options)
+	if err != nil {
+		return errors.Wrap(err, "Failed to ListAPIKeys")
+	}
+	// remove all the stale keys except the latest one
+	for i := 0; i < len(keys.Apikeys)-1; i++ {
+		deleteOptions := &iamidentityv1.DeleteAPIKeyOptions{
+			ID: keys.Apikeys[i].ID,
+		}
+		if _, err := s.Client.DeleteAPIKey(deleteOptions); err != nil {
+			return errors.Wrap(err, "Failed to DeleteAPIKey")
+		}
+	}
 	return nil
 }
 

--- a/pkg/cmd/provisioning/ibmcloud/utils.go
+++ b/pkg/cmd/provisioning/ibmcloud/utils.go
@@ -1,0 +1,29 @@
+package ibmcloud
+
+import (
+	"github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
+	"github.com/openshift/cloud-credential-operator/pkg/ibmcloud"
+	"github.com/pkg/errors"
+)
+
+// getResourceGroupID returns the resource group ID associated with the given name, returns nil if name is empty.
+func getResourceGroupID(client ibmcloud.Client, name string) (string, error) {
+	if name == "" {
+		return "", nil
+	}
+
+	// Get the ID for the given resourceGroupName
+	listResourceGroupsOptions := &resourcemanagerv2.ListResourceGroupsOptions{
+		Name: &name,
+	}
+	resourceGroups, _, err := client.ListResourceGroups(listResourceGroupsOptions)
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to list resource groups for the name: %s", name)
+	}
+
+	if len(resourceGroups.Resources) == 0 {
+		return "", errors.Errorf("Resource group %s not found", name)
+	}
+
+	return *resourceGroups.Resources[0].ID, nil
+}

--- a/pkg/ibmcloud/client.go
+++ b/pkg/ibmcloud/client.go
@@ -18,6 +18,8 @@ type Client interface {
 	ListServiceID(*identityv1.ListServiceIdsOptions) (*identityv1.ServiceIDList, *core.DetailedResponse, error)
 	DeleteServiceID(*identityv1.DeleteServiceIDOptions) (*core.DetailedResponse, error)
 	CreateAPIKey(*identityv1.CreateAPIKeyOptions) (*identityv1.APIKey, *core.DetailedResponse, error)
+	ListAPIKeys(*identityv1.ListAPIKeysOptions) (*identityv1.APIKeyList, *core.DetailedResponse, error)
+	DeleteAPIKey(*identityv1.DeleteAPIKeyOptions) (*core.DetailedResponse, error)
 	GetAPIKeysDetails(*identityv1.GetAPIKeysDetailsOptions) (*identityv1.APIKey, *core.DetailedResponse, error)
 	NewGetAPIKeysDetailsOptions() *identityv1.GetAPIKeysDetailsOptions
 	ListResourceGroups(*resourcemanagerv2.ListResourceGroupsOptions) (*resourcemanagerv2.ResourceGroupList, *core.DetailedResponse, error)
@@ -37,6 +39,14 @@ type ibmcloudClient struct {
 
 func (i *ibmcloudClient) CreateAPIKey(options *identityv1.CreateAPIKeyOptions) (*identityv1.APIKey, *core.DetailedResponse, error) {
 	return i.identityClient.CreateAPIKey(options)
+}
+
+func (i *ibmcloudClient) ListAPIKeys(options *identityv1.ListAPIKeysOptions) (*identityv1.APIKeyList, *core.DetailedResponse, error) {
+	return i.identityClient.ListAPIKeys(options)
+}
+
+func (i *ibmcloudClient) DeleteAPIKey(options *identityv1.DeleteAPIKeyOptions) (*core.DetailedResponse, error) {
+	return i.identityClient.DeleteAPIKey(options)
 }
 
 func (i *ibmcloudClient) NewGetAPIKeysDetailsOptions() *identityv1.GetAPIKeysDetailsOptions {

--- a/pkg/ibmcloud/mock/client_generated.go
+++ b/pkg/ibmcloud/mock/client_generated.go
@@ -5,101 +5,39 @@
 package mock
 
 import (
+	reflect "reflect"
+
 	core "github.com/IBM/go-sdk-core/v5/core"
 	iamidentityv1 "github.com/IBM/platform-services-go-sdk/iamidentityv1"
 	iampolicymanagementv1 "github.com/IBM/platform-services-go-sdk/iampolicymanagementv1"
 	resourcemanagerv2 "github.com/IBM/platform-services-go-sdk/resourcemanagerv2"
 	gomock "github.com/golang/mock/gomock"
-	reflect "reflect"
 )
 
-// MockClient is a mock of Client interface
+// MockClient is a mock of Client interface.
 type MockClient struct {
 	ctrl     *gomock.Controller
 	recorder *MockClientMockRecorder
 }
 
-// MockClientMockRecorder is the mock recorder for MockClient
+// MockClientMockRecorder is the mock recorder for MockClient.
 type MockClientMockRecorder struct {
 	mock *MockClient
 }
 
-// NewMockClient creates a new mock instance
+// NewMockClient creates a new mock instance.
 func NewMockClient(ctrl *gomock.Controller) *MockClient {
 	mock := &MockClient{ctrl: ctrl}
 	mock.recorder = &MockClientMockRecorder{mock}
 	return mock
 }
 
-// EXPECT returns an object that allows the caller to indicate expected use
+// EXPECT returns an object that allows the caller to indicate expected use.
 func (m *MockClient) EXPECT() *MockClientMockRecorder {
 	return m.recorder
 }
 
-// CreatePolicy mocks base method
-func (m *MockClient) CreatePolicy(arg0 *iampolicymanagementv1.CreatePolicyOptions) (*iampolicymanagementv1.Policy, *core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePolicy", arg0)
-	ret0, _ := ret[0].(*iampolicymanagementv1.Policy)
-	ret1, _ := ret[1].(*core.DetailedResponse)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CreatePolicy indicates an expected call of CreatePolicy
-func (mr *MockClientMockRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockClient)(nil).CreatePolicy), arg0)
-}
-
-// CreateServiceID mocks base method
-func (m *MockClient) CreateServiceID(arg0 *iamidentityv1.CreateServiceIDOptions) (*iamidentityv1.ServiceID, *core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateServiceID", arg0)
-	ret0, _ := ret[0].(*iamidentityv1.ServiceID)
-	ret1, _ := ret[1].(*core.DetailedResponse)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// CreateServiceID indicates an expected call of CreateServiceID
-func (mr *MockClientMockRecorder) CreateServiceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceID", reflect.TypeOf((*MockClient)(nil).CreateServiceID), arg0)
-}
-
-// ListServiceID mocks base method
-func (m *MockClient) ListServiceID(arg0 *iamidentityv1.ListServiceIdsOptions) (*iamidentityv1.ServiceIDList, *core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ListServiceID", arg0)
-	ret0, _ := ret[0].(*iamidentityv1.ServiceIDList)
-	ret1, _ := ret[1].(*core.DetailedResponse)
-	ret2, _ := ret[2].(error)
-	return ret0, ret1, ret2
-}
-
-// ListServiceID indicates an expected call of ListServiceID
-func (mr *MockClientMockRecorder) ListServiceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceID", reflect.TypeOf((*MockClient)(nil).ListServiceID), arg0)
-}
-
-// DeleteServiceID mocks base method
-func (m *MockClient) DeleteServiceID(arg0 *iamidentityv1.DeleteServiceIDOptions) (*core.DetailedResponse, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeleteServiceID", arg0)
-	ret0, _ := ret[0].(*core.DetailedResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// DeleteServiceID indicates an expected call of DeleteServiceID
-func (mr *MockClientMockRecorder) DeleteServiceID(arg0 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceID", reflect.TypeOf((*MockClient)(nil).DeleteServiceID), arg0)
-}
-
-// CreateAPIKey mocks base method
+// CreateAPIKey mocks base method.
 func (m *MockClient) CreateAPIKey(arg0 *iamidentityv1.CreateAPIKeyOptions) (*iamidentityv1.APIKey, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateAPIKey", arg0)
@@ -109,13 +47,75 @@ func (m *MockClient) CreateAPIKey(arg0 *iamidentityv1.CreateAPIKeyOptions) (*iam
 	return ret0, ret1, ret2
 }
 
-// CreateAPIKey indicates an expected call of CreateAPIKey
+// CreateAPIKey indicates an expected call of CreateAPIKey.
 func (mr *MockClientMockRecorder) CreateAPIKey(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateAPIKey", reflect.TypeOf((*MockClient)(nil).CreateAPIKey), arg0)
 }
 
-// GetAPIKeysDetails mocks base method
+// CreatePolicy mocks base method.
+func (m *MockClient) CreatePolicy(arg0 *iampolicymanagementv1.CreatePolicyOptions) (*iampolicymanagementv1.Policy, *core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreatePolicy", arg0)
+	ret0, _ := ret[0].(*iampolicymanagementv1.Policy)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreatePolicy indicates an expected call of CreatePolicy.
+func (mr *MockClientMockRecorder) CreatePolicy(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePolicy", reflect.TypeOf((*MockClient)(nil).CreatePolicy), arg0)
+}
+
+// CreateServiceID mocks base method.
+func (m *MockClient) CreateServiceID(arg0 *iamidentityv1.CreateServiceIDOptions) (*iamidentityv1.ServiceID, *core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateServiceID", arg0)
+	ret0, _ := ret[0].(*iamidentityv1.ServiceID)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// CreateServiceID indicates an expected call of CreateServiceID.
+func (mr *MockClientMockRecorder) CreateServiceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateServiceID", reflect.TypeOf((*MockClient)(nil).CreateServiceID), arg0)
+}
+
+// DeleteAPIKey mocks base method.
+func (m *MockClient) DeleteAPIKey(arg0 *iamidentityv1.DeleteAPIKeyOptions) (*core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteAPIKey", arg0)
+	ret0, _ := ret[0].(*core.DetailedResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteAPIKey indicates an expected call of DeleteAPIKey.
+func (mr *MockClientMockRecorder) DeleteAPIKey(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteAPIKey", reflect.TypeOf((*MockClient)(nil).DeleteAPIKey), arg0)
+}
+
+// DeleteServiceID mocks base method.
+func (m *MockClient) DeleteServiceID(arg0 *iamidentityv1.DeleteServiceIDOptions) (*core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteServiceID", arg0)
+	ret0, _ := ret[0].(*core.DetailedResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteServiceID indicates an expected call of DeleteServiceID.
+func (mr *MockClientMockRecorder) DeleteServiceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteServiceID", reflect.TypeOf((*MockClient)(nil).DeleteServiceID), arg0)
+}
+
+// GetAPIKeysDetails mocks base method.
 func (m *MockClient) GetAPIKeysDetails(arg0 *iamidentityv1.GetAPIKeysDetailsOptions) (*iamidentityv1.APIKey, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetAPIKeysDetails", arg0)
@@ -125,27 +125,29 @@ func (m *MockClient) GetAPIKeysDetails(arg0 *iamidentityv1.GetAPIKeysDetailsOpti
 	return ret0, ret1, ret2
 }
 
-// GetAPIKeysDetails indicates an expected call of GetAPIKeysDetails
+// GetAPIKeysDetails indicates an expected call of GetAPIKeysDetails.
 func (mr *MockClientMockRecorder) GetAPIKeysDetails(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAPIKeysDetails", reflect.TypeOf((*MockClient)(nil).GetAPIKeysDetails), arg0)
 }
 
-// NewGetAPIKeysDetailsOptions mocks base method
-func (m *MockClient) NewGetAPIKeysDetailsOptions() *iamidentityv1.GetAPIKeysDetailsOptions {
+// ListAPIKeys mocks base method.
+func (m *MockClient) ListAPIKeys(arg0 *iamidentityv1.ListAPIKeysOptions) (*iamidentityv1.APIKeyList, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewGetAPIKeysDetailsOptions")
-	ret0, _ := ret[0].(*iamidentityv1.GetAPIKeysDetailsOptions)
-	return ret0
+	ret := m.ctrl.Call(m, "ListAPIKeys", arg0)
+	ret0, _ := ret[0].(*iamidentityv1.APIKeyList)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
 }
 
-// NewGetAPIKeysDetailsOptions indicates an expected call of NewGetAPIKeysDetailsOptions
-func (mr *MockClientMockRecorder) NewGetAPIKeysDetailsOptions() *gomock.Call {
+// ListAPIKeys indicates an expected call of ListAPIKeys.
+func (mr *MockClientMockRecorder) ListAPIKeys(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGetAPIKeysDetailsOptions", reflect.TypeOf((*MockClient)(nil).NewGetAPIKeysDetailsOptions))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAPIKeys", reflect.TypeOf((*MockClient)(nil).ListAPIKeys), arg0)
 }
 
-// ListResourceGroups mocks base method
+// ListResourceGroups mocks base method.
 func (m *MockClient) ListResourceGroups(arg0 *resourcemanagerv2.ListResourceGroupsOptions) (*resourcemanagerv2.ResourceGroupList, *core.DetailedResponse, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListResourceGroups", arg0)
@@ -155,8 +157,38 @@ func (m *MockClient) ListResourceGroups(arg0 *resourcemanagerv2.ListResourceGrou
 	return ret0, ret1, ret2
 }
 
-// ListResourceGroups indicates an expected call of ListResourceGroups
+// ListResourceGroups indicates an expected call of ListResourceGroups.
 func (mr *MockClientMockRecorder) ListResourceGroups(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListResourceGroups", reflect.TypeOf((*MockClient)(nil).ListResourceGroups), arg0)
+}
+
+// ListServiceID mocks base method.
+func (m *MockClient) ListServiceID(arg0 *iamidentityv1.ListServiceIdsOptions) (*iamidentityv1.ServiceIDList, *core.DetailedResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListServiceID", arg0)
+	ret0, _ := ret[0].(*iamidentityv1.ServiceIDList)
+	ret1, _ := ret[1].(*core.DetailedResponse)
+	ret2, _ := ret[2].(error)
+	return ret0, ret1, ret2
+}
+
+// ListServiceID indicates an expected call of ListServiceID.
+func (mr *MockClientMockRecorder) ListServiceID(arg0 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListServiceID", reflect.TypeOf((*MockClient)(nil).ListServiceID), arg0)
+}
+
+// NewGetAPIKeysDetailsOptions mocks base method.
+func (m *MockClient) NewGetAPIKeysDetailsOptions() *iamidentityv1.GetAPIKeysDetailsOptions {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "NewGetAPIKeysDetailsOptions")
+	ret0, _ := ret[0].(*iamidentityv1.GetAPIKeysDetailsOptions)
+	return ret0
+}
+
+// NewGetAPIKeysDetailsOptions indicates an expected call of NewGetAPIKeysDetailsOptions.
+func (mr *MockClientMockRecorder) NewGetAPIKeysDetailsOptions() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGetAPIKeysDetailsOptions", reflect.TypeOf((*MockClient)(nil).NewGetAPIKeysDetailsOptions))
 }

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -973,4 +973,5 @@ sigs.k8s.io/controller-runtime/pkg/webhook/internal/metrics
 # sigs.k8s.io/structured-merge-diff/v4 v4.0.1
 sigs.k8s.io/structured-merge-diff/v4/value
 # sigs.k8s.io/yaml v1.2.0
+## explicit
 sigs.k8s.io/yaml


### PR DESCRIPTION
This command is used for refreshing the API Keys for the service ids.

Flows supported:
1. Refresh the API keys for the existing ServiceID
```shell
$ ./ccoctl ibmcloud refresh-keys --kubeconfig <openshift_kubeconfig_file> --credentials-requests-dir <CR_directory> --name <name_of_the_cluster>
```
2. ServiceID creation for the new Credential Request supplied.

```shell
# need that additional --create flag otherwise command will throw an error message and exit if serviceID does not exist for the CR
$ ./ccoctl ibmcloud refresh-keys --kubeconfig <openshift_kubeconfig_file> --credentials-requests-dir <CR_directory> --name <name_of_the_cluster> --create
```

xref: https://issues.redhat.com/browse/MULTIARCH-1903