### PR TITLE
Bug 2039085: Exclude operator config from ibm-cloud-managed profile

### DIFF
--- a/manifests/01-operator-config.yaml
+++ b/manifests/01-operator-config.yaml
@@ -3,7 +3,6 @@ kind: CloudCredential
 metadata:
   name: cluster
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     release.openshift.io/create-only: "true"
 spec:


### PR DESCRIPTION
The cloud cred operator does not run for ibm-cloud-managed or hypershift. This removes the annotation that includes the config CR in that profile.