### PR TITLE
Bug 1996624: Check for aws status in infra platform status field before client setup

### DIFF
--- a/pkg/operator/utils/aws/utils.go
+++ b/pkg/operator/utils/aws/utils.go
@@ -40,8 +40,8 @@ func ClientBuilder(accessKeyID, secretAccessKey []byte, c client.Client) (ccaws.
 func setupClientParams(infra *configv1.Infrastructure) *ccaws.ClientParams {
 	region := ""
 	endpoint := ""
-	if infra.Status.PlatformStatus != nil {
-		// If PlatformStatus isn't nil, then we can at least assume Region is provided
+	if infra.Status.PlatformStatus != nil && infra.Status.PlatformStatus.AWS != nil {
+		// If PlatformStatus isn't nil and has AWS status, then we can at least assume Region is provided
 		region = infra.Status.PlatformStatus.AWS.Region
 
 		endpoint = getIAMEndpoint(infra)


### PR DESCRIPTION
We go for aws, if secret annotator implementation does not exist for a cloud
platform. The current code causes panic while doing aws client setup for 
non-aws platform. This commit fixes it.