### PR TITLE
Bug 2015133: populate accountID when listing resource groups

### DIFF
--- a/pkg/cmd/provisioning/ibmcloud/create_service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_service_id.go
@@ -94,7 +94,7 @@ func createServiceIDCmd(cmd *cobra.Command, args []string) error {
 func createServiceIDs(client ibmcloud.Client, accountID *string,
 	name, resourceGroupName, credReqDir, targetDir string) error {
 
-	resourceGroupID, err := getResourceGroupID(client, resourceGroupName)
+	resourceGroupID, err := getResourceGroupID(client, accountID, resourceGroupName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to getResourceGroupID")
 	}

--- a/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
+++ b/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
@@ -71,7 +71,7 @@ func refreshKeysCmd(cmd *cobra.Command, args []string) error {
 }
 
 func refreshKeys(ibmcloudClient ibmcloud.Client, kubeClient *kubernetes.Clientset, accountID *string, name, resourceGroupName, credReqDir string, create bool) error {
-	resourceGroupID, err := getResourceGroupID(ibmcloudClient, resourceGroupName)
+	resourceGroupID, err := getResourceGroupID(ibmcloudClient, accountID, resourceGroupName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to getResourceGroupID")
 	}

--- a/pkg/cmd/provisioning/ibmcloud/utils.go
+++ b/pkg/cmd/provisioning/ibmcloud/utils.go
@@ -7,14 +7,15 @@ import (
 )
 
 // getResourceGroupID returns the resource group ID associated with the given name, returns nil if name is empty.
-func getResourceGroupID(client ibmcloud.Client, name string) (string, error) {
+func getResourceGroupID(client ibmcloud.Client, accountID *string, name string) (string, error) {
 	if name == "" {
 		return "", nil
 	}
 
 	// Get the ID for the given resourceGroupName
 	listResourceGroupsOptions := &resourcemanagerv2.ListResourceGroupsOptions{
-		Name: &name,
+		AccountID: accountID,
+		Name:      &name,
 	}
 	resourceGroups, _, err := client.ListResourceGroups(listResourceGroupsOptions)
 	if err != nil {


### PR DESCRIPTION
This allows listing of resouce groups with user API keys and Service ID
API keys as well.

This should resolve openshift/cloud-credential-operator#401