### PR TITLE
pkg/operator/status: Set an explicit happy reason/message

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -323,6 +323,8 @@ func defaultUnsetConditions(existing []configv1.ClusterOperatorStatusCondition) 
 			case configv1.OperatorUpgradeable:
 				defaultCondition.Status = configv1.ConditionTrue
 			}
+			defaultCondition.Reason = "AsExpected"
+			defaultCondition.Message = "All is well"
 			conditions = append(conditions, defaultCondition)
 		}
 	}

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -372,6 +372,8 @@ func testClusterOperator(version string, progressingLastTransition metav1.Time) 
 				{
 					Type:               configv1.OperatorProgressing,
 					Status:             configv1.ConditionFalse,
+					Reason:             "AsExpected",
+					Message:            "All is well",
 					LastTransitionTime: progressingLastTransition,
 				},
 			},


### PR DESCRIPTION
The cloud-cred operator hasn't set explicit happy-state reasons since #213:

> Because, with the new interface, controllers only report non-default conditions, the reasons for being in the expected steady state for the condition is no longer reported (i.e. `ReconcilingComplete` and `NoCredentialsFailing`).

Having an explicit happy reason makes it easier to do things like:

    sort_desc(count by (reason) (cluster_operator_conditions{name="cloud-credential",condition="Degraded"}))

without having to worry about empty reason being implicitly happy, or some weird, sad condition that just happened to not get a reason string.

These choices are fairly common.  For example, in [a recent 4.10 CI job][2]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp/1459283637437468672/artifacts/e2e-gcp/gather-extra/artifacts/clusteroperators.json | jq -r '.items[].status.conditions[] | .reason + ": " + .message' | sort | uniq -c | sort -n | tail
      1 UnsupportedPlatform: Nothing to do on this Platform
      2 : Deployed 0.19.0
      2 : Samples installation successful at 4.10.0-0.nightly-2021-11-12-221241
      2 AsExpected: NodeInstallerProgressing: 3 nodes are at revision 7
      2 AsExpected: StaticPodsAvailable: 3 nodes are active; 3 nodes are at revision 7
      2 OperatorAvailable: Available release version: 4.10.0-0.nightly-2021-11-12-221241
      4 AsExpected: NodeControllerDegraded: All master nodes are ready
     13 AsExpected:
     28 :
     34 AsExpected: All is well
```

[2]: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-gcp/1459283637437468672

xref: https://issues.redhat.com/browse/CCO-184