### PR TITLE
Bug 2023832: pkg/operator/status: Only bump lastTransitionTime on status changes

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -344,23 +344,12 @@ func setLastTransitionTime(oldConditions []configv1.ClusterOperatorStatusConditi
 	for i := range newConditions {
 		newCondition := &newConditions[i]
 		oldCondition, _ := findClusterOperatorCondition(oldConditions, newCondition.Type)
-		if oldCondition == nil || !conditionEqual(*oldCondition, *newCondition) {
+		if oldCondition == nil || oldCondition.Status != newCondition.Status {
 			newCondition.LastTransitionTime = metav1.Now()
 		} else {
 			newCondition.LastTransitionTime = oldCondition.LastTransitionTime
 		}
 	}
-}
-
-// conditionEqual compares every field except LastTransitionTime.
-func conditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
-	if a.Type == b.Type &&
-		a.Status == b.Status &&
-		a.Reason == b.Reason &&
-		a.Message == b.Message {
-		return true
-	}
-	return false
 }
 
 // isWatchedSecret is used to identify if a given secret namespace + name is one we're expecting in the future

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -344,7 +344,7 @@ func setLastTransitionTime(oldConditions []configv1.ClusterOperatorStatusConditi
 	for i := range newConditions {
 		newCondition := &newConditions[i]
 		oldCondition, _ := findClusterOperatorCondition(oldConditions, newCondition.Type)
-		if oldCondition == nil || !ConditionEqual(*oldCondition, *newCondition) {
+		if oldCondition == nil || !conditionEqual(*oldCondition, *newCondition) {
 			newCondition.LastTransitionTime = metav1.Now()
 		} else {
 			newCondition.LastTransitionTime = oldCondition.LastTransitionTime
@@ -352,8 +352,8 @@ func setLastTransitionTime(oldConditions []configv1.ClusterOperatorStatusConditi
 	}
 }
 
-// ConditionEqual compares every field except LastTransitionTime.
-func ConditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
+// conditionEqual compares every field except LastTransitionTime.
+func conditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
 	if a.Type == b.Type &&
 		a.Status == b.Status &&
 		a.Reason == b.Reason &&

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -162,7 +162,7 @@ func TestConditionsEqual(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		actual := ConditionEqual(tc.a, tc.b)
+		actual := conditionEqual(tc.a, tc.b)
 		if actual != tc.expected {
 			t.Fatalf("%q: expected %v, got %v", tc.description,
 				tc.expected, actual)

--- a/pkg/operator/status/status_controller_test.go
+++ b/pkg/operator/status/status_controller_test.go
@@ -379,6 +379,17 @@ func testClusterOperator(version string, progressingLastTransition metav1.Time) 
 	}
 }
 
+// conditionEqual compares every field except LastTransitionTime.
+func conditionEqual(a, b configv1.ClusterOperatorStatusCondition) bool {
+	if a.Type == b.Type &&
+		a.Status == b.Status &&
+		a.Reason == b.Reason &&
+		a.Message == b.Message {
+		return true
+	}
+	return false
+}
+
 type miniHandler struct {
 	name           string
 	conditions     []configv1.ClusterOperatorStatusCondition


### PR DESCRIPTION
From [the property docs][1]:

> lastTransitionTime is the time of the last update to the current status property.

Restricting the timestamp bumps to the status transitions allows consumers to answer "how long have I been `Degraded=True`?" and similar, which is often more useful than being able to answer "how long have I been `Degraded=True` with exactly this `reason` and exactly this `message`?".  Messages are [only for human consumption][2] anyway, so there should be very few users that care about "... and exactly this `message`".  For folks who do care about reasons, [the `cluster_operator_conditions` metric][3] provides access with Prometheus-scrape precision.

[1]: https://github.com/openshift/api/blob/be1be0e89115702f8b508d351c4f5c9a16e5ae95/config/v1/types_cluster_operator.go#L126
[2]: https://github.com/openshift/api/blob/be1be0e89115702f8b508d351c4f5c9a16e5ae95/config/v1/types_cluster_operator.go#L136
[3]: https://github.com/openshift/cluster-version-operator/blob/887aa47093d740ce827e3046848d4f0c1aca374f/pkg/cvo/metrics.go#L84-L86