### PR TITLE
build ccoctl for Windows and MacOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,17 +2,17 @@ FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.10 AS 
 WORKDIR /go/src/github.com/openshift/cloud-credential-operator
 COPY . .
 ENV GO_PACKAGE github.com/openshift/cloud-credential-operator
+ARG TARGETPLATFORM
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cloud-credential-operator
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/ccoctl
-RUN make cross-build-darwin-amd64
-RUN make cross-build-windows-amd64
+RUN mkdir -p /go/src/${GO_PACKAGE}/_output/bin
+RUN if [[ "$TARGETPLATFORM" == "linux/amd64" ]] ; then make cross-build-darwin-amd64 cross-build-windows-amd64 ; fi
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/cloud-credential-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/
 COPY manifests /manifests
-COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/_output/bin/darwin_amd64/ccoctl /ccoctl/darwin_amd64/
-COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/_output/bin/windows_amd64/ccoctl.exe /ccoctl/windows_amd64/
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/_output/bin/ /ccoctl/
 # Update perms so we can copy updated CA if needed
 RUN chmod -R g+w /etc/pki/ca-trust/extracted/pem/
 LABEL io.openshift.release.operator=true

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,15 @@ COPY . .
 ENV GO_PACKAGE github.com/openshift/cloud-credential-operator
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cloud-credential-operator
 RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/ccoctl
+RUN make cross-build-darwin-amd64
+RUN make cross-build-windows-amd64
 
 FROM registry.ci.openshift.org/ocp/4.10:base
 COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/cloud-credential-operator /usr/bin/
 COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/
 COPY manifests /manifests
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/_output/bin/darwin_amd64/ccoctl /ccoctl/darwin_amd64/
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/_output/bin/windows_amd64/ccoctl.exe /ccoctl/windows_amd64/
 # Update perms so we can copy updated CA if needed
 RUN chmod -R g+w /etc/pki/ca-trust/extracted/pem/
 LABEL io.openshift.release.operator=true

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ include $(addprefix ./vendor/github.com/openshift/build-machinery-go/make/, \
 	targets/openshift/deps.mk \
 )
 
+OUTPUT_DIR :=_output
+CROSS_BUILD_BINDIR :=$(OUTPUT_DIR)/bin
+
 # adapted from https://github.com/openshift/build-machinery-go/blob/master/make/targets/openshift/images.mk
 
 # IMAGE_BUILD_EXTRA_FLAGS lets you add extra flags for imagebuilder
@@ -130,3 +133,11 @@ build-no-gen: build
 coverage:
 	hack/codecov.sh
 .PHONY: coverage
+
+cross-build-darwin-amd64:
+	+@GOOS=darwin GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/ccoctl GO_BUILD_FLAGS:="$(GO_BUILD_DARWIN)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/darwin_amd64
+.PHONY: cross-build-darwin-amd64
+
+cross-build-windows-amd64:
+	+@GOOS=windows GOARCH=amd64 $(MAKE) --no-print-directory build GO_BUILD_PACKAGES:=./cmd/ccoctl GO_BUILD_FLAGS:="$(GO_BUILD_WINDOWS)" GO_BUILD_BINDIR:=$(CROSS_BUILD_BINDIR)/windows_amd64
+.PHONY: cross-build-windows-amd64


### PR DESCRIPTION
Introduce new Makefile targets to build for Windows and MacOS (amd64).

Update Dockerfile to build and save those binaries into final container
image.

xref: https://issues.redhat.com/browse/CCO-170