### PR TITLE
Bug 2035315: fix passthrough test cases

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -431,8 +431,8 @@ func (a *AWSActuator) syncPassthrough(ctx context.Context, cr *minterv1.Credenti
 			}
 		}
 		if !goodEnough {
-			msg := "root creds not sufficient"
-			logger.Info("root creds not sufficient")
+			msg := "root creds are not sufficient"
+			logger.Info(msg)
 			return &actuatoriface.ActuatorError{
 				ErrReason: minterv1.CredentialsProvisionFailure,
 				Message:   fmt.Sprintf("%v", msg),


### PR DESCRIPTION
AWS passthrough test cases were not asserting that the
CredentialsRequest .spec.secretRef contents matched the root
secret creds.

Fixing this revealed several places in the passthrough path where we
could be doing a better job of bubbling up appropriate errors when the
root credentials are simply not good enough to be passed through to
satisfy the CredentialsRequest.

Lastly, check for and return a potential error that was being ignored.

Add test cases to cover root credentials rotation, and test cases for
when insufficient root creds are found.