### PR TITLE
Bug 2036827: ensure GCP CredsReq has a list of ServiceAccounts

### DIFF
--- a/pkg/cmd/provisioning/gcp/create_service_accounts.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts.go
@@ -105,6 +105,12 @@ func processCredentialsRequests(ctx context.Context, client gcp.Client, credReqs
 }
 
 func createServiceAccount(ctx context.Context, client gcp.Client, name string, credReq *credreqv1.CredentialsRequest, serviceAccountNum int, workloadIdentityPool, workloadIdentityProvider, project, targetDir string, generateOnly bool) (string, error) {
+	// The credReq must have a non zero-length list of ServiceAccountNames
+	// that can be used to restrict which k8s ServiceAccounts can use the GCP ServiceAccount.
+	if len(credReq.Spec.ServiceAccountNames) == 0 {
+		return "", fmt.Errorf("CredentialsRequest %s/%s must provide at least one ServiceAccount in .spec.ServiceAccountNames", credReq.Namespace, credReq.Name)
+	}
+
 	// The service account id has a max length of 30 chars
 	// split it into 12-11-5 where the resuling string becomes:
 	// <infraName chopped to 12 chars>-<crName chopped to 11 chars>-<random 5 chars>


### PR DESCRIPTION
When setting up workload-identity on GCP, require that there is at least
one entry in .spec.serviceAccountNames so that we can properly restrict
which k8s ServiceAccounts can use the created GCP ServiceAccount.