### PR TITLE
cleanup CCO from ibm-cloud-managed

### DIFF
--- a/manifests/00-clusterreader_clusterrole.yaml
+++ b/manifests/00-clusterreader_clusterrole.yaml
@@ -5,7 +5,6 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:

--- a/manifests/00-crd.yaml
+++ b/manifests/00-crd.yaml
@@ -2,7 +2,6 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
   name: credentialsrequests.cloudcredential.openshift.io
 spec:

--- a/manifests/00-namespace.yaml
+++ b/manifests/00-namespace.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"

--- a/manifests/0000_90_cloud-credential-operator_01_prometheusrole.yaml
+++ b/manifests/0000_90_cloud-credential-operator_01_prometheusrole.yaml
@@ -4,7 +4,6 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:

--- a/manifests/0000_90_cloud-credential-operator_02_prometheusrolebinding.yaml
+++ b/manifests/0000_90_cloud-credential-operator_02_prometheusrolebinding.yaml
@@ -4,7 +4,6 @@ metadata:
   name: prometheus-k8s
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/0000_90_cloud-credential-operator_03_servicemonitor.yaml
+++ b/manifests/0000_90_cloud-credential-operator_03_servicemonitor.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-credential-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 spec:
   endpoints:

--- a/manifests/01-cluster-role-binding.yaml
+++ b/manifests/01-cluster-role-binding.yaml
@@ -4,7 +4,6 @@ metadata:
   creationTimestamp: null
   name: cloud-credential-operator-rolebinding
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/01-cluster-role.yaml
+++ b/manifests/01-cluster-role.yaml
@@ -4,7 +4,6 @@ metadata:
   creationTimestamp: null
   name: cloud-credential-operator-role
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:

--- a/manifests/01-role-binding.yaml
+++ b/manifests/01-role-binding.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-credential-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 subjects:
 - kind: ServiceAccount

--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -4,7 +4,6 @@ metadata:
   name: cloud-credential-operator-role
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
 rules:
 - apiGroups:

--- a/manifests/01-service.yaml
+++ b/manifests/01-service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: cloud-credential-operator-serving-cert
   name: cco-metrics

--- a/manifests/01-trusted-ca-configmap.yaml
+++ b/manifests/01-trusted-ca-configmap.yaml
@@ -6,5 +6,4 @@ metadata:
   name: cco-trusted-ca
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/02-sa.yaml
+++ b/manifests/02-sa.yaml
@@ -4,5 +4,4 @@ metadata:
   name: cloud-credential-operator
   namespace: openshift-cloud-credential-operator
   annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"

--- a/manifests/ibm-cloud-cleanup.yaml
+++ b/manifests/ibm-cloud-cleanup.yaml
@@ -1,0 +1,116 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: system:openshift:cloud-credential-operator:cluster-reader
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+  name: credentialsrequests.cloudcredential.openshift.io
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+  name: openshift-cloud-credential-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: prometheus-k8s
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: cloud-credential-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+kind: ClusterRoleBinding
+metadata:
+  name: cloud-credential-operator-rolebinding
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cloud-credential-operator-role
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: operator.openshift.io/v1
+kind: CloudCredential
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    release.openshift.io/delete: "true"
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: cloud-credential-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: cloud-credential-operator-role
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cco-trusted-ca
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cloud-credential-operator
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"

--- a/manifests/ibm-cloud-cleanup.yaml
+++ b/manifests/ibm-cloud-cleanup.yaml
@@ -93,6 +93,17 @@ metadata:
 apiVersion: v1
 kind: Service
 metadata:
+  name: controller-manager-service
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    release.openshift.io/delete: "true"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cco-metrics
+  namespace: openshift-cloud-credential-operator
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     release.openshift.io/delete: "true"


### PR DESCRIPTION
CCO is not used in the ibm-cloud-managed profile. Mark all these
previously installed resources as needing to be removed in the
ibm-cloud-managed profile, and remove the ibm-cloud-managed annotation
so they don't get installed again.

xref: https://issues.redhat.com/browse/CCO-177