### PR TITLE
Bug 2035903: handle resources with feature-gate annotation

### DIFF
--- a/pkg/cmd/provisioning/alibabacloud/alibaba.go
+++ b/pkg/cmd/provisioning/alibabacloud/alibaba.go
@@ -5,10 +5,11 @@ import (
 )
 
 type options struct {
-	TargetDir      string
-	Name           string
-	Region         string
-	CredRequestDir string
+	TargetDir         string
+	Name              string
+	Region            string
+	CredRequestDir    string
+	EnableTechPreview bool
 }
 
 // NewAliababaCloudCmd implements the "alibabacloud" subcommand for the credentials provisioning

--- a/pkg/cmd/provisioning/alibabacloud/create-ram-users.go
+++ b/pkg/cmd/provisioning/alibabacloud/create-ram-users.go
@@ -58,16 +58,17 @@ func createRAMUsersCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create a client: %v", err)
 	}
 
-	err = createRAMUsers(client, CreateRAMUsersOpts.Name, CreateRAMUsersOpts.CredRequestDir, CreateRAMUsersOpts.TargetDir)
+	err = createRAMUsers(client, CreateRAMUsersOpts.Name, CreateRAMUsersOpts.CredRequestDir,
+		CreateRAMUsersOpts.TargetDir, CreateRAMUsersOpts.EnableTechPreview)
 	if err != nil {
 		log.Fatalf(err.Error())
 	}
 }
 
 //createRAMUsers will create a ram user for the given credenital request and attach the specific ram policy
-func createRAMUsers(client alibabacloud.Client, name, credReqDir, targetDir string) error {
+func createRAMUsers(client alibabacloud.Client, name, credReqDir, targetDir string, enableTechPreview bool) error {
 	// Process directory
-	credRequests, err := provisioning.GetListOfCredentialsRequests(credReqDir)
+	credRequests, err := provisioning.GetListOfCredentialsRequests(credReqDir, enableTechPreview)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}
@@ -345,6 +346,7 @@ func NewCreateRAMUsersCmd() *cobra.Command {
 	createRAMUsersCmd.MarkPersistentFlagRequired("credentials-requests-dir")
 	createRAMUsersCmd.PersistentFlags().StringVar(&CreateRAMUsersOpts.Region, "region", "", "Alibaba Cloud region endpoint only required for GovCloud")
 	createRAMUsersCmd.PersistentFlags().StringVar(&CreateRAMUsersOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
+	createRAMUsersCmd.PersistentFlags().BoolVar(&CreateRAMUsersOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return createRAMUsersCmd
 }

--- a/pkg/cmd/provisioning/alibabacloud/create-ram-users_test.go
+++ b/pkg/cmd/provisioning/alibabacloud/create-ram-users_test.go
@@ -133,7 +133,7 @@ func TestCreateRAMUsers(t *testing.T) {
 			require.NoError(t, err, "unexpected error creating manifests dir for test")
 			defer os.RemoveAll(manifestsDir)
 
-			err = createRAMUsers(mockAlibabaClient, testNamePrefix, credReqDir, targetDir)
+			err = createRAMUsers(mockAlibabaClient, testNamePrefix, credReqDir, targetDir, false)
 
 			if test.expectError {
 				require.Error(t, err, "expected error returned")

--- a/pkg/cmd/provisioning/aws/aws.go
+++ b/pkg/cmd/provisioning/aws/aws.go
@@ -18,6 +18,7 @@ type options struct {
 	IdentityProviderARN    string
 	PermissionsBoundaryARN string
 	DryRun                 bool
+	EnableTechPreview      bool
 }
 
 // NewAWSCmd implements the "aws" subcommand for the credentials provisioning

--- a/pkg/cmd/provisioning/aws/create-iam-roles.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles.go
@@ -46,13 +46,14 @@ var (
 	// CreateIAMRolesOpts captures the options that affect creation/updating
 	// of the IAM Roles.
 	CreateIAMRolesOpts = options{
-		TargetDir: "",
+		TargetDir:         "",
+		EnableTechPreview: false,
 	}
 )
 
-func createIAMRoles(client aws.Client, identityProviderARN, PermissionsBoundaryARN, name, credReqDir, targetDir string, generateOnly bool) error {
+func createIAMRoles(client aws.Client, identityProviderARN, PermissionsBoundaryARN, name, credReqDir, targetDir string, enableTechPreview, generateOnly bool) error {
 	// Process directory
-	credRequests, err := provisioning.GetListOfCredentialsRequests(credReqDir)
+	credRequests, err := provisioning.GetListOfCredentialsRequests(credReqDir, enableTechPreview)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}
@@ -288,7 +289,8 @@ func createIAMRolesCmd(cmd *cobra.Command, args []string) {
 
 	awsClient := aws.NewClientFromSession(s)
 
-	err = createIAMRoles(awsClient, CreateIAMRolesOpts.IdentityProviderARN, CreateIAMRolesOpts.PermissionsBoundaryARN, CreateIAMRolesOpts.Name, CreateIAMRolesOpts.CredRequestDir, CreateIAMRolesOpts.TargetDir, CreateIAMRolesOpts.DryRun)
+	err = createIAMRoles(awsClient, CreateIAMRolesOpts.IdentityProviderARN, CreateIAMRolesOpts.PermissionsBoundaryARN, CreateIAMRolesOpts.Name,
+		CreateIAMRolesOpts.CredRequestDir, CreateIAMRolesOpts.TargetDir, CreateIAMRolesOpts.EnableTechPreview, CreateIAMRolesOpts.DryRun)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -410,6 +412,7 @@ func NewCreateIAMRolesCmd() *cobra.Command {
 	createIAMRolesCmd.PersistentFlags().StringVar(&CreateIAMRolesOpts.Region, "region", "", "AWS region endpoint only required for GovCloud")
 	createIAMRolesCmd.PersistentFlags().BoolVar(&CreateIAMRolesOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
 	createIAMRolesCmd.PersistentFlags().StringVar(&CreateIAMRolesOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
+	createIAMRolesCmd.PersistentFlags().BoolVar(&CreateIAMRolesOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return createIAMRolesCmd
 }

--- a/pkg/cmd/provisioning/aws/create-iam-roles_test.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles_test.go
@@ -258,7 +258,7 @@ func TestIAMRoles(t *testing.T) {
 			require.NoError(t, err, "unexpected error creating manifests dir for test")
 			defer os.RemoveAll(manifestsDir)
 
-			err = createIAMRoles(mockAWSClient, testIdentityProviderARN, testPermissionsBoundaryARN, testNamePrefix, credReqDir, targetDir, test.generateOnly)
+			err = createIAMRoles(mockAWSClient, testIdentityProviderARN, testPermissionsBoundaryARN, testNamePrefix, credReqDir, targetDir, false, test.generateOnly)
 
 			if test.expectError {
 				require.Error(t, err, "expected error returned")

--- a/pkg/cmd/provisioning/aws/create_all.go
+++ b/pkg/cmd/provisioning/aws/create_all.go
@@ -42,7 +42,8 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create Identity provider: %s", err)
 	}
 
-	err = createIAMRoles(awsClient, identityProviderARN, CreateAllOpts.PermissionsBoundaryARN, CreateAllOpts.Name, CreateAllOpts.CredRequestDir, CreateAllOpts.TargetDir, false)
+	err = createIAMRoles(awsClient, identityProviderARN, CreateAllOpts.PermissionsBoundaryARN, CreateAllOpts.Name,
+		CreateAllOpts.CredRequestDir, CreateAllOpts.TargetDir, CreateAllOpts.EnableTechPreview, false)
 	if err != nil {
 		log.Fatalf("Failed to process IAM Roles: %s", err)
 	}
@@ -103,6 +104,7 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to create IAM Roles for (can be created by running 'oc adm release extract --credentials-requests --cloud=aws' against an OpenShift release image)")
 	createAllCmd.MarkPersistentFlagRequired("credentials-requests-dir")
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
+	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return createAllCmd
 }

--- a/pkg/cmd/provisioning/constants.go
+++ b/pkg/cmd/provisioning/constants.go
@@ -39,6 +39,7 @@ const (
 }`
 	// featureGateAnnotation is the annotation used to indicate that a specific manifest is hidden behind a feature gate.
 	featureGateAnnotation = "release.openshift.io/feature-gate"
-	// validTechPreviewAnnotationValue is the only valid value for the feature-gate annoation
-	validTechPreviewAnnotationValue = "TechPreviewNoUpgrade"
+
+	// deletionAnnotation is the annotation used to tell the CVO that a resource should be deleted
+	deletionAnnotation = "release.openshift.io/delete"
 )

--- a/pkg/cmd/provisioning/constants.go
+++ b/pkg/cmd/provisioning/constants.go
@@ -37,4 +37,8 @@ const (
         "sub"
     ]
 }`
+	// featureGateAnnotation is the annotation used to indicate that a specific manifest is hidden behind a feature gate.
+	featureGateAnnotation = "release.openshift.io/feature-gate"
+	// validTechPreviewAnnotationValue is the only valid value for the feature-gate annoation
+	validTechPreviewAnnotationValue = "TechPreviewNoUpgrade"
 )

--- a/pkg/cmd/provisioning/gcp/create_all.go
+++ b/pkg/cmd/provisioning/gcp/create_all.go
@@ -51,7 +51,8 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create workload identity provider: %s", err)
 	}
 
-	if err = createServiceAccounts(ctx, gcpClient, CreateAllOpts.Name, CreateAllOpts.Name, CreateAllOpts.Name, CreateAllOpts.CredRequestDir, CreateAllOpts.TargetDir, false); err != nil {
+	if err = createServiceAccounts(ctx, gcpClient, CreateAllOpts.Name, CreateAllOpts.Name, CreateAllOpts.Name, CreateAllOpts.CredRequestDir,
+		CreateAllOpts.TargetDir, CreateAllOpts.EnableTechPreview, false); err != nil {
 		log.Fatalf("Failed to create IAM service accounts: %s", err)
 	}
 }
@@ -115,6 +116,7 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to create gcp service accounts for (can be created by running 'oc adm release extract --credentials-requests --cloud=gcp' against an OpenShift release image)")
 	createAllCmd.MarkPersistentFlagRequired("credentials-requests-dir")
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
+	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return createAllCmd
 }

--- a/pkg/cmd/provisioning/gcp/create_service_accounts.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts.go
@@ -75,9 +75,9 @@ var (
 	}
 )
 
-func createServiceAccounts(ctx context.Context, client gcp.Client, name, workloadIdentityPool, workloadIdentityProvider, credReqDir, targetDir string, generateOnly bool) error {
+func createServiceAccounts(ctx context.Context, client gcp.Client, name, workloadIdentityPool, workloadIdentityProvider, credReqDir, targetDir string, enableTechPreview, generateOnly bool) error {
 	// Process directory
-	credRequests, err := provisioning.GetListOfCredentialsRequests(credReqDir)
+	credRequests, err := provisioning.GetListOfCredentialsRequests(credReqDir, enableTechPreview)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}
@@ -331,7 +331,9 @@ func createServiceAccountsCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	err = createServiceAccounts(ctx, gcpClient, CreateServiceAccountsOpts.Name, CreateServiceAccountsOpts.WorkloadIdentityPool, CreateServiceAccountsOpts.WorkloadIdentityProvider, CreateServiceAccountsOpts.CredRequestDir, CreateServiceAccountsOpts.TargetDir, CreateServiceAccountsOpts.DryRun)
+	err = createServiceAccounts(ctx, gcpClient, CreateServiceAccountsOpts.Name, CreateServiceAccountsOpts.WorkloadIdentityPool,
+		CreateServiceAccountsOpts.WorkloadIdentityProvider, CreateServiceAccountsOpts.CredRequestDir, CreateServiceAccountsOpts.TargetDir,
+		CreateServiceAccountsOpts.EnableTechPreview, CreateServiceAccountsOpts.DryRun)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -389,6 +391,7 @@ func NewCreateServiceAccountsCmd() *cobra.Command {
 	createServiceAccountsCmd.MarkPersistentFlagRequired("project")
 	createServiceAccountsCmd.PersistentFlags().BoolVar(&CreateServiceAccountsOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
 	createServiceAccountsCmd.PersistentFlags().StringVar(&CreateServiceAccountsOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
+	createServiceAccountsCmd.PersistentFlags().BoolVar(&CreateServiceAccountsOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return createServiceAccountsCmd
 }

--- a/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
@@ -191,7 +191,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 			require.NoError(t, err, "Unexpected error creating manifests dir for test")
 			defer os.RemoveAll(manifestsDir)
 
-			err = createServiceAccounts(context.TODO(), mockGCPClient, testName, testName, testName, credReqDir, targetDir, test.generateOnly)
+			err = createServiceAccounts(context.TODO(), mockGCPClient, testName, testName, testName, credReqDir, targetDir, false, test.generateOnly)
 
 			if test.expectError {
 				require.Error(t, err, "expected error returned")

--- a/pkg/cmd/provisioning/gcp/gcp.go
+++ b/pkg/cmd/provisioning/gcp/gcp.go
@@ -16,6 +16,7 @@ type options struct {
 	WorkloadIdentityProvider string
 	CredRequestDir           string
 	DryRun                   bool
+	EnableTechPreview        bool
 }
 
 // NewGCPCmd implements the "gcp" subcommand for the credentials provisioning

--- a/pkg/cmd/provisioning/ibmcloud/create_service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_service_id.go
@@ -51,6 +51,7 @@ func NewCreateServiceIDCmd() *cobra.Command {
 	createServiceIDCmd.MarkPersistentFlagRequired("credentials-requests-dir")
 	createServiceIDCmd.PersistentFlags().StringVar(&Options.ResourceGroupName, "resource-group-name", "", "Name of the resource group used for scoping the access policies")
 	createServiceIDCmd.PersistentFlags().StringVar(&Options.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
+	createServiceIDCmd.PersistentFlags().BoolVar(&Options.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return createServiceIDCmd
 }
@@ -78,7 +79,7 @@ func createServiceIDCmd(cmd *cobra.Command, args []string) error {
 	}
 
 	err = createServiceIDs(ibmclient, apiKeyDetails.AccountID, Options.Name, Options.ResourceGroupName,
-		Options.CredRequestDir, Options.TargetDir)
+		Options.CredRequestDir, Options.TargetDir, Options.EnableTechPreview)
 	if err != nil {
 		return err
 	}
@@ -87,7 +88,7 @@ func createServiceIDCmd(cmd *cobra.Command, args []string) error {
 }
 
 func createServiceIDs(client ibmcloud.Client, accountID *string,
-	name, resourceGroupName, credReqDir, targetDir string) error {
+	name, resourceGroupName, credReqDir, targetDir string, enableTechPreview bool) error {
 
 	resourceGroupID, err := getResourceGroupID(client, accountID, resourceGroupName)
 	if err != nil {
@@ -95,7 +96,7 @@ func createServiceIDs(client ibmcloud.Client, accountID *string,
 	}
 
 	// Process directory
-	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir)
+	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir, enableTechPreview)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}

--- a/pkg/cmd/provisioning/ibmcloud/create_service_id_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_service_id_test.go
@@ -424,7 +424,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 			require.NoError(t, err, "unexpected error creating manifests dir for test")
 			defer os.RemoveAll(manifestsDir)
 
-			if err := createServiceIDs(mockIBMCloudClient, core.StringPtr("1234"), "name", tt.resourceGroupName, credReqDir, targetDir); (err != nil) != tt.wantErr {
+			if err := createServiceIDs(mockIBMCloudClient, core.StringPtr("1234"), "name", tt.resourceGroupName, credReqDir, targetDir, false); (err != nil) != tt.wantErr {
 				t.Errorf("createServiceIDs() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			tt.verify(t, targetDir, manifestsDir)
@@ -477,7 +477,7 @@ func TestCreateSharedSecretsInvalidTargetDir(t *testing.T) {
 
 			targetDir := "doesnotexist"
 
-			if err := createServiceIDs(mockIBMCloudClient, core.StringPtr("1234"), "name1", tt.resourceGroupName, credReqDir, targetDir); (err != nil) != tt.wantErr {
+			if err := createServiceIDs(mockIBMCloudClient, core.StringPtr("1234"), "name1", tt.resourceGroupName, credReqDir, targetDir, false); (err != nil) != tt.wantErr {
 				t.Errorf("createServiceIDs() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})

--- a/pkg/cmd/provisioning/ibmcloud/delete_service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/delete_service_id.go
@@ -59,7 +59,8 @@ func deleteServiceIDCmd(cmd *cobra.Command, args []string) error {
 
 func deleteServiceIDs(client ibmcloud.Client, accountID, name, credReqDir string, force bool) error {
 	// Process directory
-	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir)
+	// always tech-preview==true because we should do a full cleanup to be on the safe side
+	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir, true)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}

--- a/pkg/cmd/provisioning/ibmcloud/delete_service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/delete_service_id.go
@@ -2,11 +2,11 @@ package ibmcloud
 
 import (
 	"fmt"
-	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 
+	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 	"github.com/openshift/cloud-credential-operator/pkg/ibmcloud"
 )
 

--- a/pkg/cmd/provisioning/ibmcloud/ibmcloud.go
+++ b/pkg/cmd/provisioning/ibmcloud/ibmcloud.go
@@ -12,6 +12,7 @@ type options struct {
 	Force             bool
 	KubeConfigFile    string
 	Create            bool
+	EnableTechPreview bool
 }
 
 // NewIBMCloudCmd implements the "ibmcloud" subcommand for the credentials provisioning

--- a/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
+++ b/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 	"log"
 
 	"github.com/pkg/errors"
@@ -15,6 +14,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
 
+	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 	"github.com/openshift/cloud-credential-operator/pkg/ibmcloud"
 )
 

--- a/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
+++ b/pkg/cmd/provisioning/ibmcloud/refresh-keys.go
@@ -34,6 +34,7 @@ func NewRefreshKeysCmd() *cobra.Command {
 	refreshKeysCmd.MarkPersistentFlagRequired("kubeconfig")
 	refreshKeysCmd.PersistentFlags().StringVar(&Options.ResourceGroupName, "resource-group-name", "", "Name of the resource group used for scoping the access policies")
 	refreshKeysCmd.PersistentFlags().BoolVar(&Options.Create, "create", false, "Create the ServiceID if does not exists")
+	refreshKeysCmd.PersistentFlags().BoolVar(&Options.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
 	return refreshKeysCmd
 }
@@ -64,21 +65,21 @@ func refreshKeysCmd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return errors.Wrap(err, "Failed to create the kubernetes clientset")
 	}
-	err = refreshKeys(ibmclient, cs, apiKeyDetails.AccountID, Options.Name, Options.ResourceGroupName, Options.CredRequestDir, Options.Create)
+	err = refreshKeys(ibmclient, cs, apiKeyDetails.AccountID, Options.Name, Options.ResourceGroupName, Options.CredRequestDir, Options.Create, Options.EnableTechPreview)
 	if err != nil {
 		return errors.Wrap(err, "Failed to refresh keys")
 	}
 	return nil
 }
 
-func refreshKeys(ibmcloudClient ibmcloud.Client, kubeClient kubernetes.Interface, accountID *string, name, resourceGroupName, credReqDir string, create bool) error {
+func refreshKeys(ibmcloudClient ibmcloud.Client, kubeClient kubernetes.Interface, accountID *string, name, resourceGroupName, credReqDir string, create, enableTechPreview bool) error {
 	resourceGroupID, err := getResourceGroupID(ibmcloudClient, accountID, resourceGroupName)
 	if err != nil {
 		return errors.Wrap(err, "Failed to getResourceGroupID")
 	}
 
 	// Process directory
-	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir)
+	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir, enableTechPreview)
 	if err != nil {
 		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}

--- a/pkg/cmd/provisioning/ibmcloud/refresh-keys_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/refresh-keys_test.go
@@ -268,7 +268,7 @@ func Test_refreshKeys(t *testing.T) {
 			credReqDir := tt.setup(t)
 			defer os.RemoveAll(credReqDir)
 
-			err := refreshKeys(mockIBMCloudClient, fakeKubeClient, &testAccountID, testName, tt.resourceGroupName, credReqDir, tt.create)
+			err := refreshKeys(mockIBMCloudClient, fakeKubeClient, &testAccountID, testName, tt.resourceGroupName, credReqDir, tt.create, false)
 			if tt.expectError == "" {
 				assert.NoError(t, err)
 			} else {

--- a/pkg/cmd/provisioning/utils.go
+++ b/pkg/cmd/provisioning/utils.go
@@ -173,9 +173,21 @@ func GetListOfCredentialsRequests(dir string) ([]*credreqv1.CredentialsRequest, 
 			// infrastructure.
 			if value, ok := cr.Annotations["release.openshift.io/delete"]; ok && value == "true" {
 				log.Printf("Ignoring CredentialsRequest %s/%s as it is marked for in-cluster deletion", cr.Namespace, cr.Name)
-			} else {
-				credRequests = append(credRequests, cr)
+				continue
 			}
+
+			// Ignore CredentialsRequest with the feature-gate annotation
+			if value, ok := cr.Annotations[featureGateAnnotation]; ok {
+				// By edict, the only valid value is "TechPreviewNoUpgrade"
+				if value != validTechPreviewAnnotationValue {
+					log.Printf("CredentialsRequests %s/%s has unexpected feature-gate value", cr.Namespace, cr.Name)
+
+				}
+				log.Printf("Ignoring CredentialsRequest %s/%s with tech-preview annotation", cr.Namespace, cr.Name)
+				continue
+			}
+
+			credRequests = append(credRequests, cr)
 		}
 	}
 

--- a/pkg/cmd/provisioning/utils_test.go
+++ b/pkg/cmd/provisioning/utils_test.go
@@ -1,11 +1,18 @@
 package provisioning
 
 import (
+	"io/ioutil"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	configv1 "github.com/openshift/api/config/v1"
+
+	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 )
 
 const (
@@ -85,5 +92,180 @@ func TestEnsureDir(t *testing.T) {
 				test.cleanup(t)
 			}
 		})
+	}
+}
+
+func TestFilteringCredReqs(t *testing.T) {
+	tests := []struct {
+		name              string
+		setup             func(*testing.T)
+		expectError       bool
+		verify            func(*testing.T, []*credreqv1.CredentialsRequest)
+		enableTechPreview bool
+	}{
+		{
+			name: "ignore CredReq marked as tech-preview",
+			setup: func(t *testing.T) {
+				testNewCredReq(t, "credReqA")
+				testNewTechPreviewCredReq(t, "credReqB")
+			},
+			verify: func(t *testing.T, credReqs []*credreqv1.CredentialsRequest) {
+				sResult, err := os.Stat(testDirPath)
+				require.NoError(t, err, "failed to stat")
+				assert.True(t, sResult.IsDir(), "unexpected error")
+
+				assert.Equal(t, 1, len(credReqs))
+			},
+			enableTechPreview: false,
+		},
+		{
+			name: "include CredReq marked as tech-preview",
+			setup: func(t *testing.T) {
+				testNewCredReq(t, "credReqA")
+				testNewTechPreviewCredReq(t, "credReqB")
+			},
+			verify: func(t *testing.T, credReqs []*credreqv1.CredentialsRequest) {
+				sResult, err := os.Stat(testDirPath)
+				require.NoError(t, err, "failed to stat")
+				assert.True(t, sResult.IsDir(), "unexpected error")
+
+				assert.Equal(t, 2, len(credReqs))
+			},
+			enableTechPreview: true,
+		},
+		{
+			name: "ignore CredReq marked for deletion",
+			setup: func(t *testing.T) {
+				testNewMarkedForDeletionCredReq(t, "credReqA")
+			},
+			verify: func(t *testing.T, credReqs []*credreqv1.CredentialsRequest) {
+				sResult, err := os.Stat(testDirPath)
+				require.NoError(t, err, "failed to stat")
+				assert.True(t, sResult.IsDir(), "unexpected error")
+
+				assert.Equal(t, 0, len(credReqs))
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// start from an empty directory
+			err := os.RemoveAll(testDirPath)
+			require.NoError(t, err, "error clearing out directory that should not exist")
+			err = os.Mkdir(testDirPath, 0700)
+			require.NoError(t, err, "error creating temp directory")
+
+			test.setup(t)
+
+			credReqs, err := GetListOfCredentialsRequests(testDirPath, test.enableTechPreview)
+			require.NoError(t, err, "unexpected error")
+
+			test.verify(t, credReqs)
+
+			err = os.RemoveAll(testDirPath)
+			require.NoError(t, err, "failed to clean test environment")
+		})
+	}
+}
+
+func testNewCredReq(t *testing.T, crName string) {
+	cr := NewCredentialsRequestBuilder().
+		Options(WithName(crName)).
+		Build()
+
+	saveCredReq(t, cr)
+}
+
+func testNewTechPreviewCredReq(t *testing.T, crName string) {
+	cr := NewCredentialsRequestBuilder().
+		Options(WithName(crName)).
+		Options(WithTechPreviewAnnotation()).
+		Build()
+
+	saveCredReq(t, cr)
+}
+
+func testNewMarkedForDeletionCredReq(t *testing.T, crName string) {
+	cr := NewCredentialsRequestBuilder().
+		Options(WithName(crName)).
+		Options(WithDeletionAnnotation()).
+		Build()
+
+	saveCredReq(t, cr)
+}
+
+func saveCredReq(t *testing.T, credReq *credreqv1.CredentialsRequest) {
+	re := &runtime.RawExtension{
+		Object: credReq,
+	}
+
+	out, err := re.MarshalJSON()
+	require.NoError(t, err, "error marshaling CredReq")
+
+	f, err := ioutil.TempFile(testDirPath, "credreq-testing-")
+	require.NoError(t, err, "error creating temp file")
+	defer f.Close()
+
+	_, err = f.Write(out)
+	require.Nil(t, err, "err")
+}
+
+type option func(*credreqv1.CredentialsRequest)
+
+func Build(opts ...option) *credreqv1.CredentialsRequest {
+	retval := &credreqv1.CredentialsRequest{}
+
+	for _, o := range opts {
+		o(retval)
+	}
+
+	return retval
+}
+
+type Builder interface {
+	Build(opts ...option) *credreqv1.CredentialsRequest
+
+	Options(opts ...option) Builder
+}
+
+type builder struct {
+	options []option
+}
+
+func (b *builder) Build(opts ...option) *credreqv1.CredentialsRequest {
+	return Build(append(b.options, opts...)...)
+}
+
+func (b *builder) Options(opts ...option) Builder {
+	return &builder{
+		options: append(b.options, opts...),
+	}
+}
+func NewCredentialsRequestBuilder() Builder {
+	return &builder{}
+}
+
+func WithName(name string) option {
+	return func(credreq *credreqv1.CredentialsRequest) {
+		credreq.SetName(name)
+	}
+}
+
+func WithTechPreviewAnnotation() option {
+	return func(credreq *credreqv1.CredentialsRequest) {
+		if credreq.Annotations == nil {
+			credreq.Annotations = map[string]string{}
+		}
+		credreq.Annotations[featureGateAnnotation] = string(configv1.TechPreviewNoUpgrade)
+	}
+}
+
+func WithDeletionAnnotation() option {
+	return func(credreq *credreqv1.CredentialsRequest) {
+		if credreq.Annotations == nil {
+			credreq.Annotations = map[string]string{}
+		}
+		credreq.Annotations[deletionAnnotation] = "true"
 	}
 }


### PR DESCRIPTION
First commit disables processing of resources with feature-gate annotation.

Second commit adds new --enable-tech-preview parameter which allows tech-preview-annotated resources through. Adds several test cases to cover it.