### PR TITLE
Leader election migration 1: ConfigMap & Lease

### DIFF
--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -30,3 +30,15 @@ rules:
   - rolebindings
   verbs:
   - "*"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete


### PR DESCRIPTION
We were using ConfigMap-based leader election. We need to migrate to
using Lease instead.

Part 1: Use ConfigMap *and* Lease so we can upgrade smoothly from a
build using just ConfigMap.
Part 2: Remove ConfigMap.

This is part 1.

x-ref: https://issues.redhat.com/browse/CCO-191
epic: https://issues.redhat.com/browse/CCO-182