### PR TITLE
Skip directories when reading credentials requests

### DIFF
--- a/pkg/cmd/provisioning/alibabacloud/create-ram-users_test.go
+++ b/pkg/cmd/provisioning/alibabacloud/create-ram-users_test.go
@@ -178,7 +178,7 @@ spec:
 
 	credReq := fmt.Sprintf(credReqTemplate, crName, targetSecretNamespace, targetSecretName)
 
-	f, err := ioutil.TempFile(targetDir, "testCredReq")
+	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 

--- a/pkg/cmd/provisioning/aws/create-iam-roles_test.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles_test.go
@@ -277,7 +277,7 @@ func testCredentialsRequest(t *testing.T, crName, targetSecretNamespace, targetS
 		credReq = fmt.Sprintf(credReqTemplate, crName, targetSecretNamespace, targetSecretName)
 	}
 
-	f, err := ioutil.TempFile(targetDir, "testCredReq")
+	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 

--- a/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
@@ -227,7 +227,7 @@ spec:
 
 	credReq := fmt.Sprintf(credReqTemplate, crName, targetSecretNamespace, targetSecretName)
 
-	f, err := ioutil.TempFile(targetDir, "testCredReq")
+	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 

--- a/pkg/cmd/provisioning/ibmcloud/create_service_id_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_service_id_test.go
@@ -485,7 +485,7 @@ func TestCreateSharedSecretsInvalidTargetDir(t *testing.T) {
 }
 
 func writeToTempFile(t *testing.T, targetDir, content string) {
-	f, err := ioutil.TempFile(targetDir, "testCredReq")
+	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 

--- a/pkg/cmd/provisioning/utils.go
+++ b/pkg/cmd/provisioning/utils.go
@@ -149,13 +149,16 @@ func KeyIDFromPublicKey(publicKey interface{}) (string, error) {
 
 // GetListOfCredentialsRequests decodes manifests in a given directory and returns a list of CredentialsRequests
 func GetListOfCredentialsRequests(dir string, enableTechPreview bool) ([]*credreqv1.CredentialsRequest, error) {
-	credRequests := []*credreqv1.CredentialsRequest{}
+	credRequests := make([]*credreqv1.CredentialsRequest, 0)
 	files, err := ioutil.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}
 
 	for _, file := range files {
+		if file.IsDir() || !(strings.HasSuffix(file.Name(), ".yaml") || strings.HasSuffix(file.Name(), ".yml")) {
+			continue
+		}
 		f, err := os.Open(filepath.Join(dir, file.Name()))
 		if err != nil {
 			return nil, errors.Wrap(err, "Failed to open file")

--- a/pkg/cmd/provisioning/utils_test.go
+++ b/pkg/cmd/provisioning/utils_test.go
@@ -203,7 +203,7 @@ func saveCredReq(t *testing.T, credReq *credreqv1.CredentialsRequest) {
 	out, err := re.MarshalJSON()
 	require.NoError(t, err, "error marshaling CredReq")
 
-	f, err := ioutil.TempFile(testDirPath, "credreq-testing-")
+	f, err := ioutil.TempFile(testDirPath, "credreq-testing-*.yaml")
 	require.NoError(t, err, "error creating temp file")
 	defer f.Close()
 


### PR DESCRIPTION
Ensure directories and non-yaml files are skipped when reading
CredentialsRequests.