### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -25,6 +25,10 @@ spec:
         control-plane: controller-manager
         controller-tools.k8s.io: "1.0"
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - args:
         - --secure-listen-address=0.0.0.0:8443
@@ -35,6 +39,10 @@ spec:
         image: quay.io/openshift/origin-kube-rbac-proxy:latest
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         ports:
         - containerPort: 8443
           name: metrics
@@ -66,6 +74,10 @@ spec:
         image: quay.io/openshift/origin-cloud-credential-operator:latest
         imagePullPolicy: IfNotPresent
         name: cloud-credential-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
         resources:
           requests:
             cpu: 10m


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-cloud-credential-operator/deployments/cloud-credential-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (containers \"kube-rbac-proxy\", \"cloud-credential-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capabilities (containers \"kube-rbac-proxy\", \"cloud-credential-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or containers \"kube-rbac-proxy\", \"cloud-credential-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or containers \"kube-rbac-proxy\", \"cloud-credential-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 

[CCO-209](https://issues.redhat.com//browse/CCO-209)