### PR TITLE
Bug 2093986: Make pod identity webhook comply to restricted pod security level

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -17,6 +17,10 @@ spec:
       - name: pod-identity-webhook
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         command:
         - /usr/bin/aws-pod-identity-webhook
         - --in-cluster=false
@@ -40,6 +44,10 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: pod-identity-webhook
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -139,6 +139,10 @@ spec:
       - name: pod-identity-webhook
         image: ${IMAGE}
         imagePullPolicy: IfNotPresent
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ "ALL" ]
         command:
         - /usr/bin/aws-pod-identity-webhook
         - --in-cluster=false
@@ -162,6 +166,10 @@ spec:
         node-role.kubernetes.io/master: ""
       priorityClassName: system-cluster-critical
       serviceAccountName: pod-identity-webhook
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be restricted. 