### PR TITLE
GCP GCE Inherited Credentials

### DIFF
--- a/pkg/cmd/provisioning/gcp/create_all.go
+++ b/pkg/cmd/provisioning/gcp/create_all.go
@@ -29,11 +29,20 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateAllOpts.Project, creds.JSON)
-	if err != nil {
-		log.Fatalf("Failed to initiate GCP client: %s", err)
-	}
+	var gcpClient gcp.Client
 
+	if len(creds.JSON) != 0 {
+		gcpClient, err = gcp.NewClient(CreateAllOpts.Project, creds.JSON)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
+
+	} else {
+		gcpClient, err = gcp.NewClient_GCE(CreateAllOpts.Project, creds)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
+	}
 	publicKeyPath := CreateAllOpts.PublicKeyPath
 	if publicKeyPath == "" {
 		publicKeyPath = path.Join(CreateAllOpts.TargetDir, provisioning.PublicKeyFile)

--- a/pkg/cmd/provisioning/gcp/create_all.go
+++ b/pkg/cmd/provisioning/gcp/create_all.go
@@ -43,6 +43,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 			log.Fatalf("Failed to initiate GCP client: %s", err)
 		}
 	}
+
 	publicKeyPath := CreateAllOpts.PublicKeyPath
 	if publicKeyPath == "" {
 		publicKeyPath = path.Join(CreateAllOpts.TargetDir, provisioning.PublicKeyFile)

--- a/pkg/cmd/provisioning/gcp/create_all.go
+++ b/pkg/cmd/provisioning/gcp/create_all.go
@@ -38,7 +38,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		}
 
 	} else {
-		gcpClient, err = gcp.NewClient_GCE(CreateAllOpts.Project, creds)
+		gcpClient, err = gcp.NewClientGCE(CreateAllOpts.Project, creds)
 		if err != nil {
 			log.Fatalf("Failed to initiate GCP client: %s", err)
 		}

--- a/pkg/cmd/provisioning/gcp/create_service_accounts.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts.go
@@ -326,9 +326,19 @@ func createServiceAccountsCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds.JSON)
-	if err != nil {
-		log.Fatal(err)
+	var gcpClient gcp.Client
+
+	if len(creds.JSON) != 0 {
+		gcpClient, err = gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds.JSON)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
+
+	} else {
+		gcpClient, err = gcp.NewClientGCE(CreateWorkloadIdentityProviderOpts.Project, creds)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
 	}
 
 	err = createServiceAccounts(ctx, gcpClient, CreateServiceAccountsOpts.Name, CreateServiceAccountsOpts.WorkloadIdentityPool,

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_pool.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_pool.go
@@ -46,9 +46,19 @@ func createWorkloadIdentityPoolCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityPoolOpts.Project, creds.JSON)
-	if err != nil {
-		log.Fatalf("Failed to setup GCP client: %s", err)
+	var gcpClient gcp.Client
+
+	if len(creds.JSON) != 0 {
+		gcpClient, err = gcp.NewClient(CreateWorkloadIdentityPoolOpts.Project, creds.JSON)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
+
+	} else {
+		gcpClient, err = gcp.NewClientGCE(CreateWorkloadIdentityPoolOpts.Project, creds)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
 	}
 
 	err = createWorkloadIdentityPool(ctx, gcpClient, CreateWorkloadIdentityPoolOpts.Name, CreateWorkloadIdentityPoolOpts.Project, CreateWorkloadIdentityPoolOpts.TargetDir, CreateWorkloadIdentityPoolOpts.DryRun)

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
@@ -60,9 +60,19 @@ func createWorkloadIdentityProviderCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds.JSON)
-	if err != nil {
-		log.Fatal(err)
+	var gcpClient gcp.Client
+
+	if len(creds.JSON) != 0 {
+		gcpClient, err = gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds.JSON)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
+
+	} else {
+		gcpClient, err = gcp.NewClientGCE(CreateWorkloadIdentityProviderOpts.Project, creds)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
 	}
 
 	publicKeyPath := CreateWorkloadIdentityProviderOpts.PublicKeyPath

--- a/pkg/cmd/provisioning/gcp/delete.go
+++ b/pkg/cmd/provisioning/gcp/delete.go
@@ -106,9 +106,19 @@ func deleteCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(DeleteOpts.Project, creds.JSON)
-	if err != nil {
-		log.Fatal(err)
+	var gcpClient gcp.Client
+
+	if len(creds.JSON) != 0 {
+		gcpClient, err = gcp.NewClient(DeleteOpts.Project, creds.JSON)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
+
+	} else {
+		gcpClient, err = gcp.NewClientGCE(DeleteOpts.Project, creds)
+		if err != nil {
+			log.Fatalf("Failed to initiate GCP client: %s", err)
+		}
 	}
 
 	bucketName := fmt.Sprintf("%s-oidc", DeleteOpts.Name)

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -369,46 +369,15 @@ func NewClient(projectName string, authJSON []byte) (Client, error) {
 		return nil, err
 	}
 
-	cloudResourceManagerClient, err := cloudresourcemanager.NewService(ctx, option.WithCredentials(creds))
-	if err != nil {
-		return nil, err
-	}
-
-	iamClient, err := iamadmin.NewIamClient(ctx, option.WithCredentials(creds))
-	if err != nil {
-		return nil, err
-	}
-
-	iamService, err := iam.NewService(ctx, option.WithCredentials(creds))
-	if err != nil {
-		return nil, err
-	}
-
-	serviceUsageClient, err := serviceusage.NewService(ctx, option.WithCredentials(creds))
-	if err != nil {
-		return nil, err
-	}
-
-	storageClient, err := storage.NewClient(ctx, option.WithCredentials(creds))
-	if err != nil {
-		return nil, err
-	}
-
-	return &gcpClient{
-		projectName:                projectName,
-		creds:                      creds,
-		cloudResourceManagerClient: cloudResourceManagerClient,
-		iamClient:                  iamClient,
-		iamService:                 iamService,
-		serviceUsageClient:         serviceUsageClient,
-		storageClient:              storageClient,
-	}, nil
+	return ClientCommon(ctx, projectName, creds)
 }
 
-func NewClient_GCE(projectName string, creds *google.Credentials) (Client, error) {
+func NewClientGCE(projectName string, creds *google.Credentials) (Client, error) {
 	ctx := context.TODO()
-	var err error
-	// since we're using a single creds var, we should specify all the required scopes when initializing
+	return ClientCommon(ctx, projectName, creds)
+}
+
+func ClientCommon(ctx context.Context, projectName string, creds *google.Credentials) (Client, error) {
 
 	cloudResourceManagerClient, err := cloudresourcemanager.NewService(ctx, option.WithCredentials(creds))
 	if err != nil {

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -404,3 +404,44 @@ func NewClient(projectName string, authJSON []byte) (Client, error) {
 		storageClient:              storageClient,
 	}, nil
 }
+
+func NewClient_GCE(projectName string, creds *google.Credentials) (Client, error) {
+	ctx := context.TODO()
+	var err error
+	// since we're using a single creds var, we should specify all the required scopes when initializing
+
+	cloudResourceManagerClient, err := cloudresourcemanager.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	iamClient, err := iamadmin.NewIamClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	iamService, err := iam.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	serviceUsageClient, err := serviceusage.NewService(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	storageClient, err := storage.NewClient(ctx, option.WithCredentials(creds))
+	if err != nil {
+		return nil, err
+	}
+
+	return &gcpClient{
+		projectName:                projectName,
+		creds:                      creds,
+		cloudResourceManagerClient: cloudResourceManagerClient,
+		iamClient:                  iamClient,
+		iamService:                 iamService,
+		serviceUsageClient:         serviceUsageClient,
+		storageClient:              storageClient,
+	}, nil
+}


### PR DESCRIPTION
## Problem:

We are using this Auth Method for GCP: https://github.com/openshift/cloud-credential-operator/blob/master/pkg/cmd/provisioning/gcp/credentials.go#L37
### Command:
```bash
ccoctl gcp create-all etc...
```

### Current Output:
```log
2022/06/20 16:14:59 Credentials loaded from gcloud CLI defaults
2022/06/20 16:14:59 Failed to initiate GCP client: unexpected end of JSON input
```

## How to Re-Produce the Issue:
1. Spin up a GCP GCE VM with a service account attached to it.  
   - ```--service-account=```
3. Run ccoctl commands inside the VM

## Proposed Solution: 
See Code

Successful Output
```log
2022/06/24 16:58:10 Credentials loaded from gcloud CLI defaults
2022/06/24 16:58:10 Using existing RSA keypair found at /tmp/ocp/installer/wif-cred-out/serviceaccount-signer.private
2022/06/24 16:58:10 Copying signing key for use by installer
<snipped>
```

## Caveat:
My GoLang, & knowledge of this code-base is limited.
While this fixes my issue, I may have still must edged cases or inadvertently broken something else.

Feel free to close / modify the PR to implement in a better way if it seems fit.

[CCO-226](https://issues.redhat.com//browse/CCO-226)