### PR TITLE
Bug 2101880: manifests/00-namespace: Set empty openshift.io/run-level

### DIFF
--- a/manifests/00-namespace.yaml
+++ b/manifests/00-namespace.yaml
@@ -8,4 +8,5 @@ metadata:
     workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
+    openshift.io/run-level: "" # specify no run-level turns it off on install and upgrades
   name: openshift-cloud-credential-operator


### PR DESCRIPTION
We dropped the run-level label from this namespace back in 8120317f56 (#159, [4.5][1]).  But because of [how the cluster-version operator reconciles manifest labels][2], dropping a label from the manifest does not remove it from the in-cluster resource when old clusters are updated into the new manifest.  This commit uses [the approach the cluster-version operator used][3] to drop its run-level, by setting the value to an empty string, which the run-level-consuming code treats identically to an unset label.

This avoids errors about:

    ...container has runAsNonRoot and image will run as root...

when [updating to 4.11][4].  Because the namespace manifest sorts before the deployment manifest, there is probably no need to get this change back into 4.10 manifests, although that wouldn't hurt.

[1]: https://bugzilla.redhat.com/show_bug.cgi?id=1806892
[2]: https://issues.redhat.com/browse/OTA-330
[3]: https://github.com/openshift/cluster-version-operator/pull/623/commits/539e944920679548f17862b9f4ad9b5cb54ef233#diff-39019af7716ea5d1b86c1eb34e131de533e2701b1bb3014f9a2d71be603ff345R12
[4]: https://bugzilla.redhat.com/show_bug.cgi?id=2101880#c2