### PR TITLE
Bug 2100964: Make ccoctl work with credentials fetched from gcloud cli defaults

### DIFF
--- a/pkg/cmd/provisioning/gcp/create_all.go
+++ b/pkg/cmd/provisioning/gcp/create_all.go
@@ -29,7 +29,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateAllOpts.Project, creds.JSON)
+	gcpClient, err := gcp.NewClient(CreateAllOpts.Project, creds)
 	if err != nil {
 		log.Fatalf("Failed to initiate GCP client: %s", err)
 	}

--- a/pkg/cmd/provisioning/gcp/create_service_accounts.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts.go
@@ -326,7 +326,7 @@ func createServiceAccountsCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds.JSON)
+	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_pool.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_pool.go
@@ -46,7 +46,7 @@ func createWorkloadIdentityPoolCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityPoolOpts.Project, creds.JSON)
+	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityPoolOpts.Project, creds)
 	if err != nil {
 		log.Fatalf("Failed to setup GCP client: %s", err)
 	}

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
@@ -60,7 +60,7 @@ func createWorkloadIdentityProviderCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds.JSON)
+	gcpClient, err := gcp.NewClient(CreateWorkloadIdentityProviderOpts.Project, creds)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/cmd/provisioning/gcp/delete.go
+++ b/pkg/cmd/provisioning/gcp/delete.go
@@ -106,7 +106,7 @@ func deleteCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to load credentials: %s", err)
 	}
 
-	gcpClient, err := gcp.NewClient(DeleteOpts.Project, creds.JSON)
+	gcpClient, err := gcp.NewClient(DeleteOpts.Project, creds)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -76,7 +76,7 @@ func NewActuator(c client.Client, projectName string) (*Actuator, error) {
 		ProjectName:      projectName,
 		Client:           c,
 		Codec:            codec,
-		GCPClientBuilder: ccgcp.NewClient,
+		GCPClientBuilder: ccgcp.NewClientFromJSON,
 	}, nil
 }
 

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -359,15 +359,8 @@ func (c *gcpClient) DeleteObject(ctx context.Context, bucketName, objectName str
 }
 
 // NewClient creates our client wrapper object for interacting with GCP.
-func NewClient(projectName string, authJSON []byte) (Client, error) {
+func NewClient(projectName string, creds *google.Credentials) (Client, error) {
 	ctx := context.TODO()
-	var creds *google.Credentials
-	var err error
-	// since we're using a single creds var, we should specify all the required scopes when initializing
-	creds, err = google.CredentialsFromJSON(context.TODO(), authJSON, compute.CloudPlatformScope)
-	if err != nil {
-		return nil, err
-	}
 
 	cloudResourceManagerClient, err := cloudresourcemanager.NewService(ctx, option.WithCredentials(creds))
 	if err != nil {
@@ -403,4 +396,15 @@ func NewClient(projectName string, authJSON []byte) (Client, error) {
 		serviceUsageClient:         serviceUsageClient,
 		storageClient:              storageClient,
 	}, nil
+}
+
+func NewClientFromJSON(projectName string, authJSON []byte) (Client, error) {
+	var creds *google.Credentials
+	var err error
+	// since we're using a single creds var, we should specify all the required scopes when initializing
+	creds, err = google.CredentialsFromJSON(context.TODO(), authJSON, compute.CloudPlatformScope)
+	if err != nil {
+		return nil, err
+	}
+	return NewClient(projectName, creds)
 }

--- a/pkg/operator/secretannotator/gcp/reconciler.go
+++ b/pkg/operator/secretannotator/gcp/reconciler.go
@@ -45,7 +45,7 @@ func NewReconciler(mgr manager.Manager, projectName string) reconcile.Reconciler
 	r := &ReconcileCloudCredSecret{
 		Client:           c,
 		Logger:           log.WithField("controller", constants.SecretAnnotatorControllerName),
-		GCPClientBuilder: ccgcp.NewClient,
+		GCPClientBuilder: ccgcp.NewClientFromJSON,
 		ProjectName:      projectName,
 	}
 


### PR DESCRIPTION
ccoctl cli does not know how to leverage the VM's attached service account to talk to GCP APIs. This PR adds that support.