### PR TITLE
Bug 2117474: Fix panic when the Provider spec is empty in credential request

### DIFF
--- a/pkg/cmd/provisioning/ibmcloud/service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/service_id.go
@@ -85,6 +85,10 @@ func (s *ServiceID) Validate() error {
 		return errors.Wrap(err, "Failed to create credReq codec")
 	}
 
+	if s.cr.Spec.ProviderSpec == nil {
+		return fmt.Errorf("Spec.ProviderSpec is empty in %s credentials request", s.cr.Name)
+	}
+
 	var unknown runtime.Unknown
 	err = codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, &unknown)
 	if err != nil {


### PR DESCRIPTION
This PR contains the changes to fix the panic while generating a secret from a credential request when the Provider spec is empty or wrongly indented, Instead of panic the below error is thrown

```
2022/08/10 14:11:35 Failed to validate the serviceID: Spec.ProviderSpec is empty in powervs-block-csi-driver-operator credentials request
```