### PR TITLE
Add support for granular GCP permissions using custom roles

### DIFF
--- a/docs/ccoctl.md
+++ b/docs/ccoctl.md
@@ -186,7 +186,7 @@ $ ccoctl gcp create-all --name=<name> --region=<gcp-region> --project=<gcp-proje
 To delete resources created by ccoctl, run
 
 ```bash
-$ ccoctl gcp delete --name=<name> --project=<gcp-project-id>
+$ ccoctl gcp delete --name=<name> --project=<gcp-project-id> --credentials-requests-dir <path-to-directory-with-list-of-credentials-requests>
 
 ```
 

--- a/docs/gcp_workload_identity.md
+++ b/docs/gcp_workload_identity.md
@@ -128,4 +128,4 @@ Make sure you clean up the following resources after you uninstall your cluster.
 2. Cloud storage bucket used to store OpenID Connect configuration and the public key
 3. IAM service accounts created by ccoctl tool along with project policy bindings
 
-You can use `ccoctl gcp delete --name=<name> --project=<gcp-project-id>` to delete all the above resources.
+You can use `ccoctl gcp delete --name=<name> --project=<gcp-project-id> --credentials-requests-dir <path-to-directory-with-list-of-credentials-requests>` to delete all the above resources.

--- a/pkg/apis/cloudcredential/v1/types_gcp.go
+++ b/pkg/apis/cloudcredential/v1/types_gcp.go
@@ -29,7 +29,13 @@ type GCPProviderSpec struct {
 	// PredefinedRoles is the list of GCP pre-defined roles
 	// that the CredentialsRequest requires.
 	PredefinedRoles []string `json:"predefinedRoles"`
-	// SkipServiceCheck can be set to true to skip the check whether the requested roles
+	// Permissions is the list of GCP permissions required to create a more fine-grained custom role to
+	// satisfy the CredentialsRequest.
+	// The Permissions field may be provided in addition to PredefinedRoles. When both fields are specified,
+	// the service account will have union of permissions defined from both Permissions and PredefinedRoles.
+	// +optional
+	Permissions []string `json:"permissions,omitempty"`
+	// SkipServiceCheck can be set to true to skip the check whether the requested roles or permissions
 	// have the necessary services enabled
 	// +optional
 	SkipServiceCheck bool `json:"skipServiceCheck,omitempty"`
@@ -41,4 +47,9 @@ type GCPProviderStatus struct {
 	metav1.TypeMeta `json:",inline"`
 	// ServiceAccountID is the ID of the service account created in GCP for the requested credentials.
 	ServiceAccountID string `json:"serviceAccountID"`
+	// RoleID is the ID of the custom role created in GCP for the requested permissions apart from
+	// permissions granted by the pre-defined roles.
+	// RoleID is set by the Cloud Credential Operator controllers and should not be set manually.
+	// +optional
+	RoleID string `json:"roleID,omitempty"`
 }

--- a/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
@@ -372,6 +372,11 @@ func (in *GCPProviderSpec) DeepCopyInto(out *GCPProviderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Permissions != nil {
+		in, out := &in.Permissions, &out.Permissions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/cmd/provisioning/gcp/delete.go
+++ b/pkg/cmd/provisioning/gcp/delete.go
@@ -10,8 +10,10 @@ import (
 	"github.com/spf13/cobra"
 	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
 
+	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 	"github.com/openshift/cloud-credential-operator/pkg/gcp"
 	"github.com/openshift/cloud-credential-operator/pkg/gcp/actuator"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
 var (
@@ -50,33 +52,110 @@ func deleteOIDCBucket(ctx context.Context, client gcp.Client, bucketName, namePr
 }
 
 // deleteServiceAccounts deletes the IAM service accounts created by ccoctl
-func deleteServiceAccounts(ctx context.Context, client gcp.Client, namePrefix string) error {
+func deleteServiceAccounts(ctx context.Context, client gcp.Client, namePrefix, credReqDir string) error {
 	projectName := client.GetProjectName()
 	projectResourceName := fmt.Sprintf("projects/%s", projectName)
-	listServiceAccountsRequest := &iamadminpb.ListServiceAccountsRequest{
-		Name: projectResourceName,
-	}
 
-	svcAcctList, err := client.ListServiceAccounts(ctx, listServiceAccountsRequest)
+	// Process directory
+	// always tech-preview==true because we should do a full cleanup to be on the safe side
+	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir, true)
 	if err != nil {
-		return errors.Wrapf(err, "Failed to fetch list of service accounts")
+		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
 	}
-	for _, svcAcct := range svcAcctList {
-		if isCreatedByCcoctl(svcAcct.Email, namePrefix) || isCreatedByCcoctl(svcAcct.DisplayName, namePrefix) {
-			svcAcctBindingName := actuator.ServiceAccountBindingName(svcAcct)
-			err := actuator.RemovePolicyBindingsForProject(client, svcAcctBindingName)
-			if err != nil {
-				return errors.Wrapf(err, "Failed to remove project policy bindings for service account")
-			}
 
-			if err := actuator.DeleteServiceAccount(client, svcAcct); err != nil {
-				return errors.Wrapf(err, "Failed to delete service account")
-			}
+	for _, cr := range credReqs {
+		// Generate service account name from credentials request to fetch service account if it exists
+		// The service account name field has a 100 char max, so generate a name consisting of the
+		// infraName chopped to 50 chars + the crName chopped to 49 chars (separated by a '-').
+		serviceAccountNameFromCredReq, err := utils.GenerateNameWithFieldLimits(namePrefix, 50, cr.Name, 49)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to generate service account name from credentils request %s", cr.Name)
+		}
 
-			log.Printf("IAM Service account %s deleted", svcAcct.DisplayName)
+		listServiceAccountsRequest := &iamadminpb.ListServiceAccountsRequest{
+			Name: projectResourceName,
+		}
+		svcAcctList, err := client.ListServiceAccounts(ctx, listServiceAccountsRequest)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to fetch list of service accounts")
+		}
+		for _, svcAcct := range svcAcctList {
+			if svcAcct.DisplayName == serviceAccountNameFromCredReq {
+				svcAcctBindingName := actuator.ServiceAccountBindingName(svcAcct)
+				err := actuator.RemovePolicyBindingsForProject(client, svcAcctBindingName)
+				if err != nil {
+					return errors.Wrapf(err, "Failed to remove project policy bindings for service account")
+				}
+
+				if err := actuator.DeleteServiceAccount(client, svcAcct); err != nil {
+					return errors.Wrapf(err, "Failed to delete service account")
+				}
+
+				log.Printf("IAM service account %s deleted", svcAcct.DisplayName)
+			}
 		}
 	}
+	return nil
+}
 
+// deleteCustomRoles deletes the IAM custom roles created by ccoctl
+func deleteCustomRoles(ctx context.Context, client gcp.Client, namePrefix, credReqDir string) error {
+	projectName := client.GetProjectName()
+	projectResourceName := fmt.Sprintf("projects/%s", projectName)
+
+	// Process directory
+	// always tech-preview==true because we should do a full cleanup to be on the safe side
+	credReqs, err := provisioning.GetListOfCredentialsRequests(credReqDir, true)
+	if err != nil {
+		return errors.Wrap(err, "Failed to process files containing CredentialsRequests")
+	}
+
+	for _, cr := range credReqs {
+		// Generate role name from credentials request to fetch custom role if it exists
+		// The role name field has a 100 char max, so generate a name consisting of the
+		// infraName chopped to 50 chars + the crName chopped to 49 chars (separated by a '-').
+		roleNameFromCredReq, err := utils.GenerateNameWithFieldLimits(namePrefix, 50, cr.Name, 49)
+		if err != nil {
+			return errors.Wrapf(err, "Failed to generate custom role name from credentils request %s", cr.Name)
+		}
+
+		listRolesResponse, err := client.ListRoles(ctx, &iamadminpb.ListRolesRequest{
+			Parent: projectResourceName,
+		})
+		if err != nil {
+			return errors.Wrapf(err, "Failed to fetch list of IAM roles")
+		}
+
+		for _, role := range listRolesResponse.Roles {
+			if role.Title == roleNameFromCredReq {
+				if _, err := actuator.DeleteRole(client, role.Name); err != nil {
+					return errors.Wrapf(err, "Failed to delete custom role")
+				}
+				log.Printf("IAM custom role %s deleted", role.Title)
+			}
+		}
+		nextPageToken := listRolesResponse.NextPageToken
+
+		for nextPageToken != "" {
+			listRolesResponse, err := client.ListRoles(ctx, &iamadminpb.ListRolesRequest{
+				Parent:    projectResourceName,
+				PageToken: nextPageToken,
+			})
+			if err != nil {
+				return errors.Wrapf(err, "Failed to fetch list of IAM roles")
+			}
+
+			for _, role := range listRolesResponse.Roles {
+				if role.Title == roleNameFromCredReq {
+					if _, err := actuator.DeleteRole(client, role.Name); err != nil {
+						return errors.Wrapf(err, "Failed to delete custom role")
+					}
+					log.Printf("IAM custom role %s deleted", role.Title)
+				}
+			}
+			nextPageToken = listRolesResponse.NextPageToken
+		}
+	}
 	return nil
 }
 
@@ -121,7 +200,11 @@ func deleteCmd(cmd *cobra.Command, args []string) {
 		log.Print(err)
 	}
 
-	if err := deleteServiceAccounts(ctx, gcpClient, DeleteOpts.Name); err != nil {
+	if err := deleteCustomRoles(ctx, gcpClient, DeleteOpts.Name, DeleteOpts.CredRequestDir); err != nil {
+		log.Print(err)
+	}
+
+	if err := deleteServiceAccounts(ctx, gcpClient, DeleteOpts.Name, DeleteOpts.CredRequestDir); err != nil {
 		log.Print(err)
 	}
 
@@ -143,6 +226,8 @@ func NewDeleteCmd() *cobra.Command {
 	deleteCmd.MarkPersistentFlagRequired("name")
 	deleteCmd.PersistentFlags().StringVar(&DeleteOpts.Project, "project", "", "ID of the google cloud project")
 	deleteCmd.MarkPersistentFlagRequired("project")
+	deleteCmd.PersistentFlags().StringVar(&DeleteOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests to delete IAM Roles for (can be created by running 'oc adm release extract --credentials-requests --cloud=ibmcloud' against an OpenShift release image)")
+	deleteCmd.MarkPersistentFlagRequired("credentials-requests-dir")
 
 	return deleteCmd
 }

--- a/pkg/gcp/actuator/role.go
+++ b/pkg/gcp/actuator/role.go
@@ -19,10 +19,14 @@ package actuator
 import (
 	"context"
 	"fmt"
+	"log"
+	"regexp"
 
 	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	utilrand "k8s.io/apimachinery/pkg/util/rand"
 
 	ccgcp "github.com/openshift/cloud-credential-operator/pkg/gcp"
 )
@@ -44,4 +48,84 @@ func getPermissionsFromRoles(gcpClient ccgcp.Client, roles []string) ([]string, 
 	}
 
 	return permList, nil
+}
+
+// GetRole fetches the role created to satisfy a credentials request
+func GetRole(gcpClient ccgcp.Client, roleID, projectName string) (*iamadminpb.Role, error) {
+	log.Printf("role id %v", roleID)
+	role, err := gcpClient.GetRole(context.TODO(), &iamadminpb.GetRoleRequest{
+		Name: fmt.Sprintf("projects/%s/roles/%s", projectName, roleID),
+	})
+	return role, err
+}
+
+// CreateRole creates a new role given permissions
+func CreateRole(gcpClient ccgcp.Client, permissions []string, roleName, roleID, roleDescription, projectName string) (*iamadminpb.Role, error) {
+	role, err := gcpClient.CreateRole(context.TODO(), &iamadminpb.CreateRoleRequest{
+		Role: &iamadminpb.Role{
+			Title:               roleName,
+			Description:         roleDescription,
+			IncludedPermissions: permissions,
+			Stage:               iamadminpb.Role_GA,
+		},
+		Parent: fmt.Sprintf("projects/%s", projectName),
+		RoleId: roleID,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+// UpdateRole updates an existing role given permissions
+func UpdateRole(gcpClient ccgcp.Client, role *iamadminpb.Role, roleName string) (*iamadminpb.Role, error) {
+	role, err := gcpClient.UpdateRole(context.TODO(), &iamadminpb.UpdateRoleRequest{
+		Name: roleName,
+		Role: role,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return role, nil
+}
+
+// DeleteRole deletes the role created to satisfy a credentials request
+func DeleteRole(gcpClient ccgcp.Client, roleName string) (*iamadminpb.Role, error) {
+	role, err := gcpClient.DeleteRole(context.TODO(), &iamadminpb.DeleteRoleRequest{
+		Name: roleName,
+	})
+	return role, err
+}
+
+// GenerateRoleID generates a unique ID for the role given infra name and credentials request name.
+// The role ID has a max length of 64 chars and can include only letters, numbers, period and underscores
+// we sanitize infraName and crName to make them alphanumeric and then
+// split role ID into 29_28_5 where the resulting string becomes:
+// <infraName chopped to 29 chars>_<crName chopped to 28 chars>_<random 5 chars>
+func GenerateRoleID(infraName string, crName string) (string, error) {
+	infraName = makeAlphanumeric(infraName)
+	crName = makeAlphanumeric(crName)
+
+	infraNameMaxLenForRoleName := 29
+	crNameMaxLenForRoleName := 28
+
+	if crName == "" {
+		return "", fmt.Errorf("empty credential request name")
+	}
+
+	if infraName != "" {
+		if len(infraName) > infraNameMaxLenForRoleName {
+			infraName = infraName[0:infraNameMaxLenForRoleName]
+		}
+	}
+	if len(crName) > crNameMaxLenForRoleName {
+		crName = crName[0:crNameMaxLenForRoleName]
+	}
+	return fmt.Sprintf("%s_%s_%s", infraName, crName, utilrand.String(5)), nil
+}
+
+// makeAlphanumeric makes a given string alphanumeric
+func makeAlphanumeric(str string) string {
+	reg, _ := regexp.Compile("[^a-zA-Z0-9]+")
+	return reg.ReplaceAllString(str, "")
 }

--- a/pkg/gcp/actuator/utils.go
+++ b/pkg/gcp/actuator/utils.go
@@ -20,11 +20,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-
-	"sigs.k8s.io/controller-runtime/pkg/client"
+	"reflect"
+	"sort"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 )
@@ -90,4 +91,22 @@ func loadCredsFromSecret(kubeClient client.Client, namespace, secretName string)
 	}
 
 	return jsonBytes, nil
+}
+
+// AreSlicesEqualWithoutOrder check for equality on slices without order
+func AreSlicesEqualWithoutOrder(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	aCopy := make([]string, len(a))
+	bCopy := make([]string, len(b))
+
+	copy(aCopy, a)
+	copy(bCopy, b)
+
+	sort.Strings(aCopy)
+	sort.Strings(bCopy)
+
+	return reflect.DeepEqual(aCopy, bCopy)
 }

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -45,6 +45,10 @@ type Client interface {
 	DeleteServiceAccount(context.Context, *iamadminpb.DeleteServiceAccountRequest) error
 	DeleteServiceAccountKey(context.Context, *iamadminpb.DeleteServiceAccountKeyRequest) error
 	GetRole(context.Context, *iamadminpb.GetRoleRequest) (*iamadminpb.Role, error)
+	CreateRole(context.Context, *iamadminpb.CreateRoleRequest) (*iamadminpb.Role, error)
+	UpdateRole(context.Context, *iamadminpb.UpdateRoleRequest) (*iamadminpb.Role, error)
+	DeleteRole(context.Context, *iamadminpb.DeleteRoleRequest) (*iamadminpb.Role, error)
+	ListRoles(context.Context, *iamadminpb.ListRolesRequest) (*iamadminpb.ListRolesResponse, error)
 	GetServiceAccount(context.Context, *iamadminpb.GetServiceAccountRequest) (*iamadminpb.ServiceAccount, error)
 	ListServiceAccountKeys(context.Context, *iamadminpb.ListServiceAccountKeysRequest) (*iamadminpb.ListServiceAccountKeysResponse, error)
 	ListServiceAccounts(context.Context, *iamadminpb.ListServiceAccountsRequest) ([]*iamadminpb.ServiceAccount, error)
@@ -126,6 +130,30 @@ func (c *gcpClient) GetRole(ctx context.Context, request *iamadminpb.GetRoleRequ
 	ctx, cancel := contextWithTimeout(ctx)
 	defer cancel()
 	return c.iamClient.GetRole(ctx, request)
+}
+
+func (c *gcpClient) CreateRole(ctx context.Context, request *iamadminpb.CreateRoleRequest) (*iamadminpb.Role, error) {
+	ctx, cancel := contextWithTimeout(ctx)
+	defer cancel()
+	return c.iamClient.CreateRole(ctx, request)
+}
+
+func (c *gcpClient) UpdateRole(ctx context.Context, request *iamadminpb.UpdateRoleRequest) (*iamadminpb.Role, error) {
+	ctx, cancel := contextWithTimeout(ctx)
+	defer cancel()
+	return c.iamClient.UpdateRole(ctx, request)
+}
+
+func (c *gcpClient) DeleteRole(ctx context.Context, request *iamadminpb.DeleteRoleRequest) (*iamadminpb.Role, error) {
+	ctx, cancel := contextWithTimeout(ctx)
+	defer cancel()
+	return c.iamClient.DeleteRole(ctx, request)
+}
+
+func (c *gcpClient) ListRoles(ctx context.Context, request *iamadminpb.ListRolesRequest) (*iamadminpb.ListRolesResponse, error) {
+	ctx, cancel := contextWithTimeout(ctx)
+	defer cancel()
+	return c.iamClient.ListRoles(ctx, request)
 }
 
 func (c *gcpClient) GetServiceAccount(ctx context.Context, request *iamadminpb.GetServiceAccountRequest) (*iamadminpb.ServiceAccount, error) {

--- a/pkg/gcp/mock/client_generated.go
+++ b/pkg/gcp/mock/client_generated.go
@@ -53,6 +53,21 @@ func (mr *MockClientMockRecorder) CreateBucket(arg0, arg1, arg2, arg3 interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBucket", reflect.TypeOf((*MockClient)(nil).CreateBucket), arg0, arg1, arg2, arg3)
 }
 
+// CreateRole mocks base method.
+func (m *MockClient) CreateRole(arg0 context.Context, arg1 *admin.CreateRoleRequest) (*admin.Role, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateRole", arg0, arg1)
+	ret0, _ := ret[0].(*admin.Role)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateRole indicates an expected call of CreateRole.
+func (mr *MockClientMockRecorder) CreateRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateRole", reflect.TypeOf((*MockClient)(nil).CreateRole), arg0, arg1)
+}
+
 // CreateServiceAccount mocks base method.
 func (m *MockClient) CreateServiceAccount(arg0 context.Context, arg1 *admin.CreateServiceAccountRequest) (*admin.ServiceAccount, error) {
 	m.ctrl.T.Helper()
@@ -139,6 +154,21 @@ func (m *MockClient) DeleteObject(arg0 context.Context, arg1, arg2 string) error
 func (mr *MockClientMockRecorder) DeleteObject(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteObject", reflect.TypeOf((*MockClient)(nil).DeleteObject), arg0, arg1, arg2)
+}
+
+// DeleteRole mocks base method.
+func (m *MockClient) DeleteRole(arg0 context.Context, arg1 *admin.DeleteRoleRequest) (*admin.Role, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteRole", arg0, arg1)
+	ret0, _ := ret[0].(*admin.Role)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// DeleteRole indicates an expected call of DeleteRole.
+func (mr *MockClientMockRecorder) DeleteRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteRole", reflect.TypeOf((*MockClient)(nil).DeleteRole), arg0, arg1)
 }
 
 // DeleteServiceAccount mocks base method.
@@ -348,6 +378,21 @@ func (mr *MockClientMockRecorder) ListObjects(arg0, arg1 interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListObjects", reflect.TypeOf((*MockClient)(nil).ListObjects), arg0, arg1)
 }
 
+// ListRoles mocks base method.
+func (m *MockClient) ListRoles(arg0 context.Context, arg1 *admin.ListRolesRequest) (*admin.ListRolesResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRoles", arg0, arg1)
+	ret0, _ := ret[0].(*admin.ListRolesResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRoles indicates an expected call of ListRoles.
+func (mr *MockClientMockRecorder) ListRoles(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRoles", reflect.TypeOf((*MockClient)(nil).ListRoles), arg0, arg1)
+}
+
 // ListServiceAccountKeys mocks base method.
 func (m *MockClient) ListServiceAccountKeys(arg0 context.Context, arg1 *admin.ListServiceAccountKeysRequest) (*admin.ListServiceAccountKeysResponse, error) {
 	m.ctrl.T.Helper()
@@ -494,4 +539,19 @@ func (m *MockClient) UndeleteWorkloadIdentityPool(arg0 context.Context, arg1 str
 func (mr *MockClientMockRecorder) UndeleteWorkloadIdentityPool(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UndeleteWorkloadIdentityPool", reflect.TypeOf((*MockClient)(nil).UndeleteWorkloadIdentityPool), arg0, arg1, arg2)
+}
+
+// UpdateRole mocks base method.
+func (m *MockClient) UpdateRole(arg0 context.Context, arg1 *admin.UpdateRoleRequest) (*admin.Role, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateRole", arg0, arg1)
+	ret0, _ := ret[0].(*admin.Role)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateRole indicates an expected call of UpdateRole.
+func (mr *MockClientMockRecorder) UpdateRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateRole", reflect.TypeOf((*MockClient)(nil).UpdateRole), arg0, arg1)
 }


### PR DESCRIPTION
Add a new `permissions` API field to GCP provider spec.
Permissions is the list of GCP permissions required to create a
more fine-grained custom role to satisfy the CredentialsRequest.
When both Permissions and PredefinedRoles are specified, the
service account will have union of permissions from both the fields

For permissions specified, a custom role is created and added
to the service account along with the predefined roles.

x-ref: https://issues.redhat.com/browse/CCO-188