### PR TITLE
Make ccoctl use regional STS endpoint by default

### DIFF
--- a/docs/sts.md
+++ b/docs/sts.md
@@ -17,6 +17,7 @@ With STS we have a full-fledged AWS configuration that defines a `role` and `web
 
 ```yaml
 [default]
+sts_regional_endpoints = regional
 role_name = arn:...:role/some-role-name
 web_identity_token_file = /path/to/token
 ```

--- a/pkg/cmd/provisioning/aws/create-iam-roles.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles.go
@@ -27,6 +27,7 @@ const (
 stringData:
   credentials: |-
     [default]
+    sts_regional_endpoints = regional
     role_arn = %s
     web_identity_token_file = %s
 kind: Secret


### PR DESCRIPTION
By default, AWS Security Token Service (AWS STS) is available 
as a global service, and all AWS STS requests go to a single 
endpoint at https://sts.amazonaws.com. Global requests map 
to the us-east-1 region. AWS recommends using Regional AWS
STS endpoints instead of the global endpoint.

x-ref: https://issues.redhat.com/browse/CCO-257