### PR TITLE
Make pod-identity-webhook deployment HA by default

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,10 @@ CRD_APIS :=./pkg/apis/cloudcredential/v1
 # Exclude e2e tests from unit testing
 GO_TEST_PACKAGES :=./pkg/... ./cmd/...
 
-IMAGE_REGISTRY :=registry.ci.openshift.org
+IMAGE_REGISTRY ?=registry.ci.openshift.org
+IMAGE_REPO ?=ocp/4.5
+IMAGE_TAG ?=cloud-credential-operator
+
 
 # This will call a macro called "add-bindata" which will generate bindata specific targets based on the parameters:
 # $0 - macro name
@@ -66,7 +69,7 @@ $(call add-bindata,v4.1.0,./bindata/v4.1.0/...,bindata,v410_00_assets,pkg/assets
 # $2 - image ref
 # $3 - Dockerfile path
 # $4 - context directory for image build
-$(call build-image,ocp-cloud-credential-operator,$(IMAGE_REGISTRY)/ocp/4.5:cloud-credential-operator, ./Dockerfile,.)
+$(call build-image,ocp-cloud-credential-operator,$(IMAGE_REGISTRY)/$(IMAGE_REPO):$(IMAGE_TAG), ./Dockerfile,.)
 
 # This will call a macro called "add-crd-gen" will will generate crd manifests based on the parameters:
 # $1 - target name

--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: pod-identity-webhook
   namespace: openshift-cloud-credential-operator
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: pod-identity-webhook

--- a/bindata/v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml
@@ -1,0 +1,10 @@
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pod-identity-webhook
+  namespace: openshift-cloud-credential-operator
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pod-identity-webhook

--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -42,3 +42,9 @@ rules:
   - update
   - patch
   - delete
+- apiGroups:
+  - policy
+  resources:
+  - poddisruptionbudgets
+  verbs:
+  - "*"

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -126,7 +126,7 @@ metadata:
   name: pod-identity-webhook
   namespace: openshift-cloud-credential-operator
 spec:
-  replicas: 1
+  replicas: 2
   selector:
     matchLabels:
       app: pod-identity-webhook

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -4,6 +4,7 @@
 // bindata/v4.1.0/aws-pod-identity-webhook/clusterrolebinding.yaml
 // bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
 // bindata/v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml
+// bindata/v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml
 // bindata/v4.1.0/aws-pod-identity-webhook/role.yaml
 // bindata/v4.1.0/aws-pod-identity-webhook/rolebinding.yaml
 // bindata/v4.1.0/aws-pod-identity-webhook/sa.yaml
@@ -249,6 +250,33 @@ func v410AwsPodIdentityWebhookMutatingwebhookYaml() (*asset, error) {
 	return a, nil
 }
 
+var _v410AwsPodIdentityWebhookPoddisruptionbudgetYaml = []byte(`apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: pod-identity-webhook
+  namespace: openshift-cloud-credential-operator
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: pod-identity-webhook
+`)
+
+func v410AwsPodIdentityWebhookPoddisruptionbudgetYamlBytes() ([]byte, error) {
+	return _v410AwsPodIdentityWebhookPoddisruptionbudgetYaml, nil
+}
+
+func v410AwsPodIdentityWebhookPoddisruptionbudgetYaml() (*asset, error) {
+	bytes, err := v410AwsPodIdentityWebhookPoddisruptionbudgetYamlBytes()
+	if err != nil {
+		return nil, err
+	}
+
+	info := bindataFileInfo{name: "v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml", size: 0, mode: os.FileMode(0), modTime: time.Unix(0, 0)}
+	a := &asset{bytes: bytes, info: info}
+	return a, nil
+}
+
 var _v410AwsPodIdentityWebhookRoleYaml = []byte(`apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
@@ -425,14 +453,15 @@ func AssetNames() []string {
 
 // _bindata is a table, holding each asset generator, mapped to its name.
 var _bindata = map[string]func() (*asset, error){
-	"v4.1.0/aws-pod-identity-webhook/clusterrole.yaml":        v410AwsPodIdentityWebhookClusterroleYaml,
-	"v4.1.0/aws-pod-identity-webhook/clusterrolebinding.yaml": v410AwsPodIdentityWebhookClusterrolebindingYaml,
-	"v4.1.0/aws-pod-identity-webhook/deployment.yaml":         v410AwsPodIdentityWebhookDeploymentYaml,
-	"v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml":    v410AwsPodIdentityWebhookMutatingwebhookYaml,
-	"v4.1.0/aws-pod-identity-webhook/role.yaml":               v410AwsPodIdentityWebhookRoleYaml,
-	"v4.1.0/aws-pod-identity-webhook/rolebinding.yaml":        v410AwsPodIdentityWebhookRolebindingYaml,
-	"v4.1.0/aws-pod-identity-webhook/sa.yaml":                 v410AwsPodIdentityWebhookSaYaml,
-	"v4.1.0/aws-pod-identity-webhook/svc.yaml":                v410AwsPodIdentityWebhookSvcYaml,
+	"v4.1.0/aws-pod-identity-webhook/clusterrole.yaml":         v410AwsPodIdentityWebhookClusterroleYaml,
+	"v4.1.0/aws-pod-identity-webhook/clusterrolebinding.yaml":  v410AwsPodIdentityWebhookClusterrolebindingYaml,
+	"v4.1.0/aws-pod-identity-webhook/deployment.yaml":          v410AwsPodIdentityWebhookDeploymentYaml,
+	"v4.1.0/aws-pod-identity-webhook/mutatingwebhook.yaml":     v410AwsPodIdentityWebhookMutatingwebhookYaml,
+	"v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml": v410AwsPodIdentityWebhookPoddisruptionbudgetYaml,
+	"v4.1.0/aws-pod-identity-webhook/role.yaml":                v410AwsPodIdentityWebhookRoleYaml,
+	"v4.1.0/aws-pod-identity-webhook/rolebinding.yaml":         v410AwsPodIdentityWebhookRolebindingYaml,
+	"v4.1.0/aws-pod-identity-webhook/sa.yaml":                  v410AwsPodIdentityWebhookSaYaml,
+	"v4.1.0/aws-pod-identity-webhook/svc.yaml":                 v410AwsPodIdentityWebhookSvcYaml,
 }
 
 // AssetDir returns the file names below a certain
@@ -480,14 +509,15 @@ type bintree struct {
 var _bintree = &bintree{nil, map[string]*bintree{
 	"v4.1.0": {nil, map[string]*bintree{
 		"aws-pod-identity-webhook": {nil, map[string]*bintree{
-			"clusterrole.yaml":        {v410AwsPodIdentityWebhookClusterroleYaml, map[string]*bintree{}},
-			"clusterrolebinding.yaml": {v410AwsPodIdentityWebhookClusterrolebindingYaml, map[string]*bintree{}},
-			"deployment.yaml":         {v410AwsPodIdentityWebhookDeploymentYaml, map[string]*bintree{}},
-			"mutatingwebhook.yaml":    {v410AwsPodIdentityWebhookMutatingwebhookYaml, map[string]*bintree{}},
-			"role.yaml":               {v410AwsPodIdentityWebhookRoleYaml, map[string]*bintree{}},
-			"rolebinding.yaml":        {v410AwsPodIdentityWebhookRolebindingYaml, map[string]*bintree{}},
-			"sa.yaml":                 {v410AwsPodIdentityWebhookSaYaml, map[string]*bintree{}},
-			"svc.yaml":                {v410AwsPodIdentityWebhookSvcYaml, map[string]*bintree{}},
+			"clusterrole.yaml":         {v410AwsPodIdentityWebhookClusterroleYaml, map[string]*bintree{}},
+			"clusterrolebinding.yaml":  {v410AwsPodIdentityWebhookClusterrolebindingYaml, map[string]*bintree{}},
+			"deployment.yaml":          {v410AwsPodIdentityWebhookDeploymentYaml, map[string]*bintree{}},
+			"mutatingwebhook.yaml":     {v410AwsPodIdentityWebhookMutatingwebhookYaml, map[string]*bintree{}},
+			"poddisruptionbudget.yaml": {v410AwsPodIdentityWebhookPoddisruptionbudgetYaml, map[string]*bintree{}},
+			"role.yaml":                {v410AwsPodIdentityWebhookRoleYaml, map[string]*bintree{}},
+			"rolebinding.yaml":         {v410AwsPodIdentityWebhookRolebindingYaml, map[string]*bintree{}},
+			"sa.yaml":                  {v410AwsPodIdentityWebhookSaYaml, map[string]*bintree{}},
+			"svc.yaml":                 {v410AwsPodIdentityWebhookSvcYaml, map[string]*bintree{}},
 		}},
 	}},
 }}

--- a/pkg/operator/awspodidentity/controller.go
+++ b/pkg/operator/awspodidentity/controller.go
@@ -51,6 +51,7 @@ var (
 		"v4.1.0/aws-pod-identity-webhook/clusterrolebinding.yaml",
 		"v4.1.0/aws-pod-identity-webhook/rolebinding.yaml",
 		"v4.1.0/aws-pod-identity-webhook/svc.yaml",
+		"v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml",
 	}
 	templateFiles = []string{
 		"v4.1.0/aws-pod-identity-webhook/deployment.yaml",

--- a/pkg/operator/awspodidentity/controller.go
+++ b/pkg/operator/awspodidentity/controller.go
@@ -302,6 +302,17 @@ func (r *staticResourceReconciler) ReconcileResources(ctx context.Context) error
 	if modified {
 		r.logger.Infof("MutatingWebhookConfiguration reconciled successfully")
 	}
+
+	// "v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml"
+	requestedPDB := resourceread.ReadPodDisruptionBudgetV1OrDie(v410_00_assets.MustAsset("v4.1.0/aws-pod-identity-webhook/poddisruptionbudget.yaml"))
+	_, modified, err = resourceapply.ApplyPodDisruptionBudget(context.TODO(), r.clientset.PolicyV1(), r.eventRecorder, requestedPDB)
+	if err != nil {
+		r.logger.WithError(err).Error("error applying PodDisruptionBudget")
+		return err
+	}
+	if modified {
+		r.logger.Infof("PodDisruptionBudget reconciled successfully")
+	}
 	return nil
 }
 


### PR DESCRIPTION
[CCO-259](https://issues.redhat.com//browse/CCO-259)

This PR increases the replicas of the aws-pod-identity-webhook deployment from 1 to 2 and adds management of a `PodDisruptionBudget` with `minAvailable=1` for the mutating webhook deployment.