### PR TITLE
[release-4.10] OCPBUGS-2802: Backport --credentials-requests-dir for ccoctl gcp delete.

### DIFF
--- a/docs/ccoctl.md
+++ b/docs/ccoctl.md
@@ -156,7 +156,7 @@ $ ccoctl gcp create-all --name=<name> --region=<gcp-region> --project=<gcp-proje
 To delete resources created by ccoctl, run
 
 ```bash
-$ ccoctl gcp delete --name=<name> --project=<gcp-project-id>
+$ ccoctl gcp delete --name=<name> --project=<gcp-project-id> --credentials-requests-dir <path-to-directory-with-list-of-credentials-requests>
 
 ```
 

--- a/docs/gcp_workload_identity.md
+++ b/docs/gcp_workload_identity.md
@@ -119,4 +119,4 @@ Make sure you clean up the following resources after you uninstall your cluster.
 2. Cloud storage bucket used to store OpenID Connect configuration and the public key
 3. IAM service accounts created by ccoctl tool along with project policy bindings
 
-You can use `ccoctl gcp delete --name=<name> --project=<gcp-project-id>` command to delete all the above resources.
+You can use `ccoctl gcp delete --name=<name> --project=<gcp-project-id> --credentials-requests-dir <path-to-directory-with-list-of-credentials-requests>` to delete all the above resources.


### PR DESCRIPTION
The CredentialsRequests names are needed in order to clean up the correct service accounts in GCP.

This backports https://github.com/openshift/cloud-credential-operator/pull/489 but only code related to the bug that was fixed by requiring --credentials-requests-dir for ccoctl gcp delete described in https://github.com/openshift/cloud-credential-operator/pull/489#issuecomment-1248733205.

~Creating as draft since tests will rely on https://github.com/openshift/release/pull/33402 to delete the service accounts in GCP.~

[OCPBUGS-2802](https://issues.redhat.com/browse/OCPBUGS-2802)