### PR TITLE
`make vulncheck`: shift dependabot left

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,3 +157,7 @@ build-no-gen: build
 coverage:
 	hack/codecov.sh
 .PHONY: coverage
+
+vulncheck:
+	hack/vulncheck.sh
+.PHONY: vulncheck

--- a/hack/vulncheck.sh
+++ b/hack/vulncheck.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+### Use govulncheck to check for known vulnerabilities in the project.
+### Fail if vulnerabilities are found in module dependencies.
+### Warn (but do not fail) on stdlib vulnerabilities.
+
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+report=`mktemp`
+trap "rm $report" EXIT
+
+govulncheck -json ./... > $report
+
+modvulns=$(jq -r '.Vulns[].Modules[] | select(.Path != "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+libvulns=$(jq -r '.Vulns[].Modules[] | select(.Path == "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+
+echo "$modvulns"
+echo "$libvulns"
+
+# Exit nonzero iff there are any vulnerabilities in module dependencies
+test -z "$modvulns"


### PR DESCRIPTION
At this point we're only guessing that dependabot module vulnerability scanning uses `govulncheck` under the covers; and creates issues based on vulns found in module dependencies, ignoring those in the standard library (the actual go version). This commit attempts to replicate that check such that we can hopefully figure out whether we've resolved issues without having to merge PRs and wait for dependabot.

With this commit, `make vulncheck` will emit a report similar to:

```
[
  "golang.org/x/net",
  "v0.5.0",
  "v0.7.0"
]
[
  "stdlib",
  "go1.19.3",
  "go1.20.1"
]
[
  "stdlib",
  "go1.19.3",
  "go1.20.1"
]
[
  "stdlib",
  "go1.19.3",
  "go1.20.1"
]
[
  "stdlib",
  "go1.19.3",
  "go1.20.1"
]
[
  "stdlib",
  "go1.19.3",
  "go1.19.4"
]
[
  "stdlib",
  "go1.19.3",
  "go1.19.4"
]
```

Each stanza lists
- where the vulnerability exists
- the version it was found in
- the version it's fixed in

If the report contains any entries that are *not* in `stdlib`, the check will fail (exit nonzero). Otherwise it will succeed -- i.e. the `stdlib` entries are only warnings.