### PR TITLE
Upgrade build-machinery-go: `make vulncheck`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	github.com/mitchellh/mapstructure v1.4.1 // indirect
 	github.com/nutanix-cloud-native/prism-go-client v0.2.1-0.20220804130801-c8a253627c64
 	github.com/openshift/api v0.0.0-20230120195050-6ba31fa438f2
-	github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+	github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 	github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a
 	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.14.0

--- a/go.sum
+++ b/go.sum
@@ -619,8 +619,8 @@ github.com/onsi/gomega v1.19.0/go.mod h1:LY+I3pBVzYsTBU1AnDwOSxaYi9WoWiqgwooUqq9
 github.com/onsi/gomega v1.24.1 h1:KORJXNNTzJXzu4ScJWssJfJMnJ+2QJqhoQSRwNlze9E=
 github.com/openshift/api v0.0.0-20230120195050-6ba31fa438f2 h1:+nw0/d4spq880W7S74Twi5YU2ulsl3/a9o4OEZptYp0=
 github.com/openshift/api v0.0.0-20230120195050-6ba31fa438f2/go.mod h1:ctXNyWanKEjGj8sss1KjjHQ3ENKFm33FFnS5BKaIPh4=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d h1:RR4ah7FfaPR1WePizm0jlrsbmPu91xQZnAsVVreQV1k=
-github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
+github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533 h1:mh3ZYs7kPIIe3UUY6tJcTExmtjnXXUu0MrBuK2W/Qvw=
+github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533/go.mod h1:b1BuldmJlbA/xYtdZvKi+7j5YGB44qJUJDZ9zwiNCfE=
 github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a h1:OzF7I7mAzO4SBo5eO5CWoCTgMDydN/Tf2/Rq8YbMpT0=
 github.com/openshift/library-go v0.0.0-20230130232623-47904dd9ff5a/go.mod h1:xO4nAf0qa56dgvEJWVD1WuwSJ8JWPU1TYLBQrlutWnE=
 github.com/pborman/uuid v1.2.0/go.mod h1:X/NO0urCmaxf9VXbdlT7C2Yzkj2IKimNn4k+gtPdI/k=

--- a/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/default.example.mk.help.log
@@ -24,3 +24,4 @@ verify-gofmt
 verify-golang-versions
 verify-golint
 verify-govet
+vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/golang.example.mk.help.log
@@ -13,3 +13,4 @@ verify-gofmt
 verify-golang-versions
 verify-golint
 verify-govet
+vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
+++ b/vendor/github.com/openshift/build-machinery-go/make/operator.example.mk.help.log
@@ -31,3 +31,4 @@ verify-golang-versions
 verify-golint
 verify-govet
 verify-profile-manifests
+vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/test-unit.mk
@@ -4,11 +4,11 @@ include $(addprefix $(dir $(lastword $(MAKEFILE_LIST))), \
 
 test-unit:
 ifndef JUNITFILE
-	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES)
+	$(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) $(GO_TEST_PACKAGES) $(GO_TEST_ARGS)
 else
 ifeq (, $(shell which gotest2junit 2>/dev/null))
 	$(error gotest2junit not found! Get it by `go get -mod='' -u github.com/openshift/release/tools/gotest2junit`.)
 endif
-	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) | gotest2junit > $(JUNITFILE)
+	set -o pipefail; $(GO) test $(GO_MOD_FLAGS) $(GO_TEST_FLAGS) -json $(GO_TEST_PACKAGES) $(GO_TEST_ARGS) | gotest2junit > $(JUNITFILE)
 endif
 .PHONY: test-unit

--- a/vendor/github.com/openshift/build-machinery-go/make/targets/golang/vulncheck.mk
+++ b/vendor/github.com/openshift/build-machinery-go/make/targets/golang/vulncheck.mk
@@ -1,0 +1,31 @@
+scripts_dir :=$(shell realpath $(dir $(lastword $(MAKEFILE_LIST)))../../../scripts)
+
+# `make vulncheck` will emit a report similar to:
+# 
+# [
+#   "golang.org/x/net",
+#   "v0.5.0",
+#   "v0.7.0"
+# ]
+# [
+#   "stdlib",
+#   "go1.19.3",
+#   "go1.20.1"
+# ]
+# [
+#   "stdlib",
+#   "go1.19.3",
+#   "go1.19.4"
+# ]
+# 
+# Each stanza lists
+# - where the vulnerability exists
+# - the version it was found in
+# - the version it's fixed in
+# 
+# If the report contains any entries that are not in stdlib, the check
+# will fail (exit nonzero). Otherwise it will succeed -- i.e. the stdlib
+# entries are only warnings.
+vulncheck:
+	bash $(scripts_dir)/vulncheck.sh
+.PHONY: vulncheck

--- a/vendor/github.com/openshift/build-machinery-go/scripts/vulncheck.sh
+++ b/vendor/github.com/openshift/build-machinery-go/scripts/vulncheck.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+### Use govulncheck to check for known vulnerabilities in the project.
+### Fail if vulnerabilities are found in module dependencies.
+### Warn (but do not fail) on stdlib vulnerabilities.
+### TODO: Include useful information (ID, URL) about the vulnerability.
+
+go install golang.org/x/vuln/cmd/govulncheck@latest
+
+report=`mktemp`
+trap "rm $report" EXIT
+
+govulncheck -json ./... > $report
+
+modvulns=$(jq -r '.Vulns[].Modules[] | select(.Path != "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+libvulns=$(jq -r '.Vulns[].Modules[] | select(.Path == "stdlib") | [.Path, .FoundVersion, .FixedVersion]' < $report)
+
+echo "$modvulns"
+echo "$libvulns"
+
+# Exit nonzero iff there are any vulnerabilities in module dependencies
+test -z "$modvulns"

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8361,7 +8361,7 @@ github.com/openshift/api/template
 github.com/openshift/api/template/v1
 github.com/openshift/api/user
 github.com/openshift/api/user/v1
-# github.com/openshift/build-machinery-go v0.0.0-20220913142420-e25cf57ea46d
+# github.com/openshift/build-machinery-go v0.0.0-20230306181456-d321ffa04533
 ## explicit; go 1.13
 github.com/openshift/build-machinery-go
 github.com/openshift/build-machinery-go/make


### PR DESCRIPTION
Bring in the latest BMG so we can now `make vulncheck` to get a preview of what dependabot might complain about.