### PR TITLE
OCPBUGS-8666: feat: add workload annotation to pod identity webhook deployment

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -10,6 +10,8 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
+      annotation:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook
     spec:

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -133,6 +133,8 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
+      annotation:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook
     spec:


### PR DESCRIPTION
Add annotation to webhook deployment for workload pinning, this allows workload admission webhook to correctly modify the resources to allow the workload pinning feature to operate as desired. This annotation already exists on the [operator deployment](https://github.com/openshift/cloud-credential-operator/blob/1f7a2602bf8a9ddec5d8fc29f77215697d9e7c07/manifests/03-deployment.yaml#L20-L22), it's just missing from the webhook.

Related to the enhancements below:
https://github.com/openshift/enhancements/pull/703
https://github.com/openshift/enhancements/pull/1213