### PR TITLE
OCPBUGS-8666: Correct pod-identity-webhook annotations for PreferredDuringScheduling.

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -10,7 +10,7 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
-      annotation:
+      annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -133,7 +133,7 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
-      annotation:
+      annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook


### PR DESCRIPTION
The previous change introducing the annotations had a typo: s/annotation/annotations/.

[OCPBUGS-8666](https://issues.redhat.com/browse/OCPBUGS-8666)