### PR TITLE
[release-4.13] OCPBUGS-10822: Adding missing workload annotations

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -10,7 +10,7 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
-      annotation:
+      annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook

--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -10,6 +10,8 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
+      annotation:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook
     spec:

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -133,7 +133,7 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
-      annotation:
+      annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -133,6 +133,8 @@ spec:
       app: pod-identity-webhook
   template:
     metadata:
+      annotation:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         app: pod-identity-webhook
     spec:


### PR DESCRIPTION
Cherry-picks #520 and #522 to 4.13.

With workload pinning feature introduced in 4.13 we'll need to backport this annotation to 4.13. We've also added tests in origin to help catch these annotations going forward.

/assign @abutcher 
