### PR TITLE
CCO modified for Token mode, a PoC

### DIFF
--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -1,0 +1,18 @@
+FROM golang:1.19 AS builder
+WORKDIR /go/src/github.com/openshift/cloud-credential-operator
+COPY . .
+ENV GO_PACKAGE github.com/openshift/cloud-credential-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cloud-credential-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/ccoctl
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/cloud-credential-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/
+RUN mkdir /manifests
+COPY manifests /manifests
+# Update perms so we can copy updated CA if needed
+RUN chmod -R g+w /etc/pki/ca-trust/extracted/pem/
+LABEL io.openshift.release.operator=true
+# TODO make path explicit here to remove need for ENTRYPOINT
+# https://github.com/openshift/installer/blob/a8ddf6619794416c4600a827c2d9284724d382d8/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L347
+ENTRYPOINT [ "/usr/bin/cloud-credential-operator" ]

--- a/Dockerfile.local.debug
+++ b/Dockerfile.local.debug
@@ -1,0 +1,26 @@
+FROM golang:1.19 AS builder
+# Build Delve
+RUN go install github.com/go-delve/delve/cmd/dlv@latest
+
+WORKDIR /go/src/github.com/openshift/cloud-credential-operator
+COPY . .
+ENV GO_PACKAGE github.com/openshift/cloud-credential-operator
+RUN go build -gcflags="all=-N -l" -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/cloud-credential-operator
+RUN go build -ldflags "-X $GO_PACKAGE/pkg/version.versionFromGit=$(git describe --long --tags --abbrev=7 --match 'v[0-9]*')" ./cmd/ccoctl
+
+FROM registry.access.redhat.com/ubi8/ubi:latest
+
+EXPOSE 40000
+
+COPY --from=builder /go/bin/dlv /dlv
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/cloud-credential-operator /usr/bin/
+COPY --from=builder /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/
+RUN mkdir /manifests
+COPY manifests /manifests
+# Update perms so we can copy updated CA if needed
+RUN chmod -R g+w /etc/pki/ca-trust/extracted/pem/
+LABEL io.openshift.release.operator=true
+# TODO make path explicit here to remove need for ENTRYPOINT
+# https://github.com/openshift/installer/blob/a8ddf6619794416c4600a827c2d9284724d382d8/data/data/bootstrap/files/usr/local/bin/bootkube.sh.template#L347
+
+CMD ["/dlv", "--listen=:40000", "--continue", "--headless=true", "--api-version=2", "--accept-multiclient", "--log", "exec", "/usr/bin/cloud-credential-operator"]

--- a/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
+++ b/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
@@ -92,6 +92,12 @@ spec:
                 type: array
                 items:
                   type: string
+              cloudTokenString:
+                description: 'Like an AWS ARN String for instance'
+                type: string
+              cloudTokenPath:
+                description: 'Path to the cloud token'
+                type: string
           status:
             description: CredentialsRequestStatus defines the observed state of CredentialsRequest
             type: object

--- a/bindata/bootstrap/cloudcredential_v1_operator_config_custresdef.yaml
+++ b/bindata/bootstrap/cloudcredential_v1_operator_config_custresdef.yaml
@@ -43,6 +43,7 @@ spec:
                     - Manual
                     - Mint
                     - Passthrough
+                    - Token
                 logLevel:
                   description: "logLevel is an intent based logging for an overall component.  It does not give fine grained control, but it is a simple way to manage coarse grained logging choices that operators have to interpret for their operands. \n Valid values are: \"Normal\", \"Debug\", \"Trace\", \"TraceAll\". Defaults to \"Normal\"."
                   type: string

--- a/cred-reqs/nginx_credentials-request.yaml
+++ b/cred-reqs/nginx_credentials-request.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: nginx
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+        - s3:CreateBucket
+        - s3:DeleteBucket
+        - s3:PutBucketTagging
+        - s3:GetBucketTagging
+        - s3:PutBucketPublicAccessBlock
+        - s3:GetBucketPublicAccessBlock
+        - s3:PutEncryptionConfiguration
+        - s3:GetEncryptionConfiguration
+        - s3:PutLifecycleConfiguration
+        - s3:GetLifecycleConfiguration
+        - s3:GetBucketLocation
+        - s3:ListBucket
+        - s3:GetObject
+        - s3:PutObject
+        - s3:DeleteObject
+        - s3:ListBucketMultipartUploads
+        - s3:AbortMultipartUpload
+        - s3:ListMultipartUploadParts
+      effect: Allow
+      resource: '*'
+  secretRef:
+    name: nginx-credentials
+    namespace: default
+  serviceAccountNames:
+  - nginx

--- a/cred-reqs/nginx_credentials-request.yaml
+++ b/cred-reqs/nginx_credentials-request.yaml
@@ -37,3 +37,6 @@ spec:
     namespace: default
   serviceAccountNames:
   - nginx
+  cloudTokenString: arn:aws:iam::269733383066:oidc-provider/newstscluster-oidc.s3.us-east-1.amazonaws.com
+  cloudTokenPath: /var/cloud-token
+

--- a/hack/example-app.yaml
+++ b/hack/example-app.yaml
@@ -1,0 +1,34 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: nginx
+  namespace: default
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::269733383066:oidc-provider/newstscluster-oidc.s3.us-east-1.amazonaws.com
+    eks.amazonaws.com/audience: sts.amazonaws.com
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: nginx
+  name: nginx
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: nginx
+  strategy: {}
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      serviceAccountName: nginx
+      containers:
+      - image: nginx:alpine
+        name: nginx
+        ports:
+        - containerPort: 80
+        resources: {}

--- a/manifests/03-deployment-debug.yaml
+++ b/manifests/03-deployment-debug.yaml
@@ -1,0 +1,117 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    config.openshift.io/inject-proxy: cloud-credential-operator
+    exclude.release.openshift.io/internal-openshift-hosted: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+  name: cloud-credential-operator
+  namespace: openshift-cloud-credential-operator
+spec:
+  replicas: 1
+  revisionHistoryLimit: 4
+  selector:
+    matchLabels:
+      control-plane: controller-manager
+      controller-tools.k8s.io: "1.0"
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+      labels:
+        app: cloud-credential-operator
+        control-plane: controller-manager
+        controller-tools.k8s.io: "1.0"
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
+      containers:
+      - args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:2112/
+        - --tls-cert-file=/etc/tls/private/tls.crt
+        - --tls-private-key-file=/etc/tls/private/tls.key
+        - --logtostderr=true
+        - --kubeconfig=
+        image: quay.io/openshift/origin-kube-rbac-proxy:latest
+        imagePullPolicy: IfNotPresent
+        name: kube-rbac-proxy
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        ports:
+        - containerPort: 8443
+          name: metrics
+          protocol: TCP
+        resources:
+          requests:
+            memory: 20Mi
+            cpu: 10m
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+        volumeMounts:
+        - mountPath: /etc/tls/private
+          name: cloud-credential-operator-serving-cert
+      - args:
+        - |
+          if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
+              echo "Copying system trust bundle"
+              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+          fi
+          exec /usr/bin/cloud-credential-operator operator
+        command:
+        - /bin/bash
+        - -ec
+        env:
+        - name: RELEASE_VERSION
+          value: 0.0.1-snapshot
+        - name: AWS_POD_IDENTITY_WEBHOOK_IMAGE
+          value: quay.io/btofel/pod-identity-webhook:latest
+        image: quay.io/btofel/cco:latest-debug
+        imagePullPolicy: Always
+        name: cloud-credential-operator
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: ["ALL"]
+        resources:
+          requests:
+            cpu: 10m
+            memory: 150Mi
+        terminationMessagePolicy: FallbackToLogsOnError
+        volumeMounts:
+        - mountPath: /var/run/configmaps/trusted-ca-bundle
+          name: cco-trusted-ca
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      priorityClassName: system-cluster-critical
+      serviceAccountName: cloud-credential-operator
+      terminationGracePeriodSeconds: 10
+      tolerations:
+      - effect: NoSchedule
+        key: node-role.kubernetes.io/master
+        operator: Exists
+      - effect: NoExecute
+        key: node.kubernetes.io/unreachable
+        operator: Exists
+        tolerationSeconds: 120
+      - effect: NoExecute
+        key: node.kubernetes.io/not-ready
+        operator: Exists
+        tolerationSeconds: 120
+      volumes:
+      - configMap:
+          items:
+          - key: ca-bundle.crt
+            path: tls-ca-bundle.pem
+          name: cco-trusted-ca
+          optional: true
+        name: cco-trusted-ca
+      - name: cloud-credential-operator-serving-cert
+        secret:
+          secretName: cloud-credential-operator-serving-cert

--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -36,6 +36,7 @@ spec:
         - --tls-cert-file=/etc/tls/private/tls.crt
         - --tls-private-key-file=/etc/tls/private/tls.key
         - --logtostderr=true
+        - --kubeconfig=
         image: quay.io/openshift/origin-kube-rbac-proxy:latest
         imagePullPolicy: IfNotPresent
         name: kube-rbac-proxy
@@ -70,9 +71,9 @@ spec:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
         - name: AWS_POD_IDENTITY_WEBHOOK_IMAGE
-          value: quay.io/openshift/aws-pod-identity-webhook:latest
-        image: quay.io/openshift/origin-cloud-credential-operator:latest
-        imagePullPolicy: IfNotPresent
+          value: quay.io/btofel/pod-identity-webhook:latest
+        image: quay.io/btofel/cco:latest
+        imagePullPolicy: Always
         name: cloud-credential-operator
         securityContext:
           allowPrivilegeEscalation: false

--- a/manifests/image-references
+++ b/manifests/image-references
@@ -5,11 +5,11 @@ spec:
   - name: cloud-credential-operator
     from:
       kind: DockerImage
-      Name: quay.io/openshift/origin-cloud-credential-operator
+      Name: quay.io/btofel/cco:latest
   - name: aws-pod-identity-webhook
     from:
       kind: DockerImage
-      Name: quay.io/openshift/aws-pod-identity-webhook
+      Name: quay.io/btofel/pod-identity-webhook:latest
   - name: kube-rbac-proxy
     from:
       kind: DockerImage

--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -60,6 +60,12 @@ type CredentialsRequestSpec struct {
 	// credentials flow.
 	// +optional
 	ServiceAccountNames []string `json:"serviceAccountNames,omitempty"`
+	// CloudTokenString (for instance for AWS a Role ARN)
+	// +optional
+	CloudTokenString string `json:"cloudTokenString,omitempty"`
+	// CloudTokenPath (JWT token)
+	// +optional
+	CloudTokenPath string `json:"cloudTokenPath,omitempty"`
 }
 
 // CredentialsRequestStatus defines the observed state of CredentialsRequest

--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -226,7 +226,8 @@ func isValidMode(mode operatorv1.CloudCredentialsMode) bool {
 	case operatorv1.CloudCredentialsModeDefault,
 		operatorv1.CloudCredentialsModeManual,
 		operatorv1.CloudCredentialsModeMint,
-		operatorv1.CloudCredentialsModePassthrough:
+		operatorv1.CloudCredentialsModePassthrough,
+		utils.CloudCredentialsModeToken:
 		return true
 	default:
 		return false

--- a/pkg/operator/constants/constants.go
+++ b/pkg/operator/constants/constants.go
@@ -75,6 +75,10 @@ const (
 	// found in this repo's manifests/ dir.
 	PassthroughAnnotation = "passthrough"
 
+	// TokenAnnotation is used when the cluster is in timed token mode (for instance: STS Enabled)
+	//TODO probably should eliminate ModeManualPodIdentity
+	TokenAnnotation = "token"
+
 	// InsufficientAnnotation is used to indicate that the creds do not have
 	// sufficient permissions for cluster runtime.
 	InsufficientAnnotation = "insufficient"

--- a/pkg/operator/platform/platform.go
+++ b/pkg/operator/platform/platform.go
@@ -36,10 +36,11 @@ func GetInfraStatus(kClient client.Client) (*configv1.InfrastructureStatus, erro
 // it will get the platform type from it, otherwise it will get it from InfraStatus.Platform which
 // is deprecated in 4.2
 func GetType(infraStatus *configv1.InfrastructureStatus) configv1.PlatformType {
-	if infraStatus.PlatformStatus != nil && len(infraStatus.PlatformStatus.Type) > 0 {
-		return infraStatus.PlatformStatus.Type
-	}
-	return infraStatus.Platform
+	//if infraStatus.PlatformStatus != nil && len(infraStatus.PlatformStatus.Type) > 0 {
+	//	return infraStatus.PlatformStatus.Type
+	//}
+	return configv1.AWSPlatformType
+	//return infraStatus.Platform
 }
 
 func getClient(explicitKubeconfig string) (client.Client, error) {

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -34,6 +34,11 @@ const (
 	// OperatorDisabledDefault holds the default behavior of whether CCO is disabled
 	// in the absence of any setting in the ConfigMap
 	OperatorDisabledDefault = false
+
+	// CloudCredentialsModeToken tells cloud-credential-operator to reconcile all CredentialsRequests
+	// by looking to the operator's CredentialsRequest for token information (for instance: STS Enabled)
+	//TODO for demo only, this needs to be added in github.com/openshift/api/operator/v1
+	CloudCredentialsModeToken operatorv1.CloudCredentialsMode = "Token"
 )
 
 func LoadCredsFromSecret(kubeClient client.Client, namespace, secretName string) ([]byte, []byte, error) {
@@ -313,6 +318,8 @@ func ModeToAnnotation(operatorMode operatorv1.CloudCredentialsMode) (string, err
 		return constants.MintAnnotation, nil
 	case operatorv1.CloudCredentialsModePassthrough:
 		return constants.PassthroughAnnotation, nil
+	case CloudCredentialsModeToken:
+		return constants.TokenAnnotation, nil
 	default:
 		return "", fmt.Errorf("no annotation for operator mode: %s", operatorMode)
 	}
@@ -323,7 +330,8 @@ func IsValidMode(operatorMode operatorv1.CloudCredentialsMode) bool {
 	case operatorv1.CloudCredentialsModeDefault,
 		operatorv1.CloudCredentialsModeManual,
 		operatorv1.CloudCredentialsModeMint,
-		operatorv1.CloudCredentialsModePassthrough:
+		operatorv1.CloudCredentialsModePassthrough,
+		CloudCredentialsModeToken:
 		return true
 	default:
 		return false


### PR DESCRIPTION
Based on:
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/4449199/229759393-015e2902-000a-4599-9b65-1550215f9707.png">

Steps for the PoC / Demo:

- Assuming using OpenShift Local (CRC) based on OpenShift 4.12.5
- Follow the steps here to make cluster STS Enabled: https://github.com/openshift/cloud-credential-operator/blob/master/docs/sts.md#steps-to-in-place-migrate-an-openshift-cluster-to-sts
- Note that commit 77385e8 hard codes the platform type to AWS for purposes of the PoC/demo.
- ```kubectl replace -f bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml```
- ```export IMG=quay.io/btofel/cco:latest```
- ```docker build -t $IMG -f Dockerfile.local . && docker push $IMG```
- ```for file in `ls -1 manifests/`; do kubectl apply -f manifests/$file; done``` (which will deploy with the modified `manifests/03-deployment.yaml`
- ```kubectl apply -f cred-reqs/nginx_credentials-request.yaml -n openshift-cloud-credential-operator``` (which will apply a`CredentialsRequest` with the modified fields.

A Secret will be created in the Default Namespace with the needed token. Operator should be able to take advantage of this to access cloud resources. 
