### PR TITLE
[release-4.12] OCPBUGS-11707: ccoctl: Enable public anon read access to default OIDC S3 bucket

### DIFF
--- a/pkg/cmd/provisioning/aws/create_identity_provider_test.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider_test.go
@@ -64,6 +64,8 @@ func TestCreateIdentityProvider(t *testing.T) {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				mockCreateBucketSuccess(mockAWSClient)
 				mockPutBucketTaggingSuccess(mockAWSClient)
+				mockPutPublicAccessBlock(mockAWSClient)
+				mockPutBucketPolicy(mockAWSClient)
 				mockPutObjectSuccess(mockAWSClient)
 				return mockAWSClient
 			},
@@ -80,6 +82,8 @@ func TestCreateIdentityProvider(t *testing.T) {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				mockCreateBucketSuccess(mockAWSClient)
 				mockPutBucketTaggingSuccess(mockAWSClient)
+				mockPutPublicAccessBlock(mockAWSClient)
+				mockPutBucketPolicy(mockAWSClient)
 				mockPutObjectSuccess(mockAWSClient)
 				mockListOpenIDConnectProviders(mockAWSClient)
 				mockCreateOpenIDConnectProvider(mockAWSClient)


### PR DESCRIPTION
Cherry-pick of https://github.com/openshift/cloud-credential-operator/pull/526

* Allow policies to control publicness of S3 bucket.
* Discontinue setting ACL when uploading OIDC discovery and JWKS documents to the S3 bucket.
* Apply a policy that allows anon read to all files in the bucket.