### PR TITLE
Add a make target and stub for actuator e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -149,7 +149,7 @@ test-no-gen: test
 .PHONY: test-no-gen
 
 test-e2e-sts:
-	go test -mod=vendor -race -tags e2e ./pkg/aws/actuator
+	go test -mod=vendor -race -tags e2e ./test/e2e/aws/sts/...
 .PHONY: test-e2e-sts
 
 vet: verify-govet

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,10 @@ install: update-codegen
 test-no-gen: test
 .PHONY: test-no-gen
 
+test-e2e-sts:
+	go test -mod=vendor -race -tags e2e ./pkg/aws/actuator
+.PHONY: test-e2e-sts
+
 vet: verify-govet
 .PHONY: vet
 

--- a/pkg/aws/actuator/actutator_e2e_test.go
+++ b/pkg/aws/actuator/actutator_e2e_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-// Test_CheckSTS runs end-to-end tests to verify the basics of an STS workflow work.
+// Test_CheckSTS runs end-to-end tests to verify that the results of an STS workflow are successful.
 
 func Test_CheckSTS(t *testing.T) {
 	t.Run("test of STS", func(t *testing.T) {

--- a/pkg/aws/actuator/actutator_e2e_test.go
+++ b/pkg/aws/actuator/actutator_e2e_test.go
@@ -1,0 +1,16 @@
+//go:build e2e
+// +build e2e
+
+package actuator
+
+import (
+	"testing"
+)
+
+// Test_CheckSTS runs end-to-end tests to verify the basics of an STS workflow work.
+
+func Test_CheckSTS(t *testing.T) {
+	t.Run("test of STS", func(t *testing.T) {
+		t.Parallel()
+	})
+}

--- a/test/e2e/aws/sts/actutator_e2e_test.go
+++ b/test/e2e/aws/sts/actutator_e2e_test.go
@@ -1,7 +1,7 @@
 //go:build e2e
 // +build e2e
 
-package actuator
+package sts
 
 import (
 	"testing"


### PR DESCRIPTION
This should probably merge before the changes to the release config envisioned in the below linked PR, such that the make target will be available to calling by pj-rehearse:
https://github.com/openshift/release/pull/38624