### PR TITLE
OCPBUGS-15365: *: use a filtered LIST + WATCH on Secrets for AWS STS

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -61,6 +61,7 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/storage/armstorage v1.1.0
 	github.com/Azure/azure-sdk-for-go/sdk/storage/azblob v0.5.1
 	github.com/go-logr/logr v1.2.4
+	github.com/google/go-cmp v0.5.9
 	github.com/microsoft/kiota-authentication-azure-go v0.6.0
 	github.com/microsoftgraph/msgraph-sdk-go v0.59.0
 	github.com/openshift/client-go v0.0.0-20230503144108-75015d2347cb
@@ -96,7 +97,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/google/gofuzz v1.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.1.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect

--- a/manifests/04-cluster-operator.yaml
+++ b/manifests/04-cluster-operator.yaml
@@ -9,3 +9,42 @@ status:
   versions:
   - name: operator
     version: "0.0.1-snapshot"
+  relatedObjects:
+  - group: admissionregistration.k8s.io
+    name: pod-identity-webhook
+    resource: mutatingwebhookconfigurations
+  - group: apps
+    name: pod-identity-webhook
+    namespace: openshift-cloud-credential-operator
+    resource: deployments
+  - group: cloudcredential.openshift.io
+    name: ""
+    resource: credentialsrequests
+  - group: ""
+    name: openshift-cloud-credential-operator
+    resource: namespaces
+  - group: ""
+    name: pod-identity-webhook
+    namespace: openshift-cloud-credential-operator
+    resource: serviceaccounts
+  - group: ""
+    name: pod-identity-webhook
+    namespace: openshift-cloud-credential-operator
+    resource: services
+  - group: operator.openshift.io
+    name: cluster
+    resource: cloudcredentials
+  - group: rbac.authorization.k8s.io
+    name: pod-identity-webhook
+    namespace: openshift-cloud-credential-operator
+    resource: rolebindings
+  - group: rbac.authorization.k8s.io
+    name: pod-identity-webhook
+    namespace: openshift-cloud-credential-operator
+    resource: roles
+  - group: rbac.authorization.k8s.io
+    name: pod-identity-webhook
+    resource: clusterrolebindings
+  - group: rbac.authorization.k8s.io
+    name: pod-identity-webhook
+    resource: clusterroles

--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -27,6 +27,10 @@ const (
 	// credentials in AWS before allowing the CredentialsRequest to be deleted in etcd.
 	FinalizerDeprovision string = "cloudcredential.openshift.io/deprovision"
 
+	// LabelCredentialsRequest is to mark Secrets created as a target of CredentailsRequests.
+	LabelCredentialsRequest      string = "cloudcredential.openshift.io/credentials-request"
+	LabelCredentialsRequestValue string = "true"
+
 	// AnnotationCredentialsRequest is used on Secrets created as a target of CredentailsRequests.
 	// The annotation value will map back to the namespace/name of the CredentialsRequest that created
 	// or adopted the secret.

--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -27,11 +27,11 @@ const (
 	// credentials in AWS before allowing the CredentialsRequest to be deleted in etcd.
 	FinalizerDeprovision string = "cloudcredential.openshift.io/deprovision"
 
-	// LabelCredentialsRequest is to mark Secrets created as a target of CredentailsRequests.
+	// LabelCredentialsRequest is to mark Secrets created as a target of CredentialsRequests.
 	LabelCredentialsRequest      string = "cloudcredential.openshift.io/credentials-request"
 	LabelCredentialsRequestValue string = "true"
 
-	// AnnotationCredentialsRequest is used on Secrets created as a target of CredentailsRequests.
+	// AnnotationCredentialsRequest is used on Secrets created as a target of CredentialsRequests.
 	// The annotation value will map back to the namespace/name of the CredentialsRequest that created
 	// or adopted the secret.
 	AnnotationCredentialsRequest string = "cloudcredential.openshift.io/credentials-request"

--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -458,7 +458,7 @@ func TestSecretFormat(t *testing.T) {
 
 			cr := testCredentialsRequest()
 			logger := a.getLogger(cr)
-			err := a.syncAccessKeySecret(cr, test.accessKeyID, test.secretAccessKey, test.existingSecret, "exampleAWSPolicy", logger)
+			err := a.syncAccessKeySecret(context.Background(), cr, test.accessKeyID, test.secretAccessKey, test.existingSecret, "exampleAWSPolicy", logger)
 
 			require.NoError(t, err, "unexpected error creating/updating Secret")
 

--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -458,7 +458,7 @@ func TestSecretFormat(t *testing.T) {
 
 			cr := testCredentialsRequest()
 			logger := a.getLogger(cr)
-			err := a.syncAccessKeySecret(context.Background(), cr, test.accessKeyID, test.secretAccessKey, test.existingSecret, "exampleAWSPolicy", logger)
+			err := a.syncAccessKeySecret(context.Background(), cr, test.accessKeyID, test.secretAccessKey, "exampleAWSPolicy", logger)
 
 			require.NoError(t, err, "unexpected error creating/updating Secret")
 

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -329,6 +329,9 @@ func copyCredentialsSecret(cr *minterv1.CredentialsRequest, src, dest *corev1.Se
 	dest.ObjectMeta = metav1.ObjectMeta{
 		Name:      cr.Spec.SecretRef.Name,
 		Namespace: cr.Spec.SecretRef.Namespace,
+		Labels: map[string]string{
+			minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
+		},
 		Annotations: map[string]string{
 			minterv1.AnnotationCredentialsRequest: fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 		},

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -31,6 +31,7 @@ import (
 	"github.com/golang/glog"
 	"github.com/google/uuid"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/credentialsrequest"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
@@ -154,7 +155,7 @@ func NewOperator() *cobra.Command {
 					}
 					var missing []types.NamespacedName
 					for _, secret := range secrets.Items {
-						if isMissingSecretLabel(secret) {
+						if credentialsrequest.IsMissingSecretLabel(&secret) {
 							missing = append(missing, types.NamespacedName{
 								Namespace: secret.Namespace,
 								Name:      secret.Name,
@@ -297,15 +298,6 @@ func NewOperator() *cobra.Command {
 	flag.CommandLine.Parse([]string{})
 
 	return cmd
-}
-
-// isMissingSecretLabel determines if the secret was created by the CCO but has not been labelled yet
-func isMissingSecretLabel(secret corev1.Secret) bool {
-	_, hasAnnotation := secret.GetAnnotations()[minterv1.AnnotationCredentialsRequest]
-	value, hasLabel := secret.GetLabels()[minterv1.LabelCredentialsRequest]
-	hasValue := hasLabel && value == minterv1.LabelCredentialsRequestValue
-
-	return hasAnnotation && (!hasLabel || !hasValue)
 }
 
 func initializeGlog(flags *pflag.FlagSet) {

--- a/pkg/kubevirt/actuator.go
+++ b/pkg/kubevirt/actuator.go
@@ -191,6 +191,11 @@ func (a *KubevirtActuator) updateExistingSecret(logger log.FieldLogger, existing
 	// Update the existing secret:
 	logger.Debug("updating secret")
 	origSecret := existingSecret.DeepCopy()
+	if existingSecret.Labels == nil {
+		existingSecret.Labels = map[string]string{}
+	}
+	existingSecret.Labels[minterv1.LabelCredentialsRequest] = minterv1.LabelCredentialsRequestValue
+
 	if existingSecret.Annotations == nil {
 		existingSecret.Annotations = map[string]string{}
 	}
@@ -224,6 +229,9 @@ func (a *KubevirtActuator) createNewSecret(logger log.FieldLogger, cr *minterv1.
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      cr.Spec.SecretRef.Name,
 			Namespace: cr.Spec.SecretRef.Namespace,
+			Labels: map[string]string{
+				minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
+			},
 			Annotations: map[string]string{
 				minterv1.AnnotationCredentialsRequest: fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 			},

--- a/pkg/kubevirt/actuator.go
+++ b/pkg/kubevirt/actuator.go
@@ -37,7 +37,8 @@ import (
 )
 
 type KubevirtActuator struct {
-	Client client.Client
+	Client         client.Client
+	RootCredClient client.Client
 }
 
 func (a *KubevirtActuator) STSFeatureGateEnabled() bool {
@@ -49,9 +50,10 @@ const (
 )
 
 // NewActuator creates a new Kubevirt actuator.
-func NewActuator(client client.Client) (*KubevirtActuator, error) {
+func NewActuator(client, rootCredClient client.Client) (*KubevirtActuator, error) {
 	return &KubevirtActuator{
-		Client: client,
+		Client:         client,
+		RootCredClient: rootCredClient,
 	}, nil
 }
 
@@ -112,7 +114,7 @@ func (a *KubevirtActuator) GetCredentialsRootSecret(ctx context.Context, cr *min
 
 	// get the secret of the kubevirt credentials
 	kubevirtCredentialsSecret := &corev1.Secret{}
-	if err := a.Client.Get(ctx, a.GetCredentialsRootSecretLocation(), kubevirtCredentialsSecret); err != nil {
+	if err := a.RootCredClient.Get(ctx, a.GetCredentialsRootSecretLocation(), kubevirtCredentialsSecret); err != nil {
 		msg := "unable to fetch root cloud cred secret"
 		logger.WithError(err).Error(msg)
 		return nil, &actuatoriface.ActuatorError{
@@ -235,5 +237,5 @@ func (a *KubevirtActuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldL
 }
 
 func (a *KubevirtActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.Client, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -18,12 +18,12 @@ package openstack
 import (
 	"context"
 	"fmt"
-	"reflect"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -114,12 +114,7 @@ func (a *OpenStackActuator) sync(ctx context.Context, cr *minterv1.CredentialsRe
 	}
 
 	logger.Debugf("provisioning secret")
-	existingSecret, err := a.loadExistingSecret(cr)
-	if err != nil {
-		return err
-	}
-
-	err = a.syncCredentialSecret(ctx, cr, clouds, existingSecret, "", logger)
+	err = a.syncCredentialSecret(ctx, cr, clouds, logger)
 	if err != nil {
 		msg := "error creating/updating secret"
 		logger.WithError(err).Error(msg)
@@ -132,100 +127,43 @@ func (a *OpenStackActuator) sync(ctx context.Context, cr *minterv1.CredentialsRe
 	return nil
 }
 
-func (a *OpenStackActuator) syncCredentialSecret(ctx context.Context, cr *minterv1.CredentialsRequest, clouds string, existingSecret *corev1.Secret, userPolicy string, logger log.FieldLogger) error {
+func (a *OpenStackActuator) syncCredentialSecret(ctx context.Context, cr *minterv1.CredentialsRequest, clouds string, logger log.FieldLogger) error {
 	sLog := logger.WithFields(log.Fields{
 		"targetSecret": fmt.Sprintf("%s/%s", cr.Spec.SecretRef.Namespace, cr.Spec.SecretRef.Name),
 		"cr":           fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 	})
-
-	if existingSecret == nil || existingSecret.Name == "" {
-		if clouds == "" {
-			msg := "new access key secret needed but no key data provided"
-			sLog.Error(msg)
-			return &actuatoriface.ActuatorError{
-				ErrReason: minterv1.CredentialsProvisionFailure,
-				Message:   msg,
+	sLog.Infof("processing secret")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.SecretRef.Name,
+			Namespace: cr.Spec.SecretRef.Namespace,
+		},
+	}
+	op, err := controllerutil.CreateOrPatch(ctx, a.Client, secret, func() error {
+		if secret.Labels == nil {
+			secret.Labels = map[string]string{}
+		}
+		secret.Labels[minterv1.LabelCredentialsRequest] = minterv1.LabelCredentialsRequestValue
+		if secret.Annotations == nil {
+			secret.Annotations = map[string]string{}
+		}
+		secret.Annotations[minterv1.AnnotationCredentialsRequest] = fmt.Sprintf("%s/%s", cr.Namespace, cr.Name)
+		if clouds != "" {
+			if secret.Data == nil {
+				secret.Data = map[string][]byte{}
 			}
+			secret.Data[RootOpenStackCredsSecretKey] = []byte(clouds)
 		}
-		sLog.Info("creating secret")
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.Spec.SecretRef.Name,
-				Namespace: cr.Spec.SecretRef.Namespace,
-				Labels: map[string]string{
-					minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
-				},
-				Annotations: map[string]string{
-					minterv1.AnnotationCredentialsRequest: fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
-				},
-			},
-			Data: map[string][]byte{RootOpenStackCredsSecretKey: []byte(clouds)},
-		}
-
-		err := a.Client.Create(ctx, secret)
-		if err != nil {
-			sLog.WithError(err).Error("error creating secret")
-			return err
-		}
-		sLog.Info("secret created successfully")
 		return nil
-	}
-
-	// Update the existing secret:
-	sLog.Debug("updating secret")
-	origSecret := existingSecret.DeepCopy()
-	if existingSecret.Labels == nil {
-		existingSecret.Labels = map[string]string{}
-	}
-	existingSecret.Labels[minterv1.LabelCredentialsRequest] = minterv1.LabelCredentialsRequestValue
-
-	if existingSecret.Annotations == nil {
-		existingSecret.Annotations = map[string]string{}
-	}
-	existingSecret.Annotations[minterv1.AnnotationCredentialsRequest] = fmt.Sprintf("%s/%s", cr.Namespace, cr.Name)
-	if clouds != "" {
-		existingSecret.Data[RootOpenStackCredsSecretKey] = []byte(clouds)
-	}
-
-	if !reflect.DeepEqual(existingSecret, origSecret) {
-		sLog.Info("target secret has changed, updating")
-		err := a.Client.Update(ctx, existingSecret)
-		if err != nil {
-			msg := "error updating secret"
-			sLog.WithError(err).Error(msg)
-			return &actuatoriface.ActuatorError{
-				ErrReason: minterv1.CredentialsProvisionFailure,
-				Message:   msg,
-			}
-		}
-	} else {
-		sLog.Debug("target secret unchanged")
-	}
-
-	return nil
-}
-
-func (a *OpenStackActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) (*corev1.Secret, error) {
-	logger := a.getLogger(cr)
-
-	// Check if the credentials secret exists, if not we need to inform the syncer to generate a new one:
-	existingSecret := &corev1.Secret{}
-	err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: cr.Spec.SecretRef.Namespace, Name: cr.Spec.SecretRef.Name}, existingSecret)
+	})
+	sLog.WithField("operation", op).Info("processed secret")
 	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Debug("secret does not exist")
-		} else {
-			return nil, err
+		return &actuatoriface.ActuatorError{
+			ErrReason: minterv1.CredentialsProvisionFailure,
+			Message:   "error processing secret",
 		}
 	}
-
-	if _, ok := existingSecret.Data[RootOpenStackCredsSecretKey]; !ok {
-		logger.Warning("secret did not have expected key: " + RootOpenStackCredsSecretKey)
-	} else {
-		logger.Debug("found clouds.yaml in existing secret")
-	}
-
-	return existingSecret, nil
+	return nil
 }
 
 // GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.

--- a/pkg/operator/awspodidentity/awspodidentitywebhook_controller.go
+++ b/pkg/operator/awspodidentity/awspodidentitywebhook_controller.go
@@ -128,7 +128,7 @@ func (c *awsPodIdentityController) Start(ctx context.Context) error {
 	return nil
 }
 
-func Add(mgr manager.Manager, kubeconfig string) error {
+func Add(mgr, rootCredentialManager manager.Manager, kubeconfig string) error {
 	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(kubeconfig)
 	if err != nil {
 		return err

--- a/pkg/operator/awspodidentity/awspodidentitywebhook_controller.go
+++ b/pkg/operator/awspodidentity/awspodidentitywebhook_controller.go
@@ -129,7 +129,7 @@ func (c *awsPodIdentityController) Start(ctx context.Context) error {
 }
 
 func Add(mgr manager.Manager, kubeconfig string) error {
-	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(mgr, kubeconfig)
+	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(kubeconfig)
 	if err != nil {
 		return err
 	}

--- a/pkg/operator/cleanup/cleanup_controller.go
+++ b/pkg/operator/cleanup/cleanup_controller.go
@@ -44,7 +44,7 @@ func newReconciler(mgr manager.Manager) reconcile.Reconciler {
 }
 
 // Add creates a new Cleanup Controller and adds it to the Manager.
-func Add(mgr manager.Manager, kubeConfig string) error {
+func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 	r := newReconciler(mgr)
 
 	// Create a new controller

--- a/pkg/operator/controller.go
+++ b/pkg/operator/controller.go
@@ -59,7 +59,7 @@ func init() {
 
 // AddToManagerFuncs is a list of functions to add all Controllers to the Manager.
 // String parameter is to pass in any specific override for the kubeconfig file to use.
-var AddToManagerFuncs []func(manager.Manager, string) error
+var AddToManagerFuncs []func(manager.Manager, manager.Manager, string) error
 
 // AddToManagerWithActuatorFuncs is a list of functions to add all Controllers with Actuators to the Manager
 var AddToManagerWithActuatorFuncs []func(manager.Manager, manager.Manager, actuator.Actuator, configv1.PlatformType, corev1client.CoreV1Interface) error
@@ -67,7 +67,7 @@ var AddToManagerWithActuatorFuncs []func(manager.Manager, manager.Manager, actua
 // AddToManager adds all Controllers to the Manager
 func AddToManager(m, rootM manager.Manager, explicitKubeconfig string, coreClient corev1client.CoreV1Interface, awsSecurityTokenServiceGateEnabled bool) error {
 	for _, f := range AddToManagerFuncs {
-		if err := f(m, explicitKubeconfig); err != nil {
+		if err := f(m, rootM, explicitKubeconfig); err != nil {
 			return err
 		}
 	}

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -381,7 +381,7 @@ func IsMissingSecretLabel(secret metav1.Object) bool {
 
 type ReconcileSecretMissingLabel struct {
 	cachedClient   client.Client
-	mutatingClient corev1client.CoreV1Interface
+	mutatingClient corev1client.SecretsGetter
 }
 
 func (r *ReconcileSecretMissingLabel) GetConditions(logger log.FieldLogger) ([]configv1.ClusterOperatorStatusCondition, error) {

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
+	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -54,7 +55,8 @@ import (
 )
 
 const (
-	controllerName = "credreq"
+	controllerName      = "credreq"
+	labelControllerName = controllerName + "_labeller"
 
 	namespaceMissing = "NamespaceMissing"
 	namespaceExists  = "NamespaceExists"
@@ -84,8 +86,8 @@ var (
 // AddWithActuator creates a new CredentialsRequest Controller and adds it to the Manager with
 // default RBAC. The Manager will set fields on the Controller and Start it when
 // the Manager is Started.
-func AddWithActuator(mgr manager.Manager, actuator actuator.Actuator, platType configv1.PlatformType) error {
-	return add(mgr, newReconciler(mgr, actuator, platType))
+func AddWithActuator(mgr manager.Manager, actuator actuator.Actuator, platType configv1.PlatformType, mutatingClient corev1client.CoreV1Interface) error {
+	return add(mgr, newReconciler(mgr, actuator, platType), mutatingClient)
 }
 
 // newReconciler returns a new reconcile.Reconciler
@@ -101,7 +103,7 @@ func newReconciler(mgr manager.Manager, actuator actuator.Actuator, platType con
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler
-func add(mgr manager.Manager, r reconcile.Reconciler) error {
+func add(mgr manager.Manager, r reconcile.Reconciler, mutatingClient corev1client.CoreV1Interface) error {
 	operatorCache := mgr.GetCache()
 	name := "credentialsrequest_controller"
 

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -211,13 +211,13 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 
 	adminCredSecretPredicate := predicate.Funcs{
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return isAdminCredSecret(e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
+			return IsAdminCredSecret(e.ObjectNew.GetNamespace(), e.ObjectNew.GetName())
 		},
 		CreateFunc: func(e event.CreateEvent) bool {
-			return isAdminCredSecret(e.Object.GetNamespace(), e.Object.GetName())
+			return IsAdminCredSecret(e.Object.GetNamespace(), e.Object.GetName())
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return isAdminCredSecret(e.Object.GetNamespace(), e.Object.GetName())
+			return IsAdminCredSecret(e.Object.GetNamespace(), e.Object.GetName())
 		},
 	}
 	// Watch Secrets and reconcile if we see an event for an admin credential secret in kube-system.
@@ -463,7 +463,7 @@ func isCloudCredOperatorConfigMap(cm metav1.Object) bool {
 	return cm.GetName() == constants.CloudCredOperatorConfigMap && cm.GetNamespace() == minterv1.CloudCredOperatorNamespace
 }
 
-func isAdminCredSecret(namespace, secretName string) bool {
+func IsAdminCredSecret(namespace, secretName string) bool {
 	if namespace == constants.CloudCredSecretNamespace {
 		if secretName == constants.AWSCloudCredSecretName ||
 			secretName == constants.AzureCloudCredSecretName ||

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -24,6 +24,7 @@ import (
 
 	log "github.com/sirupsen/logrus"
 	"golang.org/x/time/rate"
+	corev1applyconfigurations "k8s.io/client-go/applyconfigurations/core/v1"
 	corev1client "k8s.io/client-go/kubernetes/typed/core/v1"
 
 	corev1 "k8s.io/api/core/v1"
@@ -315,7 +316,107 @@ func add(mgr manager.Manager, r reconcile.Reconciler, mutatingClient corev1clien
 		return err
 	}
 
+	labelControllerName := "credentialsrequest_labeller_controller"
+	labelController, err := controller.New(labelControllerName, mgr, controller.Options{
+		Reconciler: &ReconcileSecretMissingLabel{
+			cachedClient:   mgr.GetClient(),
+			mutatingClient: mutatingClient,
+		},
+	})
+	if err != nil {
+		return err
+	}
+
+	missingLabelSecretsMapFn := handler.EnqueueRequestsFromMapFunc(func(_ context.Context, a client.Object) []reconcile.Request {
+		return []reconcile.Request{
+			{
+				NamespacedName: types.NamespacedName{
+					Name:      a.GetName(),
+					Namespace: a.GetNamespace(),
+				},
+			},
+		}
+	})
+
+	missingLabelCredSecretPredicate := predicate.Funcs{
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return IsMissingSecretLabel(e.ObjectNew)
+		},
+		CreateFunc: func(e event.CreateEvent) bool {
+			return IsMissingSecretLabel(e.Object)
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return IsMissingSecretLabel(e.Object)
+		},
+	}
+	// Watch Secrets and reconcile if we see an event for an admin credential secret in kube-system.
+	err = labelController.Watch(
+		source.Kind(operatorCache, &corev1.Secret{}),
+		missingLabelSecretsMapFn,
+		missingLabelCredSecretPredicate)
+	if err != nil {
+		return err
+	}
+
 	return nil
+}
+
+// IsMissingSecretLabel determines if the secret was createded by the CCO but has not been labelled yet
+func IsMissingSecretLabel(secret metav1.Object) bool {
+	isAdmin := isAdminCredSecret(secret.GetNamespace(), secret.GetName())
+	_, hasAnnotation := secret.GetAnnotations()[minterv1.AnnotationCredentialsRequest]
+	value, hasLabel := secret.GetLabels()[minterv1.LabelCredentialsRequest]
+	hasValue := hasLabel && value == minterv1.LabelCredentialsRequestValue
+
+	return (isAdmin || hasAnnotation) && (!hasLabel || !hasValue)
+}
+
+type ReconcileSecretMissingLabel struct {
+	cachedClient   client.Client
+	mutatingClient corev1client.CoreV1Interface
+}
+
+var _ reconcile.Reconciler = &ReconcileSecretMissingLabel{}
+
+func (r *ReconcileSecretMissingLabel) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	start := time.Now()
+
+	logger := log.WithFields(log.Fields{
+		"controller": labelControllerName,
+		"secret":     fmt.Sprintf("%s/%s", request.NamespacedName.Namespace, request.NamespacedName.Name),
+	})
+
+	defer func() {
+		dur := time.Since(start)
+		metrics.MetricControllerReconcileTime.WithLabelValues(labelControllerName).Observe(dur.Seconds())
+	}()
+
+	logger.Info("syncing secret")
+	secret := &corev1.Secret{}
+	err := r.cachedClient.Get(ctx, request.NamespacedName, secret)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			logger.Debug("secret no longer exists")
+			return reconcile.Result{}, nil
+		}
+		logger.WithError(err).Error("error getting secret, requeuing")
+		return reconcile.Result{}, err
+	}
+
+	applyConfig := corev1applyconfigurations.Secret(secret.Name, secret.Namespace)
+	applyConfig.WithLabels(map[string]string{
+		minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
+	})
+
+	if _, err := r.mutatingClient.Secrets(secret.Namespace).Apply(ctx, applyConfig, metav1.ApplyOptions{
+		Force:        true, // we're the authoritative owner of this field and should not allow anyone to stomp it
+		FieldManager: labelControllerName,
+	}); err != nil {
+		logger.WithError(err).Error("failed to update label")
+		return reconcile.Result{}, err
+	}
+
+	return reconcile.Result{}, nil
 }
 
 // isCloudCredOperatorConfigMap returns true if given configmap is cloud-credential-operator-config configmap

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_azure_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_azure_test.go
@@ -102,7 +102,6 @@ func TestCredentialsRequestAzureReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
-				testAzureCredsSecret(constants.CloudCredSecretNamespace, constants.AzureCloudCredSecretName),
 				testAzureCredentialsRequest(t),
 			},
 			mockAzureAppClient: func(mockCtrl *gomock.Controller) *mockazure.MockAppClient {
@@ -127,7 +126,6 @@ func TestCredentialsRequestAzureReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
-				testAzureCredsSecret(constants.CloudCredSecretNamespace, constants.AzureCloudCredSecretName),
 				testAzureCredentialsRequestNeedingCleanup(t),
 				testAzureTargetSecret(testSecretNamespace, testSecretName, "mintedAzureClientID"),
 			},
@@ -165,7 +163,6 @@ func TestCredentialsRequestAzureReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
-				testAzureCredsSecret(constants.CloudCredSecretNamespace, constants.AzureCloudCredSecretName),
 				testAzureCredentialsRequestWithOrphanedCloudResource(t),
 				testAzureTargetSecret(testSecretNamespace, testSecretName, testAzureClientID),
 			},
@@ -212,9 +209,12 @@ func TestCredentialsRequestAzureReconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithStatusSubresource(&minterv1.CredentialsRequest{}).
 				WithRuntimeObjects(test.existing...).Build()
+			fakeAdminClient := fake.NewClientBuilder().
+				WithRuntimeObjects(testAzureCredsSecret(constants.CloudCredSecretNamespace, constants.AzureCloudCredSecretName)).Build()
 
 			azureActuator := azureactuator.NewFakeActuator(
 				fakeClient,
+				fakeAdminClient,
 				codec,
 				func(logger log.FieldLogger, clientID, clientSecret, tenantID, subscriptionID string) (*azureactuator.AzureCredentialsMinter, error) {
 					return azureactuator.NewFakeAzureCredentialsMinter(logger,

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	cloudresourcemanager "google.golang.org/api/cloudresourcemanager/v1"
+	"google.golang.org/api/cloudresourcemanager/v1"
 	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -102,6 +102,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 	tests := []struct {
 		name              string
 		existing          []runtime.Object
+		existingAdmin     []runtime.Object
 		expectErr         bool
 		mockRootGCPClient func(mockCtrl *gomock.Controller) *mockgcp.MockClient
 		mockReadGCPClient func(mockCtrl *gomock.Controller) *mockgcp.MockClient
@@ -117,10 +118,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredentialsRequest(t),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -158,10 +161,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredentialsRequestWithPermissions(t),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -204,9 +209,11 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequest(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(""),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -248,6 +255,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
 				return mockGCPClient
@@ -279,6 +287,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				// only the read-only creds exist
 				testGCPCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-gcp-ro-creds", testReadOnlyGCPAuth),
 			},
+			existingAdmin: []runtime.Object{},
 			mockReadGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
 
@@ -318,9 +327,11 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequest(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -358,10 +369,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequest(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredsSecret(testSecretNamespace, testSecretName, testServiceAccountKeyPrivateData),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -404,6 +417,9 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testGCPCredsSecret(testSecretNamespace, testSecretName, testServiceAccountKeyPrivateData),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -470,6 +486,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				// only the read-only creds exist
 				testGCPCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-gcp-ro-creds", testReadOnlyGCPAuth),
 			},
+			existingAdmin: []runtime.Object{},
 			mockReadGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
 
@@ -514,6 +531,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				// only the read-only creds exist
 				testGCPCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-gcp-ro-creds", testReadOnlyGCPAuth),
 			},
+			existingAdmin: []runtime.Object{},
 			mockReadGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
 
@@ -586,7 +604,8 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				// target secret exists
 				createTestNamespace(testSecretNamespace),
 				testGCPCredsSecret(testSecretNamespace, testSecretName, `{"private_key_id": "testGCPKeyName"}`),
-
+			},
+			existingAdmin: []runtime.Object{
 				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
@@ -629,10 +648,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequestWithDeletionTimestamp(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredsSecret(testSecretNamespace, testSecretName, testServiceAccountKeyPrivateData),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -656,10 +677,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequestWithPermissionsWithDeletionTimestamp(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredsSecret(testSecretNamespace, testSecretName, testServiceAccountKeyPrivateData),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -683,9 +706,11 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequest(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -717,9 +742,11 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequestWithDeletionTimestamp(t),
-				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecret("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -743,9 +770,11 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequest(t),
-				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -777,9 +806,11 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testGCPCredentialsRequest(t),
-				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -814,10 +845,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testGCPPassthroughCredentialsRequest(t),
-				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredsSecret(testSecretNamespace, testSecretName, testRootGCPAuth),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -846,10 +879,12 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testGCPPassthroughCredentialsRequest(t),
-				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 				testGCPCredsSecret(testSecretNamespace, testSecretName, testOldPassthroughPrivateData),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testGCPCredsSecretPassthrough("kube-system", constants.GCPCloudCredSecretName, testRootGCPAuth),
 			},
 			mockRootGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
@@ -898,11 +933,15 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithStatusSubresource(&minterv1.CredentialsRequest{}).
 				WithRuntimeObjects(test.existing...).Build()
+			fakeAdminClient := fake.NewClientBuilder().
+				WithRuntimeObjects(test.existingAdmin...).Build()
 			rcr := &ReconcileCredentialsRequest{
-				Client: fakeClient,
+				Client:      fakeClient,
+				AdminClient: fakeAdminClient,
 				Actuator: &actuator.Actuator{
-					Client: fakeClient,
-					Codec:  codec,
+					Client:         fakeClient,
+					RootCredClient: fakeAdminClient,
+					Codec:          codec,
 					GCPClientBuilder: func(name string, jsonAUTH []byte) (mintergcp.Client, error) {
 						if string(jsonAUTH) == testRootGCPAuth {
 							return mockRootGCPClient, nil

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_label_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_label_test.go
@@ -1,0 +1,260 @@
+/*
+Copyright 2023 The OpenShift Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package credentialsrequest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	configv1 "github.com/openshift/api/config/v1"
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/sirupsen/logrus"
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	clientgofake "k8s.io/client-go/kubernetes/fake"
+	clientgotesting "k8s.io/client-go/testing"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+func TestReconcileSecretMissingLabel_Reconcile(t *testing.T) {
+	// we unconditionally send the SSA request, since it's easy and trivial to make the logic correct.
+	// the server determines if a mutation needs to occur. so, we expect the patch to be sent in every case
+	tests := []struct {
+		name      string
+		existing  []runtime.Object
+		expectErr bool
+		expected  []*clientgotesting.PatchActionImpl
+	}{
+		{
+			name: "already labeled, nothing to do",
+			existing: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testSecretNamespace,
+						Annotations: map[string]string{
+							minterv1.AnnotationCredentialsRequest: "whatever",
+						},
+						Labels: map[string]string{
+							minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
+						},
+					},
+				},
+			},
+			expectErr: false,
+			expected: []*clientgotesting.PatchActionImpl{{
+				PatchType:  types.ApplyPatchType,
+				ActionImpl: clientgotesting.ActionImpl{Namespace: "myproject", Verb: "patch", Resource: corev1.SchemeGroupVersion.WithResource("secrets")},
+				Name:       "test-secret",
+				Patch:      []uint8(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test-secret","namespace":"myproject","labels":{"cloudcredential.openshift.io/credentials-request":"true"}}}`),
+			}},
+		},
+		{
+			name: "no label, but no annotation, so nothing to do",
+			existing: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testSecretNamespace,
+					},
+				},
+			},
+			expectErr: false,
+			expected: []*clientgotesting.PatchActionImpl{{
+				PatchType:  types.ApplyPatchType,
+				ActionImpl: clientgotesting.ActionImpl{Namespace: "myproject", Verb: "patch", Resource: corev1.SchemeGroupVersion.WithResource("secrets")},
+				Name:       "test-secret",
+				Patch:      []uint8(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test-secret","namespace":"myproject","labels":{"cloudcredential.openshift.io/credentials-request":"true"}}}`),
+			}},
+		},
+		{
+			name: "annotation but missing label, should be labeled",
+			existing: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testSecretNamespace,
+						Annotations: map[string]string{
+							minterv1.AnnotationCredentialsRequest: "whatever",
+						},
+					},
+				},
+			},
+			expectErr: false,
+			expected: []*clientgotesting.PatchActionImpl{{
+				PatchType:  types.ApplyPatchType,
+				ActionImpl: clientgotesting.ActionImpl{Namespace: "myproject", Verb: "patch", Resource: corev1.SchemeGroupVersion.WithResource("secrets")},
+				Name:       "test-secret",
+				Patch:      []uint8(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test-secret","namespace":"myproject","labels":{"cloudcredential.openshift.io/credentials-request":"true"}}}`),
+			}},
+		},
+		{
+			name: "annotation but bad label value, should be labeled",
+			existing: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testSecretNamespace,
+						Annotations: map[string]string{
+							minterv1.AnnotationCredentialsRequest: "whatever",
+						},
+						Labels: map[string]string{
+							minterv1.LabelCredentialsRequest: "wrong",
+						},
+					},
+				},
+			},
+			expectErr: false,
+			expected: []*clientgotesting.PatchActionImpl{{
+				PatchType:  types.ApplyPatchType,
+				ActionImpl: clientgotesting.ActionImpl{Namespace: "myproject", Verb: "patch", Resource: corev1.SchemeGroupVersion.WithResource("secrets")},
+				Name:       "test-secret",
+				Patch:      []uint8(`{"kind":"Secret","apiVersion":"v1","metadata":{"name":"test-secret","namespace":"myproject","labels":{"cloudcredential.openshift.io/credentials-request":"true"}}}`),
+			}},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithRuntimeObjects(test.existing...).Build()
+
+			var actions []*clientgotesting.PatchActionImpl
+			fakeMutatingClient := clientgofake.NewSimpleClientset(test.existing...)
+			fakeMutatingClient.PrependReactor("*", "secrets", func(action clientgotesting.Action) (handled bool, ret runtime.Object, err error) {
+				impl, ok := action.(clientgotesting.PatchActionImpl)
+				if !ok {
+					return false, nil, nil
+				}
+				actions = append(actions, &impl)
+				return false, nil, nil
+			})
+
+			rcr := ReconcileSecretMissingLabel{
+				cachedClient:   fakeClient,
+				mutatingClient: fakeMutatingClient.CoreV1(),
+			}
+
+			_, err := rcr.Reconcile(context.TODO(), reconcile.Request{
+				NamespacedName: types.NamespacedName{
+					Name:      testSecretName,
+					Namespace: testSecretNamespace,
+				},
+			})
+
+			if err != nil && !test.expectErr {
+				require.NoError(t, err, "Unexpected error: %v", err)
+			}
+			if err == nil && test.expectErr {
+				t.Errorf("Expected error but got none")
+			}
+
+			if diff := cmp.Diff(actions, test.expected); diff != "" {
+				t.Errorf("incorrect actions: %v", diff)
+			}
+		})
+	}
+}
+
+func TestReconcileSecretMissingLabel_GetConditions(t *testing.T) {
+	tests := []struct {
+		name      string
+		existing  []runtime.Object
+		expectErr bool
+		// Expected conditions on the credentials cluster operator:
+		expectedCOConditions []configv1.ClusterOperatorStatusCondition
+	}{
+		{
+			name:                 "no secrets, no condition",
+			existing:             []runtime.Object{},
+			expectErr:            false,
+			expectedCOConditions: []configv1.ClusterOperatorStatusCondition{},
+		},
+		{
+			name: "no secrets missing labels, no condition",
+			existing: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testSecretNamespace,
+						Annotations: map[string]string{
+							minterv1.AnnotationCredentialsRequest: "whatever",
+						},
+						Labels: map[string]string{
+							minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
+						},
+					},
+				},
+			},
+			expectErr:            false,
+			expectedCOConditions: []configv1.ClusterOperatorStatusCondition{},
+		},
+		{
+			name: "secrets missing labels, progressing condition",
+			existing: []runtime.Object{
+				&corev1.Secret{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      testSecretName,
+						Namespace: testSecretNamespace,
+						Annotations: map[string]string{
+							minterv1.AnnotationCredentialsRequest: "whatever",
+						},
+					},
+				},
+			},
+			expectErr: false,
+			expectedCOConditions: []configv1.ClusterOperatorStatusCondition{
+				{
+					Type:    configv1.OperatorProgressing,
+					Status:  configv1.ConditionTrue,
+					Reason:  "LabelsMissing",
+					Message: "1 secrets created for CredentialsRequests have not been labelled",
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			fakeClient := fake.NewClientBuilder().
+				WithRuntimeObjects(test.existing...).Build()
+
+			rcr := ReconcileSecretMissingLabel{
+				cachedClient:   fakeClient,
+				mutatingClient: nil,
+			}
+
+			conditions, err := rcr.GetConditions(logrus.StandardLogger())
+
+			if err != nil && !test.expectErr {
+				require.NoError(t, err, "Unexpected error: %v", err)
+			}
+			if err == nil && test.expectErr {
+				t.Errorf("Expected error but got none")
+			}
+
+			if diff := cmp.Diff(conditions, test.expectedCOConditions); diff != "" {
+				t.Errorf("incorrect conditions: %v", diff)
+			}
+		})
+	}
+}

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -109,6 +109,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 	tests := []struct {
 		name                string
 		existing            []runtime.Object
+		existingAdmin       []runtime.Object
 		expectErr           bool
 		mockRootAWSClient   func(mockCtrl *gomock.Controller) *mockaws.MockClient
 		mockReadAWSClient   func(mockCtrl *gomock.Controller) *mockaws.MockClient
@@ -131,8 +132,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 					cr.ObjectMeta.Finalizers = []string{}
 					return cr
 				}(),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -153,10 +156,12 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -194,10 +199,12 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(""),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -236,9 +243,11 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -275,6 +284,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -308,11 +318,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -343,11 +355,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -388,6 +402,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -418,9 +433,11 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -455,11 +472,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -493,11 +512,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testProvisionedCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -534,11 +555,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testLegacyAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -569,11 +592,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequestWithDeletionTimestamp(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -596,8 +621,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testPassthroughCredentialsRequest(t),
-				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
+			},
+			existingAdmin: []runtime.Object{
+				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -626,8 +653,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testPassthroughCredentialsRequest(t),
-				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
+			},
+			existingAdmin: []runtime.Object{
+				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -657,9 +686,11 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testPassthroughCredentialsRequestWithLastSyncResourceVersion(t, "12345"),
-				testPassthroughAWSCredsSecretWithResourceVersion("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey, "12345"),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
+			},
+			existingAdmin: []runtime.Object{
+				testPassthroughAWSCredsSecretWithResourceVersion("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey, "12345"),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -687,9 +718,11 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testPassthroughCredentialsRequestWithLastSyncResourceVersion(t, "0001"),
-				testPassthroughAWSCredsSecretWithResourceVersion("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey, "0002"),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
+			},
+			existingAdmin: []runtime.Object{
+				testPassthroughAWSCredsSecretWithResourceVersion("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey, "0002"),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -718,9 +751,11 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testPassthroughCredentialsRequest(t),
-				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
+			},
+			existingAdmin: []runtime.Object{
+				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -745,10 +780,13 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testPassthroughCredentialsRequestWithDeletionTimestamp(t),
-				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
+			existingAdmin: []runtime.Object{
+				testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
+			},
+
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -761,6 +799,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				testCredentialsRequest(t),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -780,6 +819,8 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
+			},
+			existingAdmin: []runtime.Object{
 				testInsufficientAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
@@ -806,6 +847,9 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testClusterVersion(),
 			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
+			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -831,10 +875,12 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testSecretNamespace),
 				testInfrastructure(testInfraName),
 				testCredentialsRequestWithDeletionTimestamp(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testAWSCredsSecret(testNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
 				testClusterVersion(),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -879,9 +925,11 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				testInfrastructure(testInfraName),
 				testClusterVersion(),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequestWithRecentLastSync(t),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -914,12 +962,16 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				cr.Generation = cr.Generation + 1 // rev the generation to trigger the sync
 				objects = append(objects, cr)
 
-				objects = append(objects, testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey))
 				objects = append(objects, testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey))
 				objects = append(objects, testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey))
 				objects = append(objects, testClusterVersion())
 				objects = append(objects, testInfrastructure(testInfraName))
 
+				return objects
+			}(),
+			existingAdmin: func() []runtime.Object {
+				objects := []runtime.Object{}
+				objects = append(objects, testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey))
 				return objects
 			}(),
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
@@ -944,6 +996,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				testGCPCredentialsRequest(t),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				return mockaws.NewMockClient(mockCtrl)
 			},
@@ -975,6 +1028,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 					return cr
 				}(),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				return mockaws.NewMockClient(mockCtrl)
 			},
@@ -996,10 +1050,12 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testCredentialsRequest(t),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -1042,6 +1098,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -1061,6 +1118,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -1081,6 +1139,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testClusterVersion(),
 				testInfrastructure(testInfraName),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -1105,8 +1164,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testClusterVersion(),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -1136,8 +1197,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testClusterVersion(),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -1188,8 +1251,10 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testInfrastructure(testInfraName),
 				createTestNamespace(testSecretNamespace),
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
-				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 				testClusterVersion(),
+			},
+			existingAdmin: []runtime.Object{
+				testAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey),
 			},
 			mockReadAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
@@ -1271,6 +1336,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey),
 				testClusterVersion(),
 			},
+			existingAdmin: []runtime.Object{},
 			mockReadAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				// Just mock up GetUser that doesn't fail for the read-only account test
@@ -1301,6 +1367,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 			existing: []runtime.Object{
 				testCredentialsRequest(t),
 			},
+			existingAdmin: []runtime.Object{},
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
 				mockAWSClient := mockaws.NewMockClient(mockCtrl)
 				return mockAWSClient
@@ -1320,14 +1387,18 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				cr.Status.LastSyncCloudCredsSecretResourceVersion = "1" // resource version of root creds before update
 				objects = append(objects, cr)
 
-				credentialsRootSecret := testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey)
-				credentialsRootSecret.ResourceVersion = testCredRootSecretResourceVersion // resource version of root creds after update
-				objects = append(objects, credentialsRootSecret)
 				objects = append(objects, testAWSCredsSecret("openshift-cloud-credential-operator", "cloud-credential-operator-iam-ro-creds", testReadAWSAccessKeyID, testReadAWSSecretAccessKey))
 				objects = append(objects, testAWSCredsSecret(testSecretNamespace, testSecretName, testAWSAccessKeyID, testAWSSecretAccessKey))
 				objects = append(objects, testClusterVersion())
 				objects = append(objects, testInfrastructure(testInfraName))
 
+				return objects
+			}(),
+			existingAdmin: func() []runtime.Object {
+				objects := []runtime.Object{}
+				credentialsRootSecret := testPassthroughAWSCredsSecret("kube-system", "aws-creds", testRootAWSAccessKeyID, testRootAWSSecretAccessKey)
+				credentialsRootSecret.ResourceVersion = testCredRootSecretResourceVersion // resource version of root creds after update
+				objects = append(objects, credentialsRootSecret)
 				return objects
 			}(),
 			mockRootAWSClient: func(mockCtrl *gomock.Controller) *mockaws.MockClient {
@@ -1377,12 +1448,16 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithStatusSubresource(&minterv1.CredentialsRequest{}).
 				WithRuntimeObjects(test.existing...).Build()
+			fakeAdminClient := fake.NewClientBuilder().
+				WithRuntimeObjects(test.existingAdmin...).Build()
 			rcr := &ReconcileCredentialsRequest{
-				Client: fakeClient,
+				Client:      fakeClient,
+				AdminClient: fakeAdminClient,
 				Actuator: &actuator.AWSActuator{
-					Client: fakeClient,
-					Codec:  codec,
-					Scheme: scheme.Scheme,
+					Client:         fakeClient,
+					RootCredClient: fakeAdminClient,
+					Codec:          codec,
+					Scheme:         scheme.Scheme,
 					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, c client.Client) (minteraws.Client, error) {
 						if string(accessKeyID) == testRootAWSAccessKeyID {
 							return mockRootAWSClient, nil

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
@@ -67,10 +67,11 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 	}
 
 	tests := []struct {
-		name      string
-		existing  []runtime.Object
-		expectErr bool
-		validate  func(client.Client, *testing.T)
+		name          string
+		existing      []runtime.Object
+		existingAdmin []runtime.Object
+		expectErr     bool
+		validate      func(client.Client, *testing.T)
 		// Expected conditions on the credentials request:
 		expectedConditions []ExpectedCondition
 		// Expected conditions on the credentials cluster operator:
@@ -82,8 +83,10 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
-				testVSphereCredsSecretPassthrough(),
 				testVSphereCredentialsRequest(t),
+			},
+			existingAdmin: []runtime.Object{
+				testVSphereCredsSecretPassthrough(),
 			},
 			validate: func(c client.Client, t *testing.T) {
 				targetSecret := getCredRequestTargetSecret(c)
@@ -104,7 +107,8 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				createTestNamespace(testSecretNamespace),
 				testVSphereCredentialsRequest(t),
 			},
-			expectErr: true,
+			existingAdmin: []runtime.Object{},
+			expectErr:     true,
 			validate: func(c client.Client, t *testing.T) {
 				targetSecret := getCredRequestTargetSecret(c)
 				assert.Nil(t, targetSecret)
@@ -125,8 +129,10 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				createTestNamespace(testNamespace),
 				createTestNamespace(testSecretNamespace),
 				testVSphereCredentialsRequestWithDeletionTimestamp(t),
-				testVSphereCredsSecretPassthrough(),
 				testSecret(testSecretNamespace, testSecretName, testVSphereCloudCredsSecretData),
+			},
+			existingAdmin: []runtime.Object{
+				testVSphereCredsSecretPassthrough(),
 			},
 			validate: func(c client.Client, t *testing.T) {
 				targetSecret := getCredRequestTargetSecret(c)
@@ -139,8 +145,10 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testVSphereCredentialsRequest(t),
-				testVSphereCredsSecretPassthrough(),
 				testSecret(testSecretNamespace, testSecretName, testVSphereCloudCredsSecretData),
+			},
+			existingAdmin: []runtime.Object{
+				testVSphereCredsSecretPassthrough(),
 			},
 			validate: func(c client.Client, t *testing.T) {
 				targetSecret := getCredRequestTargetSecret(c)
@@ -159,8 +167,10 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				createTestNamespace(testSecretNamespace),
 				testVSphereCredentialsRequest(t),
-				testVSphereCredsSecretPassthrough(),
 				testSecret(testSecretNamespace, testSecretName, map[string][]byte{"key1": []byte("olddata")}),
+			},
+			existingAdmin: []runtime.Object{
+				testVSphereCredsSecretPassthrough(),
 			},
 			validate: func(c client.Client, t *testing.T) {
 				targetSecret := getCredRequestTargetSecret(c)
@@ -184,11 +194,15 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 			fakeClient := fake.NewClientBuilder().
 				WithStatusSubresource(&minterv1.CredentialsRequest{}).
 				WithRuntimeObjects(test.existing...).Build()
+			fakeAdminClient := fake.NewClientBuilder().
+				WithRuntimeObjects(test.existingAdmin...).Build()
 			rcr := &ReconcileCredentialsRequest{
-				Client: fakeClient,
+				Client:      fakeClient,
+				AdminClient: fakeAdminClient,
 				Actuator: &actuator.VSphereActuator{
-					Client: fakeClient,
-					Codec:  codec,
+					Client:         fakeClient,
+					RootCredClient: fakeAdminClient,
+					Codec:          codec,
 				},
 				platformType: configv1.VSpherePlatformType,
 			}

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
@@ -160,7 +160,7 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				createTestNamespace(testSecretNamespace),
 				testVSphereCredentialsRequest(t),
 				testVSphereCredsSecretPassthrough(),
-				testSecret(testSecretNamespace, testSecretName, map[string][]byte{"oldkey": []byte("olddata")}),
+				testSecret(testSecretNamespace, testSecretName, map[string][]byte{"key1": []byte("olddata")}),
 			},
 			validate: func(c client.Client, t *testing.T) {
 				targetSecret := getCredRequestTargetSecret(c)

--- a/pkg/operator/loglevel/controller.go
+++ b/pkg/operator/loglevel/controller.go
@@ -41,7 +41,7 @@ const (
 )
 
 // Add creates a new ConfigController and adds it to the Manager.
-func Add(mgr manager.Manager, kubeConfig string) error {
+func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 	r := newReconciler(mgr)
 
 	// Create a new controller

--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -70,7 +70,7 @@ func init() {
 }
 
 // Add creates a new metrics Calculator and adds it to the Manager.
-func Add(mgr manager.Manager, kubeConfig string) error {
+func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 	logger := log.WithField("controller", controllerName)
 
 	mc := &Calculator{

--- a/pkg/operator/platform/platform.go
+++ b/pkg/operator/platform/platform.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
+	"github.com/openshift/cloud-credential-operator/pkg/util"
 
 	log "github.com/sirupsen/logrus"
 
@@ -21,12 +22,11 @@ import (
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	crtconfig "sigs.k8s.io/controller-runtime/pkg/client/config"
-	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // GetInfraStatusUsingKubeconfig queries the k8s api for the infrastructure CR using the kubeconfig file
 // pointed to by the passed in kubeconfig (pass in empty string to use default k8s client configurations)
-func GetInfraStatusUsingKubeconfig(m manager.Manager, kubeconfig string) (*configv1.InfrastructureStatus, error) {
+func GetInfraStatusUsingKubeconfig(kubeconfig string) (*configv1.InfrastructureStatus, error) {
 	c, err := getClient(kubeconfig)
 	if err != nil {
 		return nil, err
@@ -70,6 +70,8 @@ func getClient(explicitKubeconfig string) (client.Client, error) {
 	if err != nil {
 		return nil, err
 	}
+
+	util.SetupScheme(dynamicClient.Scheme())
 
 	return dynamicClient, nil
 }

--- a/pkg/operator/platform/platform.go
+++ b/pkg/operator/platform/platform.go
@@ -3,9 +3,10 @@ package platform
 import (
 	"context"
 	"fmt"
-	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 	"os"
 	"time"
+
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 
 	log "github.com/sirupsen/logrus"
 

--- a/pkg/operator/secretannotator/secretannotator_controller.go
+++ b/pkg/operator/secretannotator/secretannotator_controller.go
@@ -30,7 +30,7 @@ import (
 )
 
 func Add(mgr manager.Manager, kubeconfig string) error {
-	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(mgr, kubeconfig)
+	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(kubeconfig)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/operator/secretannotator/secretannotator_controller.go
+++ b/pkg/operator/secretannotator/secretannotator_controller.go
@@ -29,7 +29,7 @@ import (
 	log "github.com/sirupsen/logrus"
 )
 
-func Add(mgr manager.Manager, kubeconfig string) error {
+func Add(mgr, rootCredentialManager manager.Manager, kubeconfig string) error {
 	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(kubeconfig)
 	if err != nil {
 		log.Fatal(err)
@@ -40,19 +40,19 @@ func Add(mgr manager.Manager, kubeconfig string) error {
 
 	switch platformType {
 	case configv1.AzurePlatformType:
-		return azure.Add(mgr, azure.NewReconciler(mgr))
+		return azure.Add(rootCredentialManager, azure.NewReconciler(rootCredentialManager))
 	case configv1.AWSPlatformType:
-		return aws.Add(mgr, aws.NewReconciler(mgr))
+		return aws.Add(rootCredentialManager, aws.NewReconciler(rootCredentialManager))
 	case configv1.GCPPlatformType:
 		if infraStatus.PlatformStatus == nil || infraStatus.PlatformStatus.GCP == nil {
 			log.Fatalf("Missing GCP configuration in infrastructure platform status")
 		}
-		return gcp.Add(mgr, gcp.NewReconciler(mgr, infraStatus.PlatformStatus.GCP.ProjectID))
+		return gcp.Add(rootCredentialManager, gcp.NewReconciler(rootCredentialManager, infraStatus.PlatformStatus.GCP.ProjectID))
 	case configv1.VSpherePlatformType:
-		return vsphere.Add(mgr, vsphere.NewReconciler(mgr))
+		return vsphere.Add(rootCredentialManager, vsphere.NewReconciler(rootCredentialManager))
 	case configv1.OpenStackPlatformType:
-		return openstack.Add(mgr, openstack.NewReconciler(mgr))
+		return openstack.Add(rootCredentialManager, openstack.NewReconciler(rootCredentialManager))
 	default: // returning the AWS implementation for default to avoid changing any behavior
-		return aws.Add(mgr, aws.NewReconciler(mgr))
+		return aws.Add(rootCredentialManager, aws.NewReconciler(rootCredentialManager))
 	}
 }

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -90,7 +90,7 @@ func alwaysReconcileCCOConfigObject(ctx context.Context, c client.Object) []reco
 // Add creates a new Status Controller and adds it to the Manager.
 func Add(mgr manager.Manager, kubeConfig string) error {
 
-	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(mgr, kubeConfig)
+	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(kubeConfig)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -88,7 +88,7 @@ func alwaysReconcileCCOConfigObject(ctx context.Context, c client.Object) []reco
 }
 
 // Add creates a new Status Controller and adds it to the Manager.
-func Add(mgr manager.Manager, kubeConfig string) error {
+func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 
 	infraStatus, err := platform.GetInfraStatusUsingKubeconfig(kubeConfig)
 	if err != nil {

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -18,11 +18,11 @@ package ovirt
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 
 	"github.com/openshift/cloud-credential-operator/pkg/operator/platform"
 	"github.com/openshift/library-go/pkg/operator/configobserver/featuregates"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	log "github.com/sirupsen/logrus"
 
@@ -138,13 +138,11 @@ func (a *OvirtActuator) sync(ctx context.Context, cr *minterv1.CredentialsReques
 	}
 
 	logger.Debugf("provisioning secret")
-	existingSecret, err := a.loadExistingSecret(cr)
-
 	if err != nil && !errors.IsNotFound(err) {
 		return err
 	}
 
-	err = a.syncCredentialSecret(ctx, cr, &ovirtCreds, existingSecret, logger)
+	err = a.syncCredentialSecret(ctx, cr, &ovirtCreds, logger)
 	if err != nil {
 		msg := "error creating/updating secret"
 		logger.WithError(err).Error(msg)
@@ -157,109 +155,43 @@ func (a *OvirtActuator) sync(ctx context.Context, cr *minterv1.CredentialsReques
 	return nil
 }
 
-func (a *OvirtActuator) syncCredentialSecret(ctx context.Context, cr *minterv1.CredentialsRequest, ovirtCreds *OvirtCreds, existingSecret *corev1.Secret, logger log.FieldLogger) error {
+func (a *OvirtActuator) syncCredentialSecret(ctx context.Context, cr *minterv1.CredentialsRequest, ovirtCreds *OvirtCreds, logger log.FieldLogger) error {
 	sLog := logger.WithFields(log.Fields{
 		"targetSecret": fmt.Sprintf("%s/%s", cr.Spec.SecretRef.Namespace, cr.Spec.SecretRef.Name),
 		"cr":           fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 	})
-
-	if existingSecret == nil {
-		if ovirtCreds == nil {
-			msg := "new access key secret needed but no key data provided"
-			sLog.Error(msg)
-			return &actuatoriface.ActuatorError{
-				ErrReason: minterv1.CredentialsProvisionFailure,
-				Message:   msg,
-			}
+	sLog.Infof("processing secret")
+	secret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      cr.Spec.SecretRef.Name,
+			Namespace: cr.Spec.SecretRef.Namespace,
+		},
+	}
+	op, err := controllerutil.CreateOrPatch(ctx, a.Client, secret, func() error {
+		if secret.Labels == nil {
+			secret.Labels = map[string]string{}
 		}
-		sLog.Info("creating secret")
-		secret := &corev1.Secret{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      cr.Spec.SecretRef.Name,
-				Namespace: cr.Spec.SecretRef.Namespace,
-				Labels: map[string]string{
-					minterv1.LabelCredentialsRequest: minterv1.LabelCredentialsRequestValue,
-				},
-				Annotations: map[string]string{
-					minterv1.AnnotationCredentialsRequest: fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
-				},
-			},
-			Data: secretDataFrom(ovirtCreds),
+		secret.Labels[minterv1.LabelCredentialsRequest] = minterv1.LabelCredentialsRequestValue
+		if secret.Annotations == nil {
+			secret.Annotations = map[string]string{}
 		}
-
-		err := a.Client.Create(ctx, secret)
-		if err != nil {
-			sLog.WithError(err).Error("error creating secret")
-			return err
+		secret.Annotations[minterv1.AnnotationCredentialsRequest] = fmt.Sprintf("%s/%s", cr.Namespace, cr.Name)
+		if secret.Data == nil {
+			secret.Data = map[string][]byte{}
 		}
-		sLog.Info("secret created successfully")
+		for key, value := range secretDataFrom(ovirtCreds) {
+			secret.Data[key] = value
+		}
 		return nil
-	}
-
-	// Update the existing secret:
-	sLog.Debug("updating secret")
-	origSecret := existingSecret.DeepCopy()
-	if existingSecret.Labels == nil {
-		existingSecret.Labels = map[string]string{}
-	}
-	existingSecret.Labels[minterv1.LabelCredentialsRequest] = minterv1.LabelCredentialsRequestValue
-
-	if existingSecret.Annotations == nil {
-		existingSecret.Annotations = map[string]string{}
-	}
-	existingSecret.Annotations[minterv1.AnnotationCredentialsRequest] = fmt.Sprintf("%s/%s", cr.Namespace, cr.Name)
-	if ovirtCreds != nil {
-		existingSecret.Data = secretDataFrom(ovirtCreds)
-	}
-
-	if !reflect.DeepEqual(existingSecret, origSecret) {
-		sLog.Info("target secret has changed, updating")
-		err := a.Client.Update(ctx, existingSecret)
-		if err != nil {
-			msg := "error updating secret"
-			sLog.WithError(err).Error(msg)
-			return &actuatoriface.ActuatorError{
-				ErrReason: minterv1.CredentialsProvisionFailure,
-				Message:   msg,
-			}
-		}
-	} else {
-		sLog.Debug("target secret unchanged")
-	}
-
-	return nil
-}
-
-// loadExistingSecret load the secret from the API. If the secret is not found, the NotFound
-// err is returned, with nil secret.
-// The NotFound error can be used to signal the creation of a new signal.
-func (a *OvirtActuator) loadExistingSecret(cr *minterv1.CredentialsRequest) (*corev1.Secret, error) {
-	logger := a.getLogger(cr)
-
-	// Check if the credentials secret exists, if not we need to inform the syncer to generate a new one:
-	loadedSecret := &corev1.Secret{}
-	err := a.Client.Get(context.TODO(), types.NamespacedName{Namespace: cr.Spec.SecretRef.Namespace, Name: cr.Spec.SecretRef.Name}, loadedSecret)
+	})
+	sLog.WithField("operation", op).Info("processed secret")
 	if err != nil {
-		if errors.IsNotFound(err) {
-			logger.Debug("secret does not exist")
-			return nil, err
+		return &actuatoriface.ActuatorError{
+			ErrReason: minterv1.CredentialsProvisionFailure,
+			Message:   "error processing secret",
 		}
 	}
-
-	if _, ok := loadedSecret.Data[urlKey]; !ok {
-		logger.Warningf("secret did not have expected key: %s", urlKey)
-	}
-	if _, ok := loadedSecret.Data[usernameKey]; !ok {
-		logger.Warningf("secret did not have expected key: %s", usernameKey)
-	}
-	if _, ok := loadedSecret.Data[passwordKey]; !ok {
-		logger.Warningf("secret did not have expected key: %s", passwordKey)
-	}
-	if _, ok := loadedSecret.Data[cabundleKey]; !ok {
-		logger.Warningf("secret did not have expected key: %s", cabundleKey)
-	}
-
-	return loadedSecret, nil
+	return nil
 }
 
 // GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.


### PR DESCRIPTION
The status quo for this controller is to LIST + WATCH all Secrets on the cluster. This consumes
more resources than necessary on clusters where users put other data in Secrets themselves, as we
hold that data in our cache and never do anything with it. The reconcilers mainly need to react to
changes in Secrets created for CredentialRequests, which they control and can label, allowing us
to filter the LIST + WATCH down and hold the minimal set of data in memory. However, two caveats:

- in passthrough and mint mode, admin credentials are also provided by the user through Secrets,
  and we need to watch those, but we can't label them
- on existing clusters, secrets exist from previous work these reconcilers did that will not have
  Secrets labelled

We could solve the second issue with an interim release of this controller that labels all previous
Secrets, but does not restrict the watch stream.

Due to the way that controller-runtime closes over the client/cache concepts, it's difficult to
solve the first issue, though, since we'd need two sets of clients and caches, both for Secrets,
and ensure that we use one for client access to Secrets we're creating or mutating and the other
when we're interacting with admin credentials. Not impossible to do, but tricky to implement and
complex.

Until we undertake that effort, we apply a simplification to the space: only when AWS STS mode is
enabled, we will try to filter the LIST + WATCH. This mode is brand new, so we can be reasonably
sure that there are no previous secrets on the cluster, and, we make the filtering best-effort
in order to check if that assumption held. Second, AWS STS mode only runs in clusters without
admin credentials, so if we apply the filter, we should not see failures downstream from clients
that hope to see those objects but can't.