### PR TITLE
PORTENABLE-526: operator: use a partial metadata watch for Namespaces

### DIFF
--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -273,7 +273,12 @@ func add(mgr manager.Manager, r reconcile.Reconciler) error {
 	}
 
 	err = c.Watch(
-		&source.Kind{Type: &corev1.Namespace{}},
+		&source.Kind{Type: &metav1.PartialObjectMetadata{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "Namespace",
+				APIVersion: "v1",
+			},
+		}},
 		namespaceMapFn,
 		namespacePred)
 	if err != nil {


### PR DESCRIPTION
We only watch namespaces to react to their creation, and the only information we need about a namespace is its' name, so we can use a partial metadata watch to winnow down the size of our cache. Namespaces don't really store much in spec and status, so this effect is likely to not be enormous, but every bit helps.