### PR TITLE
CCO-394: Do not Add PodIdentityWebhook controller when InfraStatus.ControlPlaneToplogy is External.

### DIFF
--- a/pkg/operator/awspodidentity/awspodidentitywebhook_controller.go
+++ b/pkg/operator/awspodidentity/awspodidentitywebhook_controller.go
@@ -133,11 +133,15 @@ func Add(mgr manager.Manager, kubeconfig string) error {
 	if err != nil {
 		return err
 	}
+	// Only add controller when PlatformType is AWS
 	platformType := platform.GetType(infraStatus)
 	if platformType != configv1.AWSPlatformType {
 		return nil
 	}
-
+	// Do not add controller when ControlPlaneTopology is External
+	if infraStatus.ControlPlaneTopology == configv1.ExternalTopologyMode {
+		return nil
+	}
 	log.Info("setting up AWS pod identity controller")
 
 	config := mgr.GetConfig()


### PR DESCRIPTION
Do not deploy the pod identity webhook when infrastructure ControlPlaneTopology is External since Hypershift deploys the webhook independently.