### PR TITLE
CCO-353: ccoctl to create azure custom roles

### DIFF
--- a/pkg/apis/cloudcredential/v1/types_azure.go
+++ b/pkg/apis/cloudcredential/v1/types_azure.go
@@ -31,6 +31,14 @@ type AzureProviderSpec struct {
 
 	// RoleBindings contains a list of roles that should be associated with the minted credential.
 	RoleBindings []RoleBinding `json:"roleBindings"`
+
+	// Permissions is the list of Azure permissions required to create a more fine-grained custom role to
+	// satisfy the CredentialsRequest.
+	// The Permissions field may be provided in addition to RoleBindings. When both fields are specified,
+	// the user-assigned managed identity will have union of permissions defined from both Permissions
+	// and RoleBindings.
+	// +optional
+	Permissions []string `json:"permissions,omitempty"`
 }
 
 // RoleBinding models part of the Azure RBAC Role Binding

--- a/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
@@ -179,6 +179,11 @@ func (in *AzureProviderSpec) DeepCopyInto(out *AzureProviderSpec) {
 		*out = make([]RoleBinding, len(*in))
 		copy(*out, *in)
 	}
+	if in.Permissions != nil {
+		in, out := &in.Permissions, &out.Permissions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 

--- a/pkg/azure/clients.go
+++ b/pkg/azure/clients.go
@@ -208,6 +208,8 @@ func (userAssignedIdentitiesClient *userAssignedIdentitiesClient) Get(ctx contex
 }
 
 type RoleDefinitionsClient interface {
+	CreateOrUpdate(ctx context.Context, scope string, roleDefinitionID string, roleDefinition armauthorization.RoleDefinition, options *armauthorization.RoleDefinitionsClientCreateOrUpdateOptions) (armauthorization.RoleDefinitionsClientCreateOrUpdateResponse, error)
+	Delete(ctx context.Context, scope string, roleDefinitionID string, options *armauthorization.RoleDefinitionsClientDeleteOptions) (armauthorization.RoleDefinitionsClientDeleteResponse, error)
 	GetByID(ctx context.Context, roleDefinitionID string, options *armauthorization.RoleDefinitionsClientGetByIDOptions) (armauthorization.RoleDefinitionsClientGetByIDResponse, error)
 	NewListPager(scope string, options *armauthorization.RoleDefinitionsClientListOptions) *runtime.Pager[armauthorization.RoleDefinitionsClientListResponse]
 }
@@ -222,6 +224,14 @@ func NewRoleDefinitionsClient(cred azcore.TokenCredential, options *policy.Clien
 		return nil, err
 	}
 	return &roleDefinitionsClient{client: client}, err
+}
+
+func (roleDefinitionsClient *roleDefinitionsClient) CreateOrUpdate(ctx context.Context, scope string, roleDefinitionID string, roleDefinition armauthorization.RoleDefinition, options *armauthorization.RoleDefinitionsClientCreateOrUpdateOptions) (armauthorization.RoleDefinitionsClientCreateOrUpdateResponse, error) {
+	return roleDefinitionsClient.client.CreateOrUpdate(ctx, scope, roleDefinitionID, roleDefinition, options)
+}
+
+func (roleDefinitionsClient *roleDefinitionsClient) Delete(ctx context.Context, scope string, roleDefinitionID string, options *armauthorization.RoleDefinitionsClientDeleteOptions) (armauthorization.RoleDefinitionsClientDeleteResponse, error) {
+	return roleDefinitionsClient.client.Delete(ctx, scope, roleDefinitionID, options)
 }
 
 func (roleDefinitionsClient *roleDefinitionsClient) NewListPager(scope string, options *armauthorization.RoleDefinitionsClientListOptions) *runtime.Pager[armauthorization.RoleDefinitionsClientListResponse] {

--- a/pkg/azure/mock/client_generated.go
+++ b/pkg/azure/mock/client_generated.go
@@ -446,6 +446,36 @@ func (m *MockRoleDefinitionsClient) EXPECT() *MockRoleDefinitionsClientMockRecor
 	return m.recorder
 }
 
+// CreateOrUpdate mocks base method.
+func (m *MockRoleDefinitionsClient) CreateOrUpdate(ctx context.Context, scope, roleDefinitionID string, roleDefinition armauthorization.RoleDefinition, options *armauthorization.RoleDefinitionsClientCreateOrUpdateOptions) (armauthorization.RoleDefinitionsClientCreateOrUpdateResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateOrUpdate", ctx, scope, roleDefinitionID, roleDefinition, options)
+	ret0, _ := ret[0].(armauthorization.RoleDefinitionsClientCreateOrUpdateResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateOrUpdate indicates an expected call of CreateOrUpdate.
+func (mr *MockRoleDefinitionsClientMockRecorder) CreateOrUpdate(ctx, scope, roleDefinitionID, roleDefinition, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockRoleDefinitionsClient)(nil).CreateOrUpdate), ctx, scope, roleDefinitionID, roleDefinition, options)
+}
+
+// Delete mocks base method.
+func (m *MockRoleDefinitionsClient) Delete(ctx context.Context, scope, roleDefinitionID string, options *armauthorization.RoleDefinitionsClientDeleteOptions) (armauthorization.RoleDefinitionsClientDeleteResponse, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, scope, roleDefinitionID, options)
+	ret0, _ := ret[0].(armauthorization.RoleDefinitionsClientDeleteResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockRoleDefinitionsClientMockRecorder) Delete(ctx, scope, roleDefinitionID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockRoleDefinitionsClient)(nil).Delete), ctx, scope, roleDefinitionID, options)
+}
+
 // GetByID mocks base method.
 func (m *MockRoleDefinitionsClient) GetByID(ctx context.Context, roleDefinitionID string, options *armauthorization.RoleDefinitionsClientGetByIDOptions) (armauthorization.RoleDefinitionsClientGetByIDResponse, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
ccoctl azure to create custom roles for each credential request which contains permissions.

When ccoctl azure operates on a credential request which has the new permissions definition, a new custom role will be created for the operator with the specified permissions. This custom role will be added to the list of roles specified, if any, and a role assignment will be created for the associated managed identity.

https://issues.redhat.com/browse/CCO-353