### PR TITLE
OCPBUGS-15906: ccoctl azure delete to also delete role assignments

### DIFF
--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -415,7 +415,7 @@ func deleteRoleAssignment(client *azureclients.AzureClientWrapper, managedIdenti
 	if err != nil {
 		return err
 	}
-	log.Printf("Deleted role assignment for role %s with user-assigned managed identity with principal ID %s at scope %s", roleName, managedIdentityPrincipalID, scope)
+	log.Printf("Deleted role assignment for role %s with user-assigned managed identity principal ID %s at scope %s", roleName, managedIdentityPrincipalID, scope)
 	return nil
 }
 


### PR DESCRIPTION
The ccoctl azure subcommand was previously leaking role assignments. This change ensures all associated roleAssignments are removed prior to deleting the user-assigned managed identities.