### PR TITLE
OCPBUGS-15365: manifests: fix rbac

### DIFF
--- a/manifests/01-role.yaml
+++ b/manifests/01-role.yaml
@@ -14,17 +14,9 @@ rules:
   - events
   - serviceaccounts
   - services
+  - configmaps
   verbs:
   - "*"
-- apiGroups:
-    - ""
-  resources:
-    - configmaps
-  resourceNames:
-    - cloud-credential-operator-config
-    - cloud-credential-operator-leader
-  verbs:
-    - "*"
 - apiGroups:
   - apps
   resources:


### PR DESCRIPTION
We can't restrict CREATE with resourceNames, since the final name of the object is potentially unknown at admission time.