### PR TITLE
Revert "OCPBUGS-16036: Set status on CR properly when STS provisioned"

### DIFF
--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -19,8 +19,6 @@ package credentialsrequest
 import (
 	"context"
 	"fmt"
-	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/util/retry"
 	"reflect"
 	"time"
 
@@ -704,10 +702,7 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 					provisionErr = true
 				}
 
-				updateErr := r.UpdateProvisionedStatus(cr, !provisionErr)
-				if updateErr != nil {
-					logger.Errorf("failed to update credentialsrequest status: %v", updateErr)
-				}
+				cr.Status.Provisioned = !provisionErr
 
 				logger.Errorf("errored with condition: %v", t.Reason())
 				r.updateActuatorConditions(cr, t.Reason(), syncErr)
@@ -719,11 +714,7 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 		} else {
 			// it worked so clear any actuator conditions if they exist
 			r.updateActuatorConditions(cr, "", nil)
-			updateErr := r.UpdateProvisionedStatus(cr, true)
-
-			if updateErr != nil {
-				logger.Errorf("failed to update credentialsrequest status: %v", updateErr)
-			}
+			cr.Status.Provisioned = true
 		}
 	} else {
 		credentialsRootSecret, err := r.Actuator.GetCredentialsRootSecret(ctx, cr)
@@ -1048,29 +1039,4 @@ func checkForFailureConditions(cr *minterv1.CredentialsRequest) bool {
 		}
 	}
 	return false
-}
-
-// UpdateProvisionedStatus will update the status subresource of this CredentialsRequest
-func (r *ReconcileCredentialsRequest) UpdateProvisionedStatus(cr *minterv1.CredentialsRequest, provisioned bool) error {
-	// Check if the status subresource is already set
-	if cr.Status.LastSyncTimestamp == nil {
-		// Create a new status object and set its fields
-		cr.Status = minterv1.CredentialsRequestStatus{
-			LastSyncTimestamp: &metav1.Time{Time: time.Now()},
-			Provisioned:       provisioned,
-			ProviderStatus:    &runtime.RawExtension{},
-		}
-	} else {
-		// Update the Provisioned field with the given parameter
-		cr.Status.Provisioned = provisioned
-	}
-
-	// Use retry.RetryOnConflict() to update the status subresource
-	err := retry.RetryOnConflict(retry.DefaultBackoff, func() error {
-		return r.Client.Status().Update(context.Background(), cr)
-	})
-	if err != nil {
-		return err
-	}
-	return nil
 }


### PR DESCRIPTION
Reverts openshift/cloud-credential-operator#562

Per [Openshift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert) we are reverting this breaking change to get CI and/or nightly payloads flowing again.

We [suspect](https://redhat-internal.slack.com/archives/C01C8502FMM/p1689515416708439) this change is breaking:
* 4.14 CI payload since [4.14.0-0.ci-2023-07-14-194011](https://sippy.dptools.openshift.org/sippy-ng/release/4.14/tags/4.14.0-0.ci-2023-07-14-194011)

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem. Before merging the unrevert, please run these jobs on the PR and check the result of (job/X or job/X, test/Y tuple) to confirm the fix has corrected the problem:

/payload-job periodic-ci-openshift-hypershift-release-4.14-periodics-e2e-aws-ovn

And verify that the job passes

CC: @bentito 