### PR TITLE
CCO-402: Create Azure AD pod identity webhook config secret manifest in create-all,create-oidc-issuer

### DIFF
--- a/docs/azure_workload_identity.md
+++ b/docs/azure_workload_identity.md
@@ -88,6 +88,7 @@ type: Opaque
                              --output-dir <ccoctl_output_dir> \
                              --region <azure_region> \
                              --subscription-id <azure_subscription_id> \
+                             --tenant-id <azure_tenant_id> \
                              --credentials-requests-dir /path/to/credreqs/directory/created/in/step/3 \
                              --dnszone-resource-group-name <azure_dns_zone_resourcegroup_name>
    ```

--- a/docs/ccoctl.md
+++ b/docs/ccoctl.md
@@ -140,6 +140,7 @@ $ ccoctl azure create-oidc-issuer --name <azure_infra_name> \
                                     --output-dir <output_dir> \
                                     --region <azure_region> \
                                     --subscription-id <azure_subscription_id> \
+                                    --tenant-id <azure_tenant_id> \
                                     --public-key-file /path/to/rsa/keypair/serviceaccount-signer.public \
 ```
 
@@ -184,6 +185,7 @@ $ ccoctl azure create-all --name <azure_infra_name> \
                           --output-dir <output_dir> \
                           --region <azure_region> \
                           --subscription-id <azure_subscription_id> \
+                          --tenant-id <azure_tenant_id> \
                           --credentials-requests-dir ./credrequests \
                           --dnszone-resource-group-name <azure resource group containing the dns zone of the cluster>
 ```

--- a/pkg/cmd/provisioning/azure/azure.go
+++ b/pkg/cmd/provisioning/azure/azure.go
@@ -15,6 +15,7 @@ type azureOptions struct {
 	StorageAccountName string
 	BlobContainerName  string
 	SubscriptionID     string
+	TenantID           string
 	OutputDir          string
 	DryRun             bool
 	EnableTechPreview  bool

--- a/pkg/cmd/provisioning/azure/create_all.go
+++ b/pkg/cmd/provisioning/azure/create_all.go
@@ -68,6 +68,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		CreateAllOpts.StorageAccountName,
 		CreateAllOpts.BlobContainerName,
 		CreateAllOpts.SubscriptionID,
+		CreateAllOpts.TenantID,
 		publicKeyPath,
 		CreateAllOpts.OutputDir,
 		CreateAllOpts.UserTags,
@@ -136,7 +137,7 @@ func initEnvForCreateAllCmd(cmd *cobra.Command, args []string) {
 // NewCreateAllCmd combines create-identity-provider and create-managed-identities commands
 func NewCreateAllCmd() *cobra.Command {
 	createAllCmd := &cobra.Command{
-		Use:              "create-all --name NAME --region REGION --subscription-id SUBSCRIPTION_ID --credentials-requests-dir CRED_REQ_DIR --dnszone-resource-group-name DNSZONE_RESOURCE_GROUP_NAME",
+		Use:              "create-all --name NAME --region REGION --subscription-id SUBSCRIPTION_ID --tenant-id TENANT_ID \\ \n\t--credentials-requests-dir CRED_REQ_DIR --dnszone-resource-group-name DNSZONE_RESOURCE_GROUP_NAME",
 		Short:            "Create OIDC issuer and managed identities",
 		Run:              createAllCmd,
 		PersistentPreRun: initEnvForCreateAllCmd,
@@ -155,6 +156,8 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.MarkPersistentFlagRequired("region")
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.SubscriptionID, "subscription-id", "", "Azure Subscription ID within which to create identity provider infrastructure")
 	createAllCmd.MarkPersistentFlagRequired("subscription-id")
+	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.TenantID, "tenant-id", "", "Azure Tenant ID in which identity provider infrastructure will be created")
+	createAllCmd.MarkPersistentFlagRequired("tenant-id")
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing Azure CredentialsRequests files used to create user-assigned managed identities (can be created by running 'oc adm release extract --credentials-requests --cloud=azure' against an OpenShift release image)")
 	createAllCmd.MarkPersistentFlagRequired("credentials-requests-dir")
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.DNSZoneResourceGroupName, "dnszone-resource-group-name", "", "The existing Azure resource group which contains the DNS zone that will be used for the cluster's base domain. The cluster ingress operator will be scoped to allow management of DNS records in the DNS Zone resource group.")

--- a/pkg/cmd/provisioning/azure/create_oidc_issuer.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer.go
@@ -25,6 +25,7 @@ import (
 
 	azureclients "github.com/openshift/cloud-credential-operator/pkg/azure"
 	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
+	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
 )
 
 var (
@@ -58,6 +59,21 @@ var (
 
 	// ownedAzureResourceTagValue is the value of the tag applied to the Azure resources created by ccoctl
 	ownedAzureResourceTagValue = "owned"
+
+	podIdentityWebhookConfigSecretTemplate = `apiVersion: v1
+stringData:
+  azure_tenant_id: %s
+kind: Secret
+metadata:
+  name: %s
+  namespace: %s
+type: Opaque`
+
+	podIdentityWebhookConfigSecretName = "azure-credentials"
+
+	podIdentityWebhookConfigSecretManifestFilename = "azure-ad-pod-identity-webhook-config.yaml"
+
+	podIdentityWebhookConfigSecretNamespace = constants.CCONameSpace
 )
 
 // ensureResourceGroup ensures that a resource group with resourceGroupName exists within the provided region and subscription.
@@ -370,12 +386,25 @@ func uploadOIDCDocuments(client *azureclients.AzureClientWrapper, storageAccount
 	return blobContainerURL, nil
 }
 
+func createPodIdentityWebhookConfigSecret(tenantID, outputDir string) error {
+	manifestsDir := filepath.Join(outputDir, provisioning.ManifestsDirName)
+	filePath := filepath.Join(manifestsDir, podIdentityWebhookConfigSecretManifestFilename)
+	fileData := fmt.Sprintf(podIdentityWebhookConfigSecretTemplate, tenantID, podIdentityWebhookConfigSecretName, podIdentityWebhookConfigSecretNamespace)
+
+	if err := os.WriteFile(filePath, []byte(fileData), 0600); err != nil {
+		return errors.Wrapf(err, "failed to save secret file at path %s", filePath)
+	}
+	log.Printf("Saved Azure AD pod identity webhook configuration to: %s", filePath)
+
+	return nil
+}
+
 // createOIDCIssuer creates infrastructure necessary for Azure Workload Identity including,
 // * resource group in which to create storage account & identities
 // * scoping resource group which will remain empty and is used to scope identity role assignment, this resource group is for installation
 // * storage account
 // * blob container which hosts OIDC documents
-func createOIDCIssuer(client *azureclients.AzureClientWrapper, name, region, oidcResourceGroupName, storageAccountName, blobContainerName, subscriptionID, publicKeyPath, outputDir string, resourceTags map[string]string, dryRun bool) (string, error) {
+func createOIDCIssuer(client *azureclients.AzureClientWrapper, name, region, oidcResourceGroupName, storageAccountName, blobContainerName, subscriptionID, tenantID, publicKeyPath, outputDir string, resourceTags map[string]string, dryRun bool) (string, error) {
 	// Add CCO's "owned" tag to resource tags map
 	resourceTags[fmt.Sprintf("%s_%s", ownedAzureResourceTagKeyPrefix, name)] = ownedAzureResourceTagValue
 
@@ -427,6 +456,12 @@ func createOIDCIssuer(client *azureclients.AzureClientWrapper, name, region, oid
 		return "", errors.Wrap(err, "failed to create cluster authentication manifest")
 	}
 
+	// Write Azure AD pod identity webhook config secret azure-ad-pod-identity-webhook-config.yaml
+	// within outputDir/manifests
+	if err = createPodIdentityWebhookConfigSecret(tenantID, outputDir); err != nil {
+		return "", errors.Wrap(err, "failed to create Azure AD pod identity webhook manifest")
+	}
+
 	return issuerURL, nil
 }
 
@@ -466,6 +501,7 @@ func createOIDCIssuerCmd(cmd *cobra.Command, args []string) {
 		CreateOIDCIssuerOpts.StorageAccountName,
 		CreateOIDCIssuerOpts.BlobContainerName,
 		CreateOIDCIssuerOpts.SubscriptionID,
+		CreateOIDCIssuerOpts.TenantID,
 		CreateOIDCIssuerOpts.PublicKeyPath,
 		CreateOIDCIssuerOpts.OutputDir,
 		CreateOIDCIssuerOpts.UserTags,
@@ -516,7 +552,7 @@ func initEnvForCreateOIDCIssuerCmd(cmd *cobra.Command, args []string) {
 // NewCreateOIDCIssuerCmd provides the "create-oidc-issuer" subcommand
 func NewCreateOIDCIssuerCmd() *cobra.Command {
 	createOIDCIssuerCmd := &cobra.Command{
-		Use:              "create-oidc-issuer --name NAME --region REGION --subscription-id SUBSCRIPTION_ID --public-key-file PUBLIC_KEY_FILE",
+		Use:              "create-oidc-issuer --name NAME --region REGION --subscription-id SUBSCRIPTION_ID --tenant-id TENANT_ID --public-key-file PUBLIC_KEY_FILE",
 		Short:            "Create OIDC Issuer",
 		Run:              createOIDCIssuerCmd,
 		PersistentPreRun: initEnvForCreateOIDCIssuerCmd,
@@ -535,6 +571,8 @@ func NewCreateOIDCIssuerCmd() *cobra.Command {
 	createOIDCIssuerCmd.MarkPersistentFlagRequired("region")
 	createOIDCIssuerCmd.PersistentFlags().StringVar(&CreateOIDCIssuerOpts.SubscriptionID, "subscription-id", "", "Azure Subscription ID within which to create identity provider infrastructure")
 	createOIDCIssuerCmd.MarkPersistentFlagRequired("subscription-id")
+	createOIDCIssuerCmd.PersistentFlags().StringVar(&CreateOIDCIssuerOpts.TenantID, "tenant-id", "", "Azure Tenant ID in which identity provider infrastructure will be created")
+	createOIDCIssuerCmd.MarkPersistentFlagRequired("tenant-id")
 	createOIDCIssuerCmd.PersistentFlags().StringVar(&CreateOIDCIssuerOpts.PublicKeyPath, "public-key-file", "", "Path to public ServiceAccount signing key")
 	createOIDCIssuerCmd.MarkPersistentFlagRequired("public-key-file")
 

--- a/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
@@ -26,6 +26,7 @@ var (
 	testInfraName      = "testinfraname"
 	testRegionName     = "testregion"
 	testSubscriptionID = "123456789"
+	testTenantID       = "987654321"
 	testUserTags       = map[string]string{
 		"testtagname0": "testtagvalue0",
 		"testtagname1": "testtagvalue1",
@@ -136,6 +137,7 @@ func TestCreateOIDCIssuer(t *testing.T) {
 				testStorageAccountName,
 				testBlobContainerName,
 				testSubscriptionID,
+				testTenantID,
 				testPublicKeyPath,
 				tempDirName,
 				testUserTags,


### PR DESCRIPTION
This requires providing the Azure tenant ID to put within the webhook config in create-all and create-oidc-issuer subcommands which will create the webhook config. The Azure tenant ID is not made available/discoverable by azure-sdk-for-go and the method for knowing the tenant ID depends on the authentication method used. Because of this, we will now need to require the tenant ID as a parameter and only use it as a value to be set in the webhook config.

e2e-azure-manual-oidc will need to be modified to account for this new required command line parameter.