### PR TITLE
*: use a global codec

### DIFF
--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -81,7 +81,7 @@ spec:
         resources:
           requests:
             cpu: 10m
-            memory: 150Mi
+            memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /var/run/configmaps/trusted-ca-bundle

--- a/pkg/apis/cloudcredential/v1/codec.go
+++ b/pkg/apis/cloudcredential/v1/codec.go
@@ -22,12 +22,23 @@ import (
 
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/serializer"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 )
 
-// NewScheme creates a new Scheme
-func NewScheme() (*runtime.Scheme, error) {
-	s := runtime.NewScheme()
-	return s, SchemeBuilder.AddToScheme(s)
+var scheme = runtime.NewScheme()
+var codecFactory = serializer.NewCodecFactory(scheme)
+var encoder runtime.Encoder = nil
+var Codec *ProviderCodec = nil
+
+func init() {
+	utilruntime.Must(Install(scheme))
+	var err error
+	encoder, err = newEncoder(&codecFactory)
+	utilruntime.Must(err)
+	Codec = &ProviderCodec{
+		encoder: encoder,
+		decoder: codecFactory.UniversalDecoder(SchemeGroupVersion),
+	}
 }
 
 // ProviderCodec is a runtime codec for providers.
@@ -35,24 +46,6 @@ func NewScheme() (*runtime.Scheme, error) {
 type ProviderCodec struct {
 	encoder runtime.Encoder
 	decoder runtime.Decoder
-}
-
-// NewCodec creates a serializer/deserializer for the provider configuration
-func NewCodec() (*ProviderCodec, error) {
-	scheme, err := NewScheme()
-	if err != nil {
-		return nil, err
-	}
-	codecFactory := serializer.NewCodecFactory(scheme)
-	encoder, err := newEncoder(&codecFactory)
-	if err != nil {
-		return nil, err
-	}
-	codec := ProviderCodec{
-		encoder: encoder,
-		decoder: codecFactory.UniversalDecoder(SchemeGroupVersion),
-	}
-	return &codec, nil
 }
 
 // EncodeProvider serializes an object to the provider spec.

--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -249,18 +249,13 @@ func readCredentialRequest(cr []byte) (*minterv1.CredentialsRequest, error) {
 func getCredentialRequestStatements(crBytes []byte) ([]minterv1.StatementEntry, error) {
 	statementList := []minterv1.StatementEntry{}
 
-	awsCodec, err := minterv1.NewCodec()
-	if err != nil {
-		return statementList, fmt.Errorf("error creating credentialrequest codec: %v", err)
-	}
-
 	cr, err := readCredentialRequest(crBytes)
 	if err != nil {
 		return statementList, err
 	}
 
 	awsSpec := minterv1.AWSProviderSpec{}
-	err = awsCodec.DecodeProviderSpec(cr.Spec.ProviderSpec, &awsSpec)
+	err = minterv1.Codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &awsSpec)
 	if err != nil {
 		return statementList, fmt.Errorf("error decoding spec.ProviderSpec: %v", err)
 	}

--- a/pkg/azure/actuator_test.go
+++ b/pkg/azure/actuator_test.go
@@ -153,18 +153,15 @@ var (
 )
 
 func TestDecodeToUnknown(t *testing.T) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Fatalf("failed to create codec %#v", err)
-	}
+	var err error
 	var raw *runtime.RawExtension
 	aps := minterv1.AzureProviderSpec{}
-	raw, err = codec.EncodeProviderSpec(&aps)
+	raw, err = minterv1.Codec.EncodeProviderSpec(&aps)
 	if err != nil {
 		t.Fatalf("failed to encode codec %#v", err)
 	}
 	unknown := runtime.Unknown{}
-	err = codec.DecodeProviderStatus(raw, &unknown)
+	err = minterv1.Codec.DecodeProviderStatus(raw, &unknown)
 	if err != nil {
 		t.Fatalf("should be able to decode to Unknown %#v", err)
 	}
@@ -180,13 +177,9 @@ func getCredRequest(t *testing.T, c client.Client) *minterv1.CredentialsRequest 
 }
 
 func getProviderStatus(t *testing.T, cr *minterv1.CredentialsRequest) minterv1.AzureProviderStatus {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Fatalf("error creating Azure codec: %v", err)
-	}
 	azStatus := minterv1.AzureProviderStatus{}
 
-	assert.NoError(t, codec.DecodeProviderStatus(cr.Status.ProviderStatus, &azStatus))
+	assert.NoError(t, minterv1.Codec.DecodeProviderStatus(cr.Status.ProviderStatus, &azStatus))
 
 	return azStatus
 }
@@ -198,11 +191,6 @@ func TestActuator(t *testing.T) {
 
 	if err := minterv1.AddToScheme(scheme.Scheme); err != nil {
 		t.Fatal(err)
-	}
-
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Fatalf("error creating Azure codec: %v", err)
 	}
 
 	tests := []struct {
@@ -271,7 +259,7 @@ func TestActuator(t *testing.T) {
 					AppID:                     testAppRegID,
 					SecretLastResourceVersion: "oldVersion",
 				}
-				encodedStatus, err := codec.EncodeProviderStatus(rawStatus)
+				encodedStatus, err := minterv1.Codec.EncodeProviderStatus(rawStatus)
 				require.NoError(t, err, "error encoding status")
 
 				cr.Status.ProviderStatus = encodedStatus
@@ -349,7 +337,7 @@ func TestActuator(t *testing.T) {
 					AppID:                testAppRegID,
 					// SecretLastResourceVersion: "oldVersion",
 				}
-				encodedStatus, err := codec.EncodeProviderStatus(rawStatus)
+				encodedStatus, err := minterv1.Codec.EncodeProviderStatus(rawStatus)
 				require.NoError(t, err, "error encoding status")
 
 				cr.Status.ProviderStatus = encodedStatus
@@ -431,7 +419,7 @@ func TestActuator(t *testing.T) {
 					ServicePrincipalName: testAppRegName,
 					AppID:                testAppRegID,
 				}
-				encodedStatus, err := codec.EncodeProviderStatus(rawStatus)
+				encodedStatus, err := minterv1.Codec.EncodeProviderStatus(rawStatus)
 				require.NoError(t, err, "error encoding status")
 
 				cr.Status.ProviderStatus = encodedStatus
@@ -506,7 +494,6 @@ func TestActuator(t *testing.T) {
 			actuator := azure.NewFakeActuator(
 				fakeClient,
 				fakeAdminClient,
-				codec,
 				func(logger log.FieldLogger, clientID, clientSecret, tenantID, subscriptionID string) (*azure.AzureCredentialsMinter, error) {
 					return azure.NewFakeAzureCredentialsMinter(logger,
 						clientID,
@@ -562,12 +549,7 @@ func generateDisplayName() string {
 }
 
 func testCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Fatalf("error creating Azure codec: %v", err)
-	}
-
-	rawObj, err := codec.EncodeProviderSpec(azureSpec)
+	rawObj, err := minterv1.Codec.EncodeProviderSpec(azureSpec)
 	if err != nil {
 		t.Fatalf("error decoding provider v1 spec: %v", err)
 	}

--- a/pkg/azure/request.go
+++ b/pkg/azure/request.go
@@ -25,19 +25,14 @@ type request struct {
 }
 
 func newRequest(cr *minterv1.CredentialsRequest) (*request, error) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		return nil, err
-	}
-
 	status := minterv1.AzureProviderStatus{}
-	err = codec.DecodeProviderStatus(cr.Status.ProviderStatus, &status)
+	err := minterv1.Codec.DecodeProviderStatus(cr.Status.ProviderStatus, &status)
 	if err != nil {
 		return nil, err
 	}
 
 	spec := minterv1.AzureProviderSpec{}
-	err = codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &spec)
+	err = minterv1.Codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &spec)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -186,13 +186,13 @@ func NewOperator() *cobra.Command {
 					Cache: cache.Options{
 						ByObject: objectSelectors,
 					},
+					PprofBindAddress: ":6060",
 				})
 				if err != nil {
 					log.WithError(err).Fatal("unable to set up overall controller manager")
 				}
 
 				rootMgr, err := manager.New(cfg, manager.Options{
-					MetricsBindAddress: ":2113",
 					Cache: cache.Options{
 						ByObject: map[client.Object]cache.ByObject{
 							&corev1.Secret{}: {

--- a/pkg/cmd/provisioning/alibabacloud/create-ram-users.go
+++ b/pkg/cmd/provisioning/alibabacloud/create-ram-users.go
@@ -240,13 +240,8 @@ func createUserAndAttachPolicy(client alibabacloud.Client, name, targetDir strin
 	policyName := generatePolicyName(fmt.Sprintf("%s-%s-%s-policy", name, credReq.Spec.SecretRef.Namespace, credReq.Spec.SecretRef.Name))
 
 	// Decode Alibaba CloudProviderSpec
-	codec, err := credreqv1.NewCodec()
-	if err != nil {
-		return errors.Wrap(err, "Failed to create credReq codec")
-	}
-
 	alibabaProviderSpec := credreqv1.AlibabaCloudProviderSpec{}
-	if err := codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &alibabaProviderSpec); err != nil {
+	if err := credreqv1.Codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &alibabaProviderSpec); err != nil {
 		return errors.Wrap(err, "Failed to decode the provider spec")
 	}
 

--- a/pkg/cmd/provisioning/aws/create-iam-roles.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles.go
@@ -89,13 +89,8 @@ func createRole(awsClient aws.Client, name string, credReq *credreqv1.Credential
 	roleName := fmt.Sprintf("%s-%s-%s", name, credReq.Spec.SecretRef.Namespace, credReq.Spec.SecretRef.Name)
 
 	// Decode AWSProviderSpec
-	codec, err := credreqv1.NewCodec()
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to create credReq codec")
-	}
-
 	awsProviderSpec := credreqv1.AWSProviderSpec{}
-	if err := codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &awsProviderSpec); err != nil {
+	if err := credreqv1.Codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &awsProviderSpec); err != nil {
 		return "", errors.Wrap(err, "Failed to decode the provider spec")
 	}
 

--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -14,7 +14,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/runtime"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/to"
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
-	armauthorization "github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
+	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/authorization/armauthorization/v2"
 	"github.com/Azure/azure-sdk-for-go/sdk/resourcemanager/msi/armmsi"
 
 	credreqv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
@@ -82,11 +82,7 @@ func createManagedIdentity(client *azureclients.AzureClientWrapper, name, resour
 	// Decode CredentialsRequest.Spec.ProviderSpec.RoleBindings from Azure CredentialsRequest
 	crProviderSpec := &credreqv1.AzureProviderSpec{}
 	if credentialsRequest.Spec.ProviderSpec != nil {
-		codec, err := credreqv1.NewCodec()
-		if err != nil {
-			return err
-		}
-		err = codec.DecodeProviderSpec(credentialsRequest.Spec.ProviderSpec, crProviderSpec)
+		err := credreqv1.Codec.DecodeProviderSpec(credentialsRequest.Spec.ProviderSpec, crProviderSpec)
 		if err != nil {
 			return fmt.Errorf("error decoding provider spec from CredentialsRequest: %w", err)
 		}

--- a/pkg/cmd/provisioning/gcp/create_service_accounts.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts.go
@@ -141,13 +141,8 @@ func createServiceAccount(ctx context.Context, client gcp.Client, name string, c
 	}
 
 	// Decode GCPProviderSpec
-	codec, err := credreqv1.NewCodec()
-	if err != nil {
-		return "", errors.Wrap(err, "Failed to create credReq codec")
-	}
-
 	gcpProviderSpec := credreqv1.GCPProviderSpec{}
-	if err := codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &gcpProviderSpec); err != nil {
+	if err := credreqv1.Codec.DecodeProviderSpec(credReq.Spec.ProviderSpec, &gcpProviderSpec); err != nil {
 		return "", errors.Wrap(err, "Failed to decode the provider spec")
 	}
 

--- a/pkg/cmd/provisioning/ibmcloud/service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/service_id.go
@@ -80,17 +80,12 @@ func (s *ServiceID) List() ([]iamidentityv1.ServiceID, error) {
 }
 
 func (s *ServiceID) Validate() error {
-	codec, err := credreqv1.NewCodec()
-	if err != nil {
-		return errors.Wrap(err, "Failed to create credReq codec")
-	}
-
 	if s.cr.Spec.ProviderSpec == nil {
 		return fmt.Errorf("Spec.ProviderSpec is empty in %s credentials request", s.cr.Name)
 	}
 
 	var unknown runtime.Unknown
-	err = codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, &unknown)
+	err := credreqv1.Codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, &unknown)
 	if err != nil {
 		return errors.Wrapf(err, "failed to DecodeProviderSpec")
 	}
@@ -275,12 +270,8 @@ func (s *ServiceID) createPolicy(policy *credreqv1.AccessPolicy) error {
 }
 
 func (s *ServiceID) extractPolicies() (policies []credreqv1.AccessPolicy, returnErr error) {
-	codec, returnErr := credreqv1.NewCodec()
-	if returnErr != nil {
-		return nil, errors.Wrap(returnErr, "Failed to create credReq codec")
-	}
 	var unknown runtime.Unknown
-	returnErr = codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, &unknown)
+	returnErr = credreqv1.Codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, &unknown)
 	if returnErr != nil {
 		return nil, returnErr
 	}
@@ -288,13 +279,13 @@ func (s *ServiceID) extractPolicies() (policies []credreqv1.AccessPolicy, return
 	switch unknown.Kind {
 	case reflect.TypeOf(credreqv1.IBMCloudProviderSpec{}).Name():
 		ibmcloudProviderSpec := &credreqv1.IBMCloudProviderSpec{}
-		if err := codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, ibmcloudProviderSpec); err != nil {
+		if err := credreqv1.Codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, ibmcloudProviderSpec); err != nil {
 			return nil, errors.Wrap(err, "Failed to decode the provider spec")
 		}
 		policies = ibmcloudProviderSpec.Policies
 	case reflect.TypeOf(credreqv1.IBMCloudPowerVSProviderSpec{}).Name():
 		ibmCloudPowerVSProviderSpec := &credreqv1.IBMCloudPowerVSProviderSpec{}
-		if err := codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, ibmCloudPowerVSProviderSpec); err != nil {
+		if err := credreqv1.Codec.DecodeProviderSpec(s.cr.Spec.ProviderSpec, ibmCloudPowerVSProviderSpec); err != nil {
 			return nil, errors.Wrap(err, "Failed to decode the provider spec")
 		}
 		policies = ibmCloudPowerVSProviderSpec.Policies

--- a/pkg/cmd/provisioning/nutanix/create_shared_secrets.go
+++ b/pkg/cmd/provisioning/nutanix/create_shared_secrets.go
@@ -173,13 +173,8 @@ func writeCredReqSecret(cr *credreqv1.CredentialsRequest, targetDir string, cred
 
 func processCredReq(cr *credreqv1.CredentialsRequest, targetDir string, creds *kubernetes.NutanixCredentials) error {
 	// Decode NutanixProviderSpec
-	codec, err := credreqv1.NewCodec()
-	if err != nil {
-		return errors.Wrap(err, "Failed to create credReq codec")
-	}
-
 	nutanixProviderSpec := credreqv1.NutanixProviderSpec{}
-	if err := codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &nutanixProviderSpec); err != nil {
+	if err := credreqv1.Codec.DecodeProviderSpec(cr.Spec.ProviderSpec, &nutanixProviderSpec); err != nil {
 		return errors.Wrap(err, "Failed to decode the provider spec")
 	}
 

--- a/pkg/kubevirt/actuator_test.go
+++ b/pkg/kubevirt/actuator_test.go
@@ -73,18 +73,14 @@ var (
 )
 
 func TestDecodeToUnknown(t *testing.T) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Fatalf("failed to create codec %#v", err)
-	}
 	var raw *runtime.RawExtension
 	aps := minterv1.KubevirtProviderSpec{}
-	raw, err = codec.EncodeProviderSpec(&aps)
+	raw, err := minterv1.Codec.EncodeProviderSpec(&aps)
 	if err != nil {
 		t.Fatalf("failed to encode codec %#v", err)
 	}
 	unknown := runtime.Unknown{}
-	err = codec.DecodeProviderStatus(raw, &unknown)
+	err = minterv1.Codec.DecodeProviderStatus(raw, &unknown)
 	if err != nil {
 		t.Fatalf("should be able to decode to Unknown %#v", err)
 	}
@@ -358,12 +354,7 @@ func existingObjectsAfterCreate(t *testing.T) []runtime.Object {
 }
 
 func testCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Fatalf("error creating Kubevirt codec: %v", err)
-	}
-
-	rawObj, err := codec.EncodeProviderSpec(kubevirtSpec)
+	rawObj, err := minterv1.Codec.EncodeProviderSpec(kubevirtSpec)
 	if err != nil {
 		t.Fatalf("error decoding provider v1 spec: %v", err)
 	}

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -40,7 +40,6 @@ import (
 type OpenStackActuator struct {
 	Client         client.Client
 	RootCredClient client.Client
-	Codec          *minterv1.ProviderCodec
 }
 
 func (a *OpenStackActuator) STSFeatureGateEnabled() bool {
@@ -49,14 +48,7 @@ func (a *OpenStackActuator) STSFeatureGateEnabled() bool {
 
 // NewOpenStackActuator creates a new OpenStack actuator.
 func NewOpenStackActuator(client, rootCredClient client.Client) (*OpenStackActuator, error) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		log.WithError(err).Error("error creating OpenStack codec")
-		return nil, fmt.Errorf("error creating OpenStack codec: %v", err)
-	}
-
 	return &OpenStackActuator{
-		Codec:          codec,
 		Client:         client,
 		RootCredClient: rootCredClient,
 	}, nil

--- a/pkg/operator/cleanup/cleanup_controller_test.go
+++ b/pkg/operator/cleanup/cleanup_controller_test.go
@@ -234,14 +234,7 @@ func createTestNamespace(namespace string) *corev1.Namespace {
 func testStaleCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
 	cr := testPassthroughCredentialsRequest(t)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	awsStatus, err := codec.EncodeProviderStatus(
+	awsStatus, err := minterv1.Codec.EncodeProviderStatus(
 		&minterv1.AWSProviderStatus{
 			User: testAWSUser,
 		})
@@ -256,13 +249,7 @@ func testStaleCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
 }
 
 func testPassthroughCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-	awsProvSpec, err := codec.EncodeProviderSpec(
+	awsProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.AWSProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AWSProviderSpec",

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_azure_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_azure_test.go
@@ -78,13 +78,6 @@ func init() {
 func TestCredentialsRequestAzureReconcile(t *testing.T) {
 	schemeutils.SetupScheme(scheme.Scheme)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		fmt.Printf("error creating codec: %v", err)
-		t.FailNow()
-		return
-	}
-
 	tests := []struct {
 		name               string
 		existing           []runtime.Object
@@ -215,7 +208,6 @@ func TestCredentialsRequestAzureReconcile(t *testing.T) {
 			azureActuator := azureactuator.NewFakeActuator(
 				fakeClient,
 				fakeAdminClient,
-				codec,
 				func(logger log.FieldLogger, clientID, clientSecret, tenantID, subscriptionID string) (*azureactuator.AzureCredentialsMinter, error) {
 					return azureactuator.NewFakeAzureCredentialsMinter(logger,
 						clientID,
@@ -289,14 +281,7 @@ func testAzureCredentialsRequestWithOrphanedCloudResource(t *testing.T) *minterv
 }
 func testAzureCredentialsRequestNeedingCleanup(t *testing.T) *minterv1.CredentialsRequest {
 	cr := testAzureCredentialsRequest(t)
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	azureProviderStatus, err := codec.EncodeProviderStatus(
+	azureProviderStatus, err := minterv1.Codec.EncodeProviderStatus(
 		&minterv1.AzureProviderStatus{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AzureProviderStatus",
@@ -319,14 +304,7 @@ func testAzureCredentialsRequestNeedingCleanup(t *testing.T) *minterv1.Credentia
 }
 
 func testAzureCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	azureProviderSpec, err := codec.EncodeProviderSpec(
+	azureProviderSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.AzureProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AzureProviderSpec",

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -92,13 +92,6 @@ func init() {
 func TestCredentialsRequestGCPReconcile(t *testing.T) {
 	schemeutils.SetupScheme(scheme.Scheme)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		fmt.Printf("error creating codec: %v", err)
-		t.FailNow()
-		return
-	}
-
 	tests := []struct {
 		name              string
 		existing          []runtime.Object
@@ -580,7 +573,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				// already minted, last synced 2 hours ago
 				func() *minterv1.CredentialsRequest {
 					cr := testGCPCredentialsRequestWithPermissions(t)
-					gcpStatus, err := codec.EncodeProviderStatus(
+					gcpStatus, err := minterv1.Codec.EncodeProviderStatus(
 						&minterv1.GCPProviderStatus{
 							TypeMeta: metav1.TypeMeta{
 								Kind: "GCPProviderSpec",
@@ -941,7 +934,6 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				Actuator: &actuator.Actuator{
 					Client:         fakeClient,
 					RootCredClient: fakeAdminClient,
-					Codec:          codec,
 					GCPClientBuilder: func(name string, jsonAUTH []byte) (mintergcp.Client, error) {
 						if string(jsonAUTH) == testRootGCPAuth {
 							return mockRootGCPClient, nil
@@ -1001,14 +993,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 func testGCPCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
 	cr := testGCPPassthroughCredentialsRequest(t)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	gcpStatus, err := codec.EncodeProviderStatus(
+	gcpStatus, err := minterv1.Codec.EncodeProviderStatus(
 		&minterv1.GCPProviderStatus{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "GCPProviderSpec",
@@ -1043,14 +1028,7 @@ func testGCPCredentialsRequestWithDeletionTimestamp(t *testing.T) *minterv1.Cred
 func testGCPCredentialsRequestWithPermissionsWithDeletionTimestamp(t *testing.T) *minterv1.CredentialsRequest {
 	cr := testGCPCredentialsRequestWithPermissions(t)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	gcpStatus, err := codec.EncodeProviderStatus(
+	gcpStatus, err := minterv1.Codec.EncodeProviderStatus(
 		&minterv1.GCPProviderStatus{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "GCPProviderSpec",
@@ -1073,13 +1051,7 @@ func testGCPCredentialsRequestWithPermissionsWithDeletionTimestamp(t *testing.T)
 }
 
 func testGCPPassthroughCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-	gcpProvSpec, err := codec.EncodeProviderSpec(
+	gcpProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.GCPProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "GCPProviderSpec",
@@ -1134,13 +1106,7 @@ func testGCPCredsSecret(namespace, name, jsonAUTH string) *corev1.Secret {
 }
 
 func testGCPCredentialsRequestWithPermissions(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-	gcpProvSpec, err := codec.EncodeProviderSpec(
+	gcpProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.GCPProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "GCPProviderSpec",

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_test.go
@@ -99,13 +99,6 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 		return nil
 	}
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		fmt.Printf("error creating codec: %v", err)
-		t.FailNow()
-		return
-	}
-
 	tests := []struct {
 		name                string
 		existing            []runtime.Object
@@ -1220,7 +1213,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				func() *minterv1.CredentialsRequest {
 					cr := testCredentialsRequest(t)
-					awsProvSpec, err := codec.EncodeProviderSpec(
+					awsProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 						&minterv1.AWSProviderSpec{
 							TypeMeta: metav1.TypeMeta{
 								Kind: "AWSProviderSpec",
@@ -1288,7 +1281,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				testOperatorConfig(""),
 				func() *minterv1.CredentialsRequest {
 					cr := testCredentialsRequest(t)
-					awsProvSpec, err := codec.EncodeProviderSpec(
+					awsProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 						&minterv1.AWSProviderSpec{
 							TypeMeta: metav1.TypeMeta{
 								Kind: "AWSProviderSpec",
@@ -1314,7 +1307,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 
 					cr.Spec.ProviderSpec = awsProvSpec
 
-					awsStatus, err := codec.EncodeProviderStatus(
+					awsStatus, err := minterv1.Codec.EncodeProviderStatus(
 						&minterv1.AWSProviderStatus{
 							User:   testAWSUser,
 							Policy: testAWSUser + "-policy",
@@ -1456,7 +1449,6 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				Actuator: &actuator.AWSActuator{
 					Client:         fakeClient,
 					RootCredClient: fakeAdminClient,
-					Codec:          codec,
 					Scheme:         scheme.Scheme,
 					AWSClientBuilder: func(accessKeyID, secretAccessKey []byte, c client.Client) (minteraws.Client, error) {
 						if string(accessKeyID) == testRootAWSAccessKeyID {
@@ -1471,7 +1463,7 @@ func TestCredentialsRequestReconcile(t *testing.T) {
 				platformType: configv1.AWSPlatformType,
 			}
 
-			_, err = rcr.Reconcile(context.TODO(), reconcile.Request{
+			_, err := rcr.Reconcile(context.TODO(), reconcile.Request{
 				NamespacedName: types.NamespacedName{
 					Name:      testCRName,
 					Namespace: testNamespace,
@@ -1581,13 +1573,7 @@ func testPassthroughCredentialsRequestWithLastSyncResourceVersion(t *testing.T, 
 
 // passthrough credentialsrequest objects have no awsStatus
 func testPassthroughCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-	awsProvSpec, err := codec.EncodeProviderSpec(
+	awsProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.AWSProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AWSProviderSpec",
@@ -1629,14 +1615,7 @@ func testPassthroughCredentialsRequest(t *testing.T) *minterv1.CredentialsReques
 func testCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
 	cr := testPassthroughCredentialsRequest(t)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	awsStatus, err := codec.EncodeProviderStatus(
+	awsStatus, err := minterv1.Codec.EncodeProviderStatus(
 		&minterv1.AWSProviderStatus{
 			User: testAWSUser,
 		})

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_vsphere_test.go
@@ -18,7 +18,6 @@ package credentialsrequest
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/golang/mock/gomock"
@@ -58,13 +57,6 @@ func init() {
 
 func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 	schemeutils.SetupScheme(scheme.Scheme)
-
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		fmt.Printf("error creating codec: %v", err)
-		t.FailNow()
-		return
-	}
 
 	tests := []struct {
 		name          string
@@ -202,7 +194,6 @@ func TestCredentialsRequestVSphereReconcile(t *testing.T) {
 				Actuator: &actuator.VSphereActuator{
 					Client:         fakeClient,
 					RootCredClient: fakeAdminClient,
-					Codec:          codec,
 				},
 				platformType: configv1.VSpherePlatformType,
 			}
@@ -260,14 +251,7 @@ func testVSphereCredentialsRequestWithDeletionTimestamp(t *testing.T) *minterv1.
 }
 
 func testVSphereCredentialsRequest(t *testing.T) *minterv1.CredentialsRequest {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-		return nil
-	}
-
-	vsphereProvSpec, err := codec.EncodeProviderSpec(
+	vsphereProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.VSphereProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "VSphereProviderSpec",

--- a/pkg/operator/credentialsrequest/status_test.go
+++ b/pkg/operator/credentialsrequest/status_test.go
@@ -25,7 +25,7 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 
@@ -47,25 +47,20 @@ var (
 func TestClusterOperatorStatus(t *testing.T) {
 	schemeutils.SetupScheme(scheme.Scheme)
 
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		t.Logf("error creating new codec: %v", err)
-		t.FailNow()
-	}
-
-	defaultAWSProviderConfig, err = testAWSProviderConfig(codec)
+	var err error
+	defaultAWSProviderConfig, err = testAWSProviderConfig()
 	if err != nil {
 		t.Logf("error creating test AWS ProviderConfig: %v", err)
 		t.FailNow()
 	}
 
-	defaultAzureProviderConfig, err = testAzureProviderConfig(codec)
+	defaultAzureProviderConfig, err = testAzureProviderConfig()
 	if err != nil {
 		t.Logf("error creating test Azure ProviderConfig: %v", err)
 		t.FailNow()
 	}
 
-	defaultGCPProviderConfig, err = testGCPProviderConfig(codec)
+	defaultGCPProviderConfig, err = testGCPProviderConfig()
 	if err != nil {
 		t.Logf("error creating test GCP ProviderConfig: %v", err)
 		t.FailNow()
@@ -262,8 +257,8 @@ func testCredentialsRequestWithStatus(name string, provisioned bool, conditions 
 	}
 }
 
-func testAWSProviderConfig(codec *minterv1.ProviderCodec) (*runtime.RawExtension, error) {
-	awsProvSpec, err := codec.EncodeProviderSpec(
+func testAWSProviderConfig() (*runtime.RawExtension, error) {
+	awsProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.AWSProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AWSProviderSpec",
@@ -284,8 +279,8 @@ func testAWSProviderConfig(codec *minterv1.ProviderCodec) (*runtime.RawExtension
 	return awsProvSpec, err
 }
 
-func testGCPProviderConfig(codec *minterv1.ProviderCodec) (*runtime.RawExtension, error) {
-	gcpProvSpec, err := codec.EncodeProviderSpec(
+func testGCPProviderConfig() (*runtime.RawExtension, error) {
+	gcpProvSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.GCPProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "GCPProviderSpec",
@@ -298,8 +293,8 @@ func testGCPProviderConfig(codec *minterv1.ProviderCodec) (*runtime.RawExtension
 	return gcpProvSpec, err
 }
 
-func testAzureProviderConfig(codec *minterv1.ProviderCodec) (*runtime.RawExtension, error) {
-	azureProviderSpec, err := codec.EncodeProviderSpec(
+func testAzureProviderConfig() (*runtime.RawExtension, error) {
+	azureProviderSpec, err := minterv1.Codec.EncodeProviderSpec(
 		&minterv1.AzureProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AzureProviderSpec",

--- a/pkg/operator/metrics/metrics_test.go
+++ b/pkg/operator/metrics/metrics_test.go
@@ -22,8 +22,6 @@ import (
 )
 
 var (
-	codec *credreqv1.ProviderCodec
-
 	missingTargetNamespaceCond = credreqv1.CredentialsRequestCondition{
 		Type:   credreqv1.MissingTargetNamespace,
 		Status: corev1.ConditionTrue,
@@ -51,12 +49,6 @@ var (
 )
 
 func TestSecretGetter(t *testing.T) {
-	var err error
-	codec, err = credreqv1.NewCodec()
-	if err != nil {
-		t.Fatalf("failed to create codec: %v", err)
-	}
-
 	configv1.AddToScheme(scheme.Scheme)
 
 	logger := log.WithField("controller", "metricscontrollertest")
@@ -135,12 +127,6 @@ func TestSecretGetter(t *testing.T) {
 }
 
 func TestCredentialsRequests(t *testing.T) {
-	var err error
-	codec, err = credreqv1.NewCodec()
-	if err != nil {
-		t.Fatalf("failed to create codec: %v", err)
-	}
-
 	credreqv1.AddToScheme(scheme.Scheme)
 	configv1.AddToScheme(scheme.Scheme)
 
@@ -381,7 +367,7 @@ func testAWSCredRequest(name string) credreqv1.CredentialsRequest {
 		Spec: credreqv1.CredentialsRequestSpec{},
 	}
 
-	awsProviderSpec, err := codec.EncodeProviderSpec(
+	awsProviderSpec, err := credreqv1.Codec.EncodeProviderSpec(
 		&credreqv1.AWSProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "AWSProviderSpec",
@@ -396,7 +382,7 @@ func testAWSCredRequest(name string) credreqv1.CredentialsRequest {
 }
 
 func testGCPCredRequest(name string) credreqv1.CredentialsRequest {
-	gcpProviderSpec, err := codec.EncodeProviderSpec(
+	gcpProviderSpec, err := credreqv1.Codec.EncodeProviderSpec(
 		&credreqv1.GCPProviderSpec{
 			TypeMeta: metav1.TypeMeta{
 				Kind: "GCPProviderSpec",

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -146,12 +146,8 @@ func GetAuth(ctx context.Context, c client.Client) (*configv1.Authentication, er
 // GetCredentialsRequestCloudType decodes a Spec.ProviderSpec and returns the kind
 // field.
 func GetCredentialsRequestCloudType(providerSpec *runtime.RawExtension) (string, error) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		return "", err
-	}
 	unknown := runtime.Unknown{}
-	err = codec.DecodeProviderSpec(providerSpec, &unknown)
+	err := minterv1.Codec.DecodeProviderSpec(providerSpec, &unknown)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -51,7 +51,6 @@ const (
 type OvirtActuator struct {
 	Client         client.Client
 	RootCredClient client.Client
-	Codec          *minterv1.ProviderCodec
 }
 
 func (a *OvirtActuator) GetFeatureGates(ctx context.Context) (featuregates.FeatureGate, error) {
@@ -72,14 +71,7 @@ type OvirtCreds struct {
 
 // NewActuator creates a new Ovirt actuator.
 func NewActuator(client, rootCredClient client.Client) (*OvirtActuator, error) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		log.WithError(err).Error("error creating Ovirt codec")
-		return nil, fmt.Errorf("error creating Ovirt codec: %v", err)
-	}
-
 	return &OvirtActuator{
-		Codec:          codec,
 		Client:         client,
 		RootCredClient: rootCredClient,
 	}, nil

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -55,14 +55,7 @@ func (a *VSphereActuator) STSFeatureGateEnabled() bool {
 
 // NewVSphereActuator creates a new VSphereActuator.
 func NewVSphereActuator(client, rootCredClient client.Client) (*VSphereActuator, error) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		log.WithError(err).Error("error creating AWS codec")
-		return nil, fmt.Errorf("error creating AWS codec: %v", err)
-	}
-
 	return &VSphereActuator{
-		Codec:          codec,
 		Client:         client,
 		RootCredClient: rootCredClient,
 	}, nil
@@ -364,12 +357,8 @@ func isSecretAnnotated(secret *corev1.Secret) bool {
 }
 
 func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
-	codec, err := minterv1.NewCodec()
-	if err != nil {
-		return false, err
-	}
 	unknown := runtime.Unknown{}
-	err = codec.DecodeProviderSpec(providerSpec, &unknown)
+	err := minterv1.Codec.DecodeProviderSpec(providerSpec, &unknown)
 	if err != nil {
 		return false, err
 	}

--- a/test/e2e/aws/sts/actutator_e2e_test.go
+++ b/test/e2e/aws/sts/actutator_e2e_test.go
@@ -5,6 +5,10 @@ package sts
 
 import (
 	"context"
+	"os"
+	"testing"
+	"time"
+
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/util"
 	corev1 "k8s.io/api/core/v1"
@@ -12,15 +16,12 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/klog/v2"
-	"os"
 	"sigs.k8s.io/e2e-framework/klient/conf"
 	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
 	"sigs.k8s.io/e2e-framework/pkg/env"
 	"sigs.k8s.io/e2e-framework/pkg/envconf"
 	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
 	"sigs.k8s.io/e2e-framework/pkg/features"
-	"testing"
-	"time"
 )
 
 var testenv env.Environment
@@ -109,8 +110,7 @@ func newCredentialsRequest() *minterv1.CredentialsRequest {
 		STSIAMRoleARN: "arn:aws:iam::269733383069:oidc-provider/newstscluster-oidc.s3.us-east-1.amazonaws.com",
 	}
 
-	var codec, _ = minterv1.NewCodec()
-	var ProviderSpec, _ = codec.EncodeProviderSpec(in.DeepCopyObject())
+	var ProviderSpec, _ = minterv1.Codec.EncodeProviderSpec(in.DeepCopyObject())
 	var CredentialsRequestTemplate = &minterv1.CredentialsRequest{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,


### PR DESCRIPTION
pkg/operator: correctly fetch CA for AWS minter

We just need to read *one* and only *one* ConfigMap, so add a Role to
let us and use a live client to just read the thing.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

cmd: add pprof endpoint

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

*: use a global codec

The codec *is* global and only ever changes at compile-time, so
generally the pattern is to declare it as a package global and
intiialize it in an init() method. 30% of our runtime allocations were
building up the scheme/codec on-demand.

Signed-off-by: Steve Kuznetsov <skuznets@redhat.com>

---

