### PR TITLE
OCPBUGS-16684: Set cr.status.provisioned=false on syncErr path

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -341,7 +341,10 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 		}
 		if awsSTSIAMRoleARN == "" {
 			logger.Debug("CredentialsRequest has no awsSTSIAMRoleARN, no reason to sync")
-			return err
+			return &actuatoriface.ActuatorError{
+				ErrReason: minterv1.CredentialsProvisionFailure,
+				Message:   "an empty roleARN was found so no Secret was created",
+			}
 		}
 		cloudTokenPath := cr.Spec.CloudTokenPath
 		if cr.Spec.CloudTokenPath == "" {

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -341,7 +341,7 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 		}
 		if awsSTSIAMRoleARN == "" {
 			logger.Debug("CredentialsRequest has no awsSTSIAMRoleARN, no reason to sync")
-			return nil
+			return err
 		}
 		cloudTokenPath := cr.Spec.CloudTokenPath
 		if cr.Spec.CloudTokenPath == "" {

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -343,7 +343,7 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 			logger.Debug("CredentialsRequest has no awsSTSIAMRoleARN, no reason to sync")
 			return &actuatoriface.ActuatorError{
 				ErrReason: minterv1.CredentialsProvisionFailure,
-				Message:   "an empty roleARN was found so no Secret was created",
+				Message:   "an empty awsSTSIAMRoleARN was found so no Secret was created",
 			}
 		}
 		cloudTokenPath := cr.Spec.CloudTokenPath

--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -606,7 +606,7 @@ func TestDetectSTS(t *testing.T) {
 			CredentialsRequest: func() *minterv1.CredentialsRequest {
 				cr := testCredentialsRequest()
 				var err error
-				cr.Spec.ProviderSpec, err = testAWSProviderConfig("")
+				cr.Spec.ProviderSpec, err = testAWSProviderConfig("not empty	")
 				if err != nil {
 					t.Log(err)
 					t.FailNow()

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -688,20 +688,17 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 
 		var syncErr error
 		syncErr = r.CreateOrUpdateOnCredsExist(ctx, credsExists, syncErr, cr)
-		var provisionErr bool
 		if syncErr != nil {
 			switch t := syncErr.(type) {
 			case actuator.ActuatorStatus:
 				if t.Reason() == minterv1.OrphanedCloudResource {
 					// not a critical error, just set the condition to communicate
-					// what happened
-					provisionErr = false
+					// what happened with updateActuatorConditions()
 				} else {
 					logger.Errorf("error syncing credentials: %v", syncErr)
-					provisionErr = true
 				}
-
-				updateErr := r.UpdateProvisionedStatus(cr, !provisionErr)
+				// syncErr means we failed to provision, so cr.status.provisioned is set false
+				updateErr := r.UpdateProvisionedStatus(cr, false)
 				if updateErr != nil {
 					logger.Errorf("failed to update credentialsrequest status: %v", updateErr)
 				}


### PR DESCRIPTION
I think this cures the bug as long as I tracked from the correct part of the code that was setting `cr.status.provisioned` to true despite a failure to actually provision the Secret.