### PR TITLE
CCO-413: Add dataPermissions to Azure credentials request.

### DIFF
--- a/pkg/apis/cloudcredential/v1/types_azure.go
+++ b/pkg/apis/cloudcredential/v1/types_azure.go
@@ -39,6 +39,14 @@ type AzureProviderSpec struct {
 	// and RoleBindings.
 	// +optional
 	Permissions []string `json:"permissions,omitempty"`
+
+	// DataPermissions is the list of Azure data permissions required to create a more fine-grained custom
+	// role to satisfy the CredentialsRequest.
+	// The DataPermissions field may be provided in addition to RoleBindings. When both fields are specified,
+	// the user-assigned managed identity will have union of permissions defined from both DataPermissions
+	// and RoleBindings.
+	// +optional
+	DataPermissions []string `json:"dataPermissions,omitempty"`
 }
 
 // RoleBinding models part of the Azure RBAC Role Binding

--- a/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
+++ b/pkg/apis/cloudcredential/v1/zz_generated.deepcopy.go
@@ -184,6 +184,11 @@ func (in *AzureProviderSpec) DeepCopyInto(out *AzureProviderSpec) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.DataPermissions != nil {
+		in, out := &in.DataPermissions, &out.DataPermissions
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	return
 }
 


### PR DESCRIPTION
Add a new dataPermissions parameter to the Azure credentials request and plumb it through to the custom role that is attached to the generated user-assigned managed identity.