### PR TITLE
OCPBUGS-17049: update lastSyncGeneration in STS flow sync success

### DIFF
--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -727,6 +727,11 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 			if updateErr != nil {
 				logger.Errorf("failed to update credentialsrequest status: %v", updateErr)
 			}
+			err = utils.UpdateStatus(r.Client, origCR, cr, logger)
+			if err != nil {
+				logger.Errorf("error updating status: %v", err)
+				return reconcile.Result{}, err
+			}
 		}
 	} else {
 		credentialsRootSecret, err := r.Actuator.GetCredentialsRootSecret(ctx, cr)

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -722,7 +722,8 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 			// it worked so clear any actuator conditions if they exist
 			r.updateActuatorConditions(cr, "", nil)
 			updateErr := r.UpdateProvisionedStatus(cr, true)
-
+			// same as in non-STS case, sync happened so update the lastSyncGeneration
+			cr.Status.LastSyncGeneration = origCR.Generation
 			if updateErr != nil {
 				logger.Errorf("failed to update credentialsrequest status: %v", updateErr)
 			}


### PR DESCRIPTION
Should now be properly setting the `lastSyncGeneration` as per the non-STS flow.