### PR TITLE
CCO-401: Add azure-workload-identity-webhook to image references.

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,3 +14,7 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy:latest
+  - name: azure-workload-identity-webhook
+    from:
+      kind: DockerImage
+      Name: quay.io/openshift/azure-workload-identity-webhook


### PR DESCRIPTION
Per https://docs.ci.openshift.org/docs/how-tos/onboarding-a-new-component/#product-builds-and-becoming-part-of-an-openshift-release-image the image must be listed in an image references file to be picked up by CI nightlies.

> 2. Operands managed by second level operators. These images are pulled into the release payload by virtue of being [specified in an image-references file by a second level operator](https://github.com/openshift/cloud-credential-operator/blob/c2bec26d3734e444666024858e76d4ca80dd31cf/manifests/image-references#L9-L12).