### PR TITLE
CCO-372: Azure Workload Identity info in CredsRequests creates a Secret

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -137,6 +137,10 @@ test-e2e-sts:
 	go test -mod=vendor -race -tags e2e ./test/e2e/aws/sts/...
 .PHONY: test-e2e-sts
 
+test-e2e-azident:
+	go test -mod=vendor -race -tags e2e ./test/e2e/azure/azident/...
+.PHONY: test-e2e-azident
+
 vet: verify-govet
 .PHONY: vet
 

--- a/pkg/apis/cloudcredential/v1/types_azure.go
+++ b/pkg/apis/cloudcredential/v1/types_azure.go
@@ -47,6 +47,24 @@ type AzureProviderSpec struct {
 	// and RoleBindings.
 	// +optional
 	DataPermissions []string `json:"dataPermissions,omitempty"`
+
+	// The following fields are only required for Azure Workload Identity.
+	// AzureClientID is the ID of the specific application you created in Azure
+	// +optional
+	AzureClientID string `json:"azureClientID,omitempty"`
+
+	// AzureRegion is the geographic region of the Azure service.
+	// +optional
+	AzureRegion string `json:"azureRegion,omitempty"`
+
+	// Each Azure subscription has an ID associated with it, as does the tenant to which a subscription belongs.
+	// AzureSubscriptionID is the ID of the subscription.
+	// +optional
+	AzureSubscriptionID string `json:"azureSubscriptionID,omitempty"`
+
+	// AzureTenantID is the ID of the tenant to which the subscription belongs.
+	// +optional
+	AzureTenantID string `json:"azureTenantID,omitempty"`
 }
 
 // RoleBinding models part of the Azure RBAC Role Binding

--- a/pkg/azure/const.go
+++ b/pkg/azure/const.go
@@ -1,11 +1,12 @@
 package azure
 
 const (
-	AzureClientID       = "azure_client_id"
-	AzureClientSecret   = "azure_client_secret"
-	AzureRegion         = "azure_region"
-	AzureResourceGroup  = "azure_resourcegroup"
-	AzureResourcePrefix = "azure_resource_prefix"
-	AzureSubscriptionID = "azure_subscription_id"
-	AzureTenantID       = "azure_tenant_id"
+	AzureClientID           = "azure_client_id"
+	AzureClientSecret       = "azure_client_secret"
+	AzureRegion             = "azure_region"
+	AzureResourceGroup      = "azure_resourcegroup"
+	AzureResourcePrefix     = "azure_resource_prefix"
+	AzureSubscriptionID     = "azure_subscription_id"
+	AzureTenantID           = "azure_tenant_id"
+	AzureFederatedTokenFile = "azure_federated_token_file"
 )

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -531,7 +531,7 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 			logger.Infof("operator set to disabled / manual mode")
 			return reconcile.Result{}, err
 		} else {
-			logger.Infof("operator detects STS enabled cluster")
+			logger.Infof("operator detects timed access token enabled cluster (STS, Workload Identity, etc.)")
 		}
 	}
 

--- a/test/e2e/azure/azident/actutator_e2e_test.go
+++ b/test/e2e/azure/azident/actutator_e2e_test.go
@@ -1,0 +1,134 @@
+//go:build e2e
+// +build e2e
+
+package azident
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
+	"github.com/openshift/cloud-credential-operator/pkg/util"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/klog/v2"
+	"sigs.k8s.io/e2e-framework/klient/conf"
+	"sigs.k8s.io/e2e-framework/klient/k8s/resources"
+	"sigs.k8s.io/e2e-framework/pkg/env"
+	"sigs.k8s.io/e2e-framework/pkg/envconf"
+	"sigs.k8s.io/e2e-framework/pkg/envfuncs"
+	"sigs.k8s.io/e2e-framework/pkg/features"
+)
+
+var testenv env.Environment
+var secret = &corev1.Secret{}
+
+const (
+	name       = "test-azident-creds-req"
+	namespace  = "default"
+	secretName = "test-azident-secret"
+)
+
+func TestMain(m *testing.M) {
+	testenv = env.New()
+	path := conf.ResolveKubeConfigFile()
+	cfg := envconf.NewWithKubeConfig(path)
+	testenv = env.NewWithConfig(cfg)
+	namespace := envconf.RandomName("sample-ns", 16)
+	testenv.Setup(
+		envfuncs.CreateNamespace(namespace),
+	)
+	testenv.Finish(
+		envfuncs.DeleteNamespace(namespace),
+	)
+	os.Exit(testenv.Run(m))
+}
+
+func TestSecretCreationOnCredsRequestWithAzIdentInfo(t *testing.T) {
+	t.Logf("About to create a CredentialsRequest for testing Secret creation")
+	cr := newCredentialsRequest()
+	credReqFeature := features.New("minterv1.CredentialsRequest").
+		Setup(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			// create a CredentialsRequest
+			client := cfg.Client()
+			util.SetupScheme(scheme.Scheme)
+			if err := client.Resources().Create(ctx, cr); err != nil {
+				t.Fatal(err)
+			}
+			// watch for the Secret and trigger action based on the event received.
+			client.Resources().Watch(
+				&corev1.SecretList{},
+				resources.WithFieldSelector(
+					labels.FormatLabels(map[string]string{"metadata.name": secretName}))).
+				WithAddFunc(onAdd(t, *cfg, ctx)).
+				Start(ctx)
+			return ctx
+		}).
+		Assess("secret creation", func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			time.Sleep(2 * time.Minute)
+			if secretName != secret.GetName() {
+				t.Errorf("Secret name is incorrect. Expected: `%s`", secretName)
+			}
+			return context.WithValue(ctx, "test-secret", secret)
+		}).
+		Teardown(func(ctx context.Context, t *testing.T, cfg *envconf.Config) context.Context {
+			if err := cfg.Client().Resources().Delete(ctx, cr); err != nil {
+				t.Fatal(err)
+			}
+			return ctx
+		}).Feature()
+	testenv.Test(t, credReqFeature)
+}
+
+func onAdd(t *testing.T, cfg envconf.Config, ctx context.Context) func(obj interface{}) {
+	time.Sleep(2 * time.Minute)
+	if err := cfg.Client().Resources().Get(ctx, secretName, namespace, secret); err != nil {
+		t.Fatal(err)
+	}
+	if secretName != secret.GetName() {
+		t.Errorf("onAdd watch: Secret name is incorrect. Expected: `%s`", secretName)
+	}
+	klog.InfoS("Found Secret with name %s", secretName)
+	return nil
+}
+
+func newCredentialsRequest() *minterv1.CredentialsRequest {
+	var in = minterv1.AzureProviderSpec{
+		RoleBindings: []minterv1.RoleBinding{
+			{
+				Role: "Owner",
+			},
+		},
+		AzureClientID:       "0420bfd1-ab26-4b80-a9ac-deadbeeff1f9",
+		AzureTenantID:       "6047c7e9-b2ad-488d-a54e-deadbeefa7ee",
+		AzureRegion:         "centralus",
+		AzureSubscriptionID: "8c20ec23-8478-4f46-96f4-deadbeeff185",
+	}
+
+	var ProviderSpec, _ = minterv1.Codec.EncodeProviderSpec(in.DeepCopyObject())
+	var CredentialsRequestTemplate = &minterv1.CredentialsRequest{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: "openshift-cloud-credential-operator",
+		},
+		Spec: minterv1.CredentialsRequestSpec{
+			ProviderSpec: ProviderSpec,
+			SecretRef: corev1.ObjectReference{
+				Name:      secretName,
+				Namespace: namespace,
+			},
+			ServiceAccountNames: []string{
+				"serviceaccountname",
+			},
+			CloudTokenPath: "",
+		},
+	}
+
+	credReq := CredentialsRequestTemplate
+	credReq.Spec.CloudTokenPath = "/var/cloud-token"
+	return credReq
+}


### PR DESCRIPTION
Adds Azure Workload Identity (Timed Access Token) support and e2e test and unit tests.

`pkg/azure/actuator_test.go` should get a review for changes that were needed to pre-existing unit tests. The changes were needed because of the requirements of the new detection for Workload Identity in-use flow.

Known issues:

- [x] - ~Still need to verify OCPBUGS filed against~ the AWS STS work, particularly around properly setting status, conditions and lastSync times that were fixed for AWS STS are not brought back here for Azure.
      * Reviewed the several bug fix PRs against the AWS STS work, most fixes were in credentialsrequest_controller so their all present for this Azure branch as well, just OCPBUGS-16684 had an actuator change that seemed to be needed here.
- [x] - This should be e2e testable with a PR in `release` which actually calls the new Make target: `test-e2e-azident` with the `e2e-azure-manual-oidc` workflow
      * PR to add calling make target to azure e2e is here: https://github.com/openshift/release/pull/42126