### PR TITLE
Revert "CCO-401: Add azure-workload-identity-webhook to image references."

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -14,7 +14,3 @@ spec:
     from:
       kind: DockerImage
       name: quay.io/openshift/origin-kube-rbac-proxy:latest
-  - name: azure-workload-identity-webhook
-    from:
-      kind: DockerImage
-      Name: quay.io/openshift/azure-workload-identity-webhook


### PR DESCRIPTION
Reverts openshift/cloud-credential-operator#586

Per [OpenShift policy](https://github.com/openshift/enhancements/blob/master/enhancements/release/improving-ci-signal.md#quick-revert), we are reverting this breaking change to get CI and/or nightly payloads flowing again.

The last 3 [nightlies](https://amd64.ocp.releases.ci.openshift.org/#4.14.0-0.nightly) have failed with:
error: unable to create a release: operator "cloud-credential-operator" contained an invalid image-references file: no input image tag named "azure-workload-identity-webhook"

To unrevert this, revert this PR, and layer an additional separate commit on top that addresses the problem