### PR TITLE
OCPBUGS-13597: Discover AWS dns suffix from partition and region.

### DIFF
--- a/pkg/cmd/provisioning/aws/create_identity_provider_test.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider_test.go
@@ -25,7 +25,7 @@ import (
 
 const (
 	testInfraName     = "test-infra-name"
-	testRegionName    = "test-region"
+	testRegionName    = "us-west-2"
 	testPublicKeyFile = "publicKeyFile"
 	testPublicKeyData = "-----BEGIN PUBLIC KEY-----" +
 		"\nMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAwlzW80E8Tj19NCuPTdwd" +


### PR DESCRIPTION
DNS suffix is different in China regions `.amazonaws.com.cn` vs `.amazonaws.com` so discover the DNS suffix based on the partition via AWS SDK using the region.