### PR TITLE
OCPBUGS-18246: Add networkResourceGroupName parameter for Azure

### DIFF
--- a/pkg/cmd/provisioning/azure/azure.go
+++ b/pkg/cmd/provisioning/azure/azure.go
@@ -46,6 +46,12 @@ type azureOptions struct {
 	// DeleteResourceGroup is a bool indicating that the OIDC resource group should be deleted when
 	// ccoctl azure delete is invoked with the --delete-oidc-resource-group flag
 	DeleteOIDCResourceGroup bool
+
+	// NetworkResourceGroupName is the name of the Azure resource group for network resources like
+	// the Virtual Network and Subnets used by the cluster. If provided, several operators
+	// (cluster-network-operator, machine-api-operator, and cluster-storage-operator(file)) will be
+	// scoped to the NetworkResourceGroupName.
+	NetworkResourceGroupName string
 }
 
 // NewAzureCmd implements the "azure" subcommand for credentials provisioning

--- a/pkg/cmd/provisioning/azure/create_all.go
+++ b/pkg/cmd/provisioning/azure/create_all.go
@@ -92,6 +92,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		CreateAllOpts.OutputDir,
 		CreateAllOpts.InstallationResourceGroupName,
 		CreateAllOpts.DNSZoneResourceGroupName,
+		CreateAllOpts.NetworkResourceGroupName,
 		CreateAllOpts.UserTags,
 		CreateAllOpts.EnableTechPreview,
 		// dryRun may only be invoked by subcommands create-oidc-issuer and create-managed-identities
@@ -185,6 +186,14 @@ func NewCreateAllCmd() *cobra.Command {
 			"contain no resources if the resource group was previously created. "+
 			"A resource group will be created (with name derived from the --name parameter) if an installation-resource-group-name parameter was not provided. "+
 			"Note that this resource group must be provided as the installation resource group when installing the OpenShift cluster.",
+	)
+	createAllCmd.PersistentFlags().StringVar(
+		&CreateAllOpts.NetworkResourceGroupName,
+		"network-resource-group-name",
+		"",
+		"The name of the Azure resource group in which existing Azure Virtual Network (VNet) infrastructure has been created for cluster installation. "+
+			"Cluster operators which interact with network resources will be scoped to allow management of resources in the network resource group. "+
+			"This is an optional parameter that does not need to be specified when installation will not utilize an existing VNet in the install-config.yaml.",
 	)
 	createAllCmd.PersistentFlags().StringVar(
 		&CreateAllOpts.StorageAccountName,

--- a/pkg/cmd/provisioning/azure/create_managed_identities_test.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities_test.go
@@ -496,6 +496,7 @@ func TestCreateManagedIdentities(t *testing.T) {
 				tempDirName,
 				testInstallResourceGroupName,
 				testDNSZoneResourceGroupName,
+				testNetworkResourceGroupName,
 				testUserTags,
 				test.enableTechPreview,
 				test.dryRun)

--- a/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
@@ -39,6 +39,7 @@ var (
 	testStorageAccountName       = testInfraName
 	testBlobContainerName        = testInfraName
 	testDNSZoneResourceGroupName = testInfraName
+	testNetworkResourceGroupName = "" // not supplied by default
 	testIssuerURL                = fmt.Sprintf("https://%s.blob.core.windows.net/%s", testBlobContainerName, testBlobContainerName)
 
 	testPublicKeyFile = "publicKeyFile"


### PR DESCRIPTION
This optional paramter can be used to specify a resource group containing existing network resources, which (if provided) will be scoped to several network-related operators in addition to the main installation resource group

xref: [OCPBUGS-18246](https://issues.redhat.com//browse/OCPBUGS-18246)

Virtual network related permissions were discovered in the following credentials requests (recent nightly):

```
0000_30_machine-api-operator_00_credentials-request.yaml
53:    - Microsoft.Network/virtualNetworks/delete
54:    - Microsoft.Network/virtualNetworks/read
55:    - Microsoft.Network/virtualNetworks/subnets/delete
56:    - Microsoft.Network/virtualNetworks/subnets/join/action
57:    - Microsoft.Network/virtualNetworks/subnets/read
58:    - Microsoft.Network/virtualNetworks/subnets/write
59:    - Microsoft.Network/virtualNetworks/write

0000_50_cluster-storage-operator_03_credentials_request_azure_file.yaml
17:    - Microsoft.Network/virtualNetworks/subnets/read
18:    - Microsoft.Network/virtualNetworks/subnets/write

0000_50_cluster-network-operator_02-cncc-credentials.yaml
19:    - Microsoft.Network/virtualNetworks/read
```

/assign @abutcher 
/cc @jstuever 