### PR TITLE
OCPBUGS-21745: azure create-managed-identites to add cloud controller manager to network resource group

### DIFF
--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -3,12 +3,13 @@ package azure
 import (
 	"context"
 	"fmt"
-	"k8s.io/utils/strings/slices"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"time"
+
+	"k8s.io/utils/strings/slices"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore/arm/policy"
@@ -48,6 +49,7 @@ type: Opaque`
 	machineAPIOperatorCredentialRequestName         = "openshift-machine-api-azure"
 	clusterStorageOperatorFileCredentialRequestName = "azure-file-csi-driver-operator"
 	clusterNetworkOperatorCredentialRequestName     = "openshift-cloud-network-config-controller-azure"
+	cloudControllerManagerCredentialRequestName     = "openshift-azure-cloud-controller-manager"
 )
 
 // createManagedIdentity creates a user-assigned managed identity for the provided CredentialsRequest
@@ -641,7 +643,7 @@ func createManagedIdentities(client *azureclients.AzureClientWrapper, credReqDir
 		// Additionally scope vnet related CredentialRequest within the networkResourceGroupName,
 		// if one is provided
 		if len(networkResourceGroupName) > 0 {
-			if slices.Contains([]string{machineAPIOperatorCredentialRequestName, clusterStorageOperatorFileCredentialRequestName, clusterNetworkOperatorCredentialRequestName}, credentialsRequest.Name) {
+			if slices.Contains([]string{machineAPIOperatorCredentialRequestName, clusterStorageOperatorFileCredentialRequestName, clusterNetworkOperatorCredentialRequestName, cloudControllerManagerCredentialRequestName}, credentialsRequest.Name) {
 				scopingResourceGroupNames = append(scopingResourceGroupNames, networkResourceGroupName)
 			}
 		}


### PR DESCRIPTION
The Azure cloud controller manager needs access to modify the load balancers, which may exist in a network resource group. This change adds that access to the network resource group when using azure create-manage-identities.