### PR TITLE
OCPBUGS-22369: explicitly set azure oidc bucket to allow public blob access

### DIFF
--- a/pkg/cmd/provisioning/azure/create_oidc_issuer.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer.go
@@ -205,7 +205,10 @@ func ensureStorageAccount(client *azureclients.AzureClientWrapper, storageAccoun
 					Name: to.Ptr(armstorage.SKUNameStandardLRS),
 				},
 				Location: to.Ptr(region),
-				Tags:     mergedResourceTags,
+				Properties: &armstorage.AccountPropertiesCreateParameters{
+					AllowBlobPublicAccess: to.Ptr(true),
+				},
+				Tags: mergedResourceTags,
 			},
 			&armstorage.AccountsClientBeginCreateOptions{})
 		if err != nil {

--- a/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
@@ -437,7 +437,10 @@ func mockStorageAccountBeginCreate(wrapper *azureclients.AzureClientWrapper, res
 			Name: to.Ptr(armstorage.SKUNameStandardLRS),
 		},
 		Location: to.Ptr(region),
-		Tags:     tags,
+		Properties: &armstorage.AccountPropertiesCreateParameters{
+			AllowBlobPublicAccess: to.Ptr(true),
+		},
+		Tags: tags,
 	}
 
 	// This poller is not returned from subsequent PollerWrapper.PollUntilDone() and is just instantiated


### PR DESCRIPTION
The cloud provider is changing the default behavior of the buckets to not be publicly available. This change explicitly sets the bucket created by 'ccoctl azure create' to allow public blob access.