### PR TITLE
CCO-430: Use per-project custom roles instead of per-cluster custom roles

### DIFF
--- a/pkg/cmd/provisioning/gcp/create_all.go
+++ b/pkg/cmd/provisioning/gcp/create_all.go
@@ -60,7 +60,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 // validationForCreateAllCmd will validate the arguments to the command, ensure the destination directory
 // is ready to receive the generated files, and will create the directory if necessary.
 func validationForCreateAllCmd(cmd *cobra.Command, args []string) {
-	if len(CreateWorkloadIdentityPoolOpts.Name) > 32 {
+	if len(CreateAllOpts.Name) > 32 {
 		log.Fatalf("Name can be at most 32 characters long")
 	}
 

--- a/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
@@ -75,7 +75,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 			generateOnly: true,
 			mockGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
-				mockGetProjectName(mockGCPClient, 1)
+				mockGetProjectName(mockGCPClient, 3)
 				mockGetProject(mockGCPClient)
 				return mockGCPClient
 			},
@@ -106,7 +106,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 				mockListServiceAccountsEmpty(mockGCPClient)
 				mockListRolesEmpty(mockGCPClient)
 				mockCreateServiceAccountSuccessful(mockGCPClient)
-				mockGetProjectName(mockGCPClient, 6)
+				mockGetProjectName(mockGCPClient, 8)
 				mockGetProject(mockGCPClient)
 				mockGetProjectIamPolicy(mockGCPClient)
 				mockSetProjectIamPolicy(mockGCPClient)
@@ -140,7 +140,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 			generateOnly: false,
 			mockGCPClient: func(mockCtrl *gomock.Controller) *mockgcp.MockClient {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
-				mockGetProjectName(mockGCPClient, 2)
+				mockGetProjectName(mockGCPClient, 4)
 				mockGetProject(mockGCPClient)
 				mockListServiceAccountsEmpty(mockGCPClient)
 				mockCreateServiceAccountFailed(mockGCPClient)
@@ -164,7 +164,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 				mockGCPClient := mockgcp.NewMockClient(mockCtrl)
 				mockListServiceAccountsNotEmpty(mockGCPClient)
 				mockListRolesNotEmpty(mockGCPClient)
-				mockGetProjectName(mockGCPClient, 6)
+				mockGetProjectName(mockGCPClient, 8)
 				mockGetProject(mockGCPClient)
 				mockGetProjectIamPolicy(mockGCPClient)
 				mockSetProjectIamPolicy(mockGCPClient)
@@ -290,7 +290,7 @@ func mockListRolesNotEmpty(mockGCPClient *mockgcp.MockClient) {
 		&iamadminpb.ListRolesResponse{
 			Roles: []*iamadminpb.Role{
 				{
-					Title: fmt.Sprintf("%s-%s", testName, testCredReqName),
+					Title: fmt.Sprintf("%s-%s", testProject, testCredReqName),
 				},
 			},
 		}, nil).Times(1)

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
@@ -248,7 +248,7 @@ func createIdentityProvider(ctx context.Context, client gcp.Client, name, projec
 // validationForCreateWorkloadIdentityProviderCmd will validate the arguments to the command, ensure the destination directory
 // is ready to receive the generated files, and will create the directory if necessary.
 func validationForCreateWorkloadIdentityProviderCmd(cmd *cobra.Command, args []string) {
-	if len(CreateWorkloadIdentityPoolOpts.Name) > 32 {
+	if len(CreateWorkloadIdentityProviderOpts.Name) > 32 {
 		log.Fatalf("Name can be at most 32 characters long")
 	}
 

--- a/pkg/gcp/actuator/policy.go
+++ b/pkg/gcp/actuator/policy.go
@@ -288,7 +288,8 @@ func serviceAccountNeedsPermissionsUpdate(gcpClient ccgcp.Client, serviceAccount
 			return true, fmt.Errorf("error fetching custom role: %v", err)
 		}
 
-		if !AreSlicesEqualWithoutOrder(role.IncludedPermissions, permissions) {
+		addedPermissions, _ := CalculateSliceDiff(role.IncludedPermissions, permissions)
+		if len(addedPermissions) > 0 {
 			return true, nil
 		}
 	}

--- a/pkg/gcp/actuator/utils_test.go
+++ b/pkg/gcp/actuator/utils_test.go
@@ -1,0 +1,67 @@
+package actuator
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestCalculateSliceDiff(t *testing.T) {
+	tests := []struct {
+		name            string
+		original        []string
+		new             []string
+		expectedAdded   []string
+		expectedRemoved []string
+	}{
+		{
+			name:            "No Differences",
+			original:        []string{"a", "b", "c", "d", "e", "f"},
+			new:             []string{"a", "b", "c", "d", "e", "f"},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{},
+		},
+		{
+			name:            "Only Added",
+			original:        []string{"a", "b", "c"},
+			new:             []string{"a", "b", "c", "d", "e", "f"},
+			expectedAdded:   []string{"d", "e", "f"},
+			expectedRemoved: []string{},
+		},
+		{
+			name:            "Only Removed",
+			original:        []string{"a", "b", "c", "d", "e", "f"},
+			new:             []string{"d", "e", "f"},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{"a", "b", "c"},
+		},
+		{
+			name:            "Added And Removed",
+			original:        []string{"a", "b", "c", "d"},
+			new:             []string{"c", "d", "e", "f"},
+			expectedAdded:   []string{"e", "f"},
+			expectedRemoved: []string{"a", "b"},
+		},
+		{
+			name:            "Empty Original",
+			original:        []string{},
+			new:             []string{"a", "b", "c", "d", "e", "f"},
+			expectedAdded:   []string{"a", "b", "c", "d", "e", "f"},
+			expectedRemoved: []string{},
+		},
+		{
+			name:            "Empty New",
+			original:        []string{"a", "b", "c", "d", "e", "f"},
+			new:             []string{},
+			expectedAdded:   []string{},
+			expectedRemoved: []string{"a", "b", "c", "d", "e", "f"},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			added, removed := CalculateSliceDiff(test.original, test.new)
+			assert.ElementsMatch(t, test.expectedAdded, added)
+			assert.ElementsMatch(t, test.expectedRemoved, removed)
+		})
+	}
+}

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller_gcp_test.go
@@ -684,7 +684,6 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				mockGetProjectIamPolicy(mockGCPClient, testValidPolicyBindings)
 				mockSetProjectIamPolicy(mockGCPClient)
 				mockDeleteServiceAccount(mockGCPClient)
-				mockDeleteRole(mockGCPClient)
 
 				return mockGCPClient
 			},
@@ -932,6 +931,7 @@ func TestCredentialsRequestGCPReconcile(t *testing.T) {
 				Client:      fakeClient,
 				AdminClient: fakeAdminClient,
 				Actuator: &actuator.Actuator{
+					ProjectName:    testGCPProjectName,
 					Client:         fakeClient,
 					RootCredClient: fakeAdminClient,
 					GCPClientBuilder: func(name string, jsonAUTH []byte) (mintergcp.Client, error) {


### PR DESCRIPTION
Because CCO now manages custom roles per-project instead of per-cluster, the name format is fixed instead of random so that it all clusters within the same project will use the same custom roles.

Additionally, by default, custom roles will not be deleted.  To delete per-project custom roles, pass the `--force-delete-custom-roles` flag to `ccoctl`.

xref: https://issues.redhat.com/browse/CCO-430

/assign @jstuever 
/cc @abutcher 