### PR TITLE
CCO-244: gcp-ro-credentialrequest to use granular permissions

### DIFF
--- a/manifests/05-gcp-ro-credentialsrequest.yaml
+++ b/manifests/05-gcp-ro-credentialsrequest.yaml
@@ -10,9 +10,13 @@ spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
-    predefinedRoles:
-    - roles/iam.securityReviewer
-    - roles/iam.roleViewer
+    permissions:
+      - "iam.roles.get"
+      - "iam.serviceAccounts.get"
+      - "iam.serviceAccountKeys.list"
+      - "resourcemanager.projects.get"
+      - "resourcemanager.projects.getIamPolicy"
+      - "serviceusage.services.list"
     skipServiceCheck: true
   secretRef:
     name: cloud-credential-operator-gcp-ro-creds


### PR DESCRIPTION
Switch the gcp-ro credential request to use granular permissions. It is only used by the actuator.needsUpdate() function. Everything else escalates to the root service account. The needsUpdate() function currently requires the following permissions as per the specified function calls.

iam.roles.get:
  getPermissionsFromRoles()
  serviceAccountNeedsPermissionsUpdate()
iam.serviceAccountKeys.list
  serviceAccountKeyExists()
iam.serviceAccounts.get:
  GetServiceAccount()
  serviceAccountNeedsPermissionsUpdate()
resourcemanager.projects.get:
  checkServicesEnabled()
resourcemanager.projects.getIamPolicy:
  serviceAccountNeedsPermissionsUpdate()
serviceusage.services.list:
  checkServicesEnabled()