### PR TITLE
CCO-192: Use Leases for leader election

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -266,7 +266,7 @@ func NewOperator() *cobra.Command {
 
 			kubeClient := kubernetes.NewForConfigOrDie(cfg)
 			lock, err := resourcelock.New(
-				resourcelock.ConfigMapsLeasesResourceLock,
+				resourcelock.LeasesResourceLock,
 				minterv1.CloudCredOperatorNamespace,
 				leaderElectionLockName,
 				kubeClient.CoreV1(),


### PR DESCRIPTION
This is phase 2 of the cutover from ConfigMaps to Leases for leader election. See [CCO-191](https://issues.redhat.com//browse/CCO-191) / #446 / 0139ffd3 for phase 1.

Closes [CCO-192](https://issues.redhat.com//browse/CCO-192)