### PR TITLE
OCPBUGS-20478: Explicitly set the vsphere secret credential data on sync.

### DIFF
--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -294,9 +294,9 @@ func (a *VSphereActuator) syncTargetSecret(ctx context.Context, cr *minterv1.Cre
 			secret.Annotations = map[string]string{}
 		}
 		secret.Annotations[minterv1.AnnotationCredentialsRequest] = fmt.Sprintf("%s/%s", cr.Namespace, cr.Name)
-		if secret.Data == nil {
-			secret.Data = map[string][]byte{}
-		}
+
+		secret.Data = map[string][]byte{}
+
 		for key, value := range secretData {
 			secret.Data[key] = value
 		}


### PR DESCRIPTION
The behavior recently changed to patching the credential secrets as opposed to updating them. As a result, sometimes when a credential is changed it can continue to have pieces of the old credential.

This change overrides the entire vphere credential data to be explicitly set to the new credential. This will remove all old credential data when syncing the new credential.