### PR TITLE
OCPBUGS-23178: Enable GCP sync to undelete custom roles

### DIFF
--- a/pkg/gcp/actuator/policy.go
+++ b/pkg/gcp/actuator/policy.go
@@ -18,6 +18,7 @@ package actuator
 
 import (
 	"fmt"
+
 	"google.golang.org/api/cloudresourcemanager/v1"
 	"google.golang.org/api/iam/v1"
 	iamadminpb "google.golang.org/genproto/googleapis/iam/admin/v1"
@@ -286,6 +287,11 @@ func serviceAccountNeedsPermissionsUpdate(gcpClient ccgcp.Client, serviceAccount
 		role, err := GetRole(gcpClient, roleID, projectName)
 		if err != nil {
 			return true, fmt.Errorf("error fetching custom role: %v", err)
+		}
+
+		// custom roles should not be in the deleted state
+		if role.Deleted {
+			return true, nil
 		}
 
 		addedPermissions, _ := CalculateSliceDiff(role.IncludedPermissions, permissions)

--- a/pkg/gcp/actuator/role.go
+++ b/pkg/gcp/actuator/role.go
@@ -95,6 +95,14 @@ func DeleteRole(gcpClient ccgcp.Client, roleName string) (*iamadminpb.Role, erro
 	return role, err
 }
 
+// UndeleteRole undeletes a previously deleted role that has not yet been pruned
+func UndeleteRole(gcpClient ccgcp.Client, roleName string) (*iamadminpb.Role, error) {
+	role, err := gcpClient.UndeleteRole(context.TODO(), &iamadminpb.UndeleteRoleRequest{
+		Name: roleName,
+	})
+	return role, err
+}
+
 // GenerateRoleID generates a unique ID for the role given project name and credentials request name.
 // The role ID has a max length of 64 chars and can include only letters, numbers, period and underscores
 // we sanitize projectName and crName to make them alphanumeric and then

--- a/pkg/gcp/client.go
+++ b/pkg/gcp/client.go
@@ -48,6 +48,7 @@ type Client interface {
 	CreateRole(context.Context, *iamadminpb.CreateRoleRequest) (*iamadminpb.Role, error)
 	UpdateRole(context.Context, *iamadminpb.UpdateRoleRequest) (*iamadminpb.Role, error)
 	DeleteRole(context.Context, *iamadminpb.DeleteRoleRequest) (*iamadminpb.Role, error)
+	UndeleteRole(context.Context, *iamadminpb.UndeleteRoleRequest) (*iamadminpb.Role, error)
 	ListRoles(context.Context, *iamadminpb.ListRolesRequest) (*iamadminpb.ListRolesResponse, error)
 	GetServiceAccount(context.Context, *iamadminpb.GetServiceAccountRequest) (*iamadminpb.ServiceAccount, error)
 	ListServiceAccountKeys(context.Context, *iamadminpb.ListServiceAccountKeysRequest) (*iamadminpb.ListServiceAccountKeysResponse, error)
@@ -148,6 +149,12 @@ func (c *gcpClient) DeleteRole(ctx context.Context, request *iamadminpb.DeleteRo
 	ctx, cancel := contextWithTimeout(ctx)
 	defer cancel()
 	return c.iamClient.DeleteRole(ctx, request)
+}
+
+func (c *gcpClient) UndeleteRole(ctx context.Context, request *iamadminpb.UndeleteRoleRequest) (*iamadminpb.Role, error) {
+	ctx, cancel := contextWithTimeout(ctx)
+	defer cancel()
+	return c.iamClient.UndeleteRole(ctx, request)
 }
 
 func (c *gcpClient) ListRoles(ctx context.Context, request *iamadminpb.ListRolesRequest) (*iamadminpb.ListRolesResponse, error) {

--- a/pkg/gcp/mock/client_generated.go
+++ b/pkg/gcp/mock/client_generated.go
@@ -526,6 +526,21 @@ func (mr *MockClientMockRecorder) TestIamPermissions(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TestIamPermissions", reflect.TypeOf((*MockClient)(nil).TestIamPermissions), arg0, arg1)
 }
 
+// UndeleteRole mocks base method.
+func (m *MockClient) UndeleteRole(arg0 context.Context, arg1 *admin.UndeleteRoleRequest) (*admin.Role, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UndeleteRole", arg0, arg1)
+	ret0, _ := ret[0].(*admin.Role)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UndeleteRole indicates an expected call of UndeleteRole.
+func (mr *MockClientMockRecorder) UndeleteRole(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UndeleteRole", reflect.TypeOf((*MockClient)(nil).UndeleteRole), arg0, arg1)
+}
+
 // UndeleteWorkloadIdentityPool mocks base method.
 func (m *MockClient) UndeleteWorkloadIdentityPool(arg0 context.Context, arg1 string, arg2 *iam0.UndeleteWorkloadIdentityPoolRequest) (*iam0.Operation, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Previously, the GCP sync would error when attempting to add permissions to a custom role that was deleted and pending pruning. This change ensures the custom roles are undeleted.