### PR TITLE
OCPBUGS-26488: Use live client for metrics

### DIFF
--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -74,7 +74,7 @@ func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 	logger := log.WithField("controller", controllerName)
 
 	mc := &Calculator{
-		Client:   mgr.GetClient(),
+		Client:   utils.LiveClient(mgr),
 		Interval: 2 * time.Minute,
 		log:      logger,
 	}


### PR DESCRIPTION
The controller-runtime client used in metrics calculator, i.e. 
https://github.com/openshift/cloud-credential-operator/blob/77a68ad01e75162bfa04097b22f80d305c192439/pkg/operator/metrics/metrics.go#L77
is unable to GET the root credentials Secret as follows
https://github.com/openshift/cloud-credential-operator/blob/77a68ad01e75162bfa04097b22f80d305c192439/pkg/operator/metrics/metrics.go#L184

This is because above client is backed by a cache which only contains Secrets requested by other components but not the root credentials Secret, see
https://github.com/openshift/cloud-credential-operator/blob/77a68ad01e75162bfa04097b22f80d305c192439/pkg/cmd/operator/cmd.go#L164-L168