### PR TITLE
OCPBUGS-27445: Use cached clients to avoid client side throttling

### DIFF
--- a/pkg/operator/metrics/metrics.go
+++ b/pkg/operator/metrics/metrics.go
@@ -90,7 +90,7 @@ func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 // a standard controller watching Kube resources, it runs periodically and then goes to sleep.
 //
 // This should be used for metrics which do not fit well into controller reconcile loops,
-// things that are calculated globally rather than metrics releated to specific reconciliations.
+// things that are calculated globally rather than metrics related to specific reconciliations.
 type Calculator struct {
 	Client client.Client
 
@@ -178,7 +178,7 @@ func (mc *Calculator) getCloudSecret() (*corev1.Secret, error) {
 	case configv1.KubevirtPlatformType:
 		secretKey.Name = constants.KubevirtCloudCredSecretName
 	default:
-		mc.log.WithField("cloud", platformType).Info("unsupported cloud for determing CCO mode")
+		mc.log.WithField("cloud", platformType).Info("unsupported cloud for determining CCO mode")
 		return nil, nil
 	}
 	err = mc.Client.Get(context.TODO(), secretKey, secret)
@@ -227,7 +227,7 @@ func newAccumulator(client client.Client, logger log.FieldLogger) *credRequestAc
 	}
 
 	// make entries with '0' so we make sure to send updated metrics for any
-	// condititons that may have cleared
+	// conditions that may have cleared
 	for _, c := range credreqv1.FailureConditionTypes {
 		acc.crConditions[c] = 0
 	}

--- a/pkg/operator/metrics/metrics_test.go
+++ b/pkg/operator/metrics/metrics_test.go
@@ -49,7 +49,8 @@ var (
 )
 
 func TestSecretGetter(t *testing.T) {
-	configv1.AddToScheme(scheme.Scheme)
+	err := configv1.Install(scheme.Scheme)
+	assert.NoError(t, err, "error installing configv1 types to scheme")
 
 	logger := log.WithField("controller", "metricscontrollertest")
 
@@ -112,11 +113,12 @@ func TestSecretGetter(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-
-			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.clusterInfra, test.cloudCredsSecret).Build()
+			fakeClient := fake.NewClientBuilder().WithRuntimeObjects(test.clusterInfra).Build()
+			fakeRootClient := fake.NewClientBuilder().WithRuntimeObjects(test.cloudCredsSecret).Build()
 			calc := &Calculator{
-				Client: fakeClient,
-				log:    logger,
+				Client:     fakeClient,
+				rootClient: fakeRootClient,
+				log:        logger,
 			}
 
 			secret, err := calc.getCloudSecret()


### PR DESCRIPTION
Client-side throttling was observed after switching to the live client in the metrics controller in #645. 

This PR:
- Adds a (cached) root client to the Calculator struct for querying the root credential only. 
- Switches back to the default (cached) client (i.e. `mgr.GetClient()`) for querying anything else. 