### PR TITLE
OCPBUGS-16646: GCP to use full project path when testing iam passthrough permissions.

### DIFF
--- a/pkg/operator/utils/gcp/utils.go
+++ b/pkg/operator/utils/gcp/utils.go
@@ -190,6 +190,7 @@ func filterOutPermissions(gcpClient ccgcp.Client, projectName string, permList [
 func CheckPermissionsAgainstPermissionList(gcpClient ccgcp.Client, permList []string, logger log.FieldLogger) (bool, error) {
 
 	projectName := gcpClient.GetProjectName()
+	projectNamePath := fmt.Sprintf(`//cloudresourcemanager.googleapis.com/projects/%s`, projectName)
 
 	filteredPermList, err := filterOutPermissions(gcpClient, projectName, permList, logger)
 	if err != nil {
@@ -210,7 +211,7 @@ func CheckPermissionsAgainstPermissionList(gcpClient ccgcp.Client, permList []st
 			end = permLen
 		}
 		req := &cloudresourcemanager.TestIamPermissionsRequest{Permissions: filteredPermList[i:end]}
-		resp, err := gcpClient.TestIamPermissions(projectName, req)
+		resp, err := gcpClient.TestIamPermissions(projectNamePath, req)
 		if err != nil {
 			return false, fmt.Errorf("error testing permissions: %v", err)
 		}


### PR DESCRIPTION
This change switches from using the GCP project name to the project fully qualified name when testing if the passthrough service account has sufficient permissions. This removes the possibility of collision when other resources have the same name as the project. This should remove the 400 errors for permission being invalid for the wrong resource by these collisions.