### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -53,7 +53,7 @@ spec:
             memory: 20Mi
             cpu: 10m
         terminationMessagePath: /dev/termination-log
-        terminationMessagePolicy: File
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - mountPath: /etc/tls/private
           name: cloud-credential-operator-serving-cert


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.