### PR TITLE
OCPBUGS-28388: Fix the ClusterOperator watch of the status controller

### DIFF
--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -112,13 +112,13 @@ func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 	// always reconcile status when the clusteroperator/cloud-credential changes.
 	if err := c.Watch(source.Kind(operatorCache, &configv1.ClusterOperator{}), handler.EnqueueRequestsFromMapFunc(alwaysReconcileCCOConfigObject), predicate.Funcs{
 		CreateFunc: func(e event.CreateEvent) bool {
-			return e.Object.GetName() == constants.CloudCredClusterOperatorName
+			return e.Object != nil && e.Object.GetName() == constants.CloudCredClusterOperatorName
 		},
 		UpdateFunc: func(e event.UpdateEvent) bool {
-			return e.ObjectNew.GetName() == constants.CloudCredClusterOperatorName
+			return e.ObjectNew != nil && e.ObjectNew.GetName() == constants.CloudCredClusterOperatorName
 		},
 		DeleteFunc: func(e event.DeleteEvent) bool {
-			return e.Object.GetName() == constants.CloudCredClusterOperatorName
+			return e.Object != nil && e.Object.GetName() == constants.CloudCredClusterOperatorName
 		},
 	}); err != nil {
 		return err

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -111,11 +111,14 @@ func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 
 	// always reconcile status when the clusteroperator/cloud-credential changes.
 	if err := c.Watch(source.Kind(operatorCache, &configv1.ClusterOperator{}), handler.EnqueueRequestsFromMapFunc(alwaysReconcileCCOConfigObject), predicate.Funcs{
-		GenericFunc: func(genericEvent event.GenericEvent) bool {
-			if genericEvent.Object == nil {
-				return false
-			}
-			return genericEvent.Object.GetName() == "cloud-credential"
+		CreateFunc: func(e event.CreateEvent) bool {
+			return e.Object.GetName() == constants.CloudCredClusterOperatorName
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			return e.ObjectNew.GetName() == constants.CloudCredClusterOperatorName
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			return e.Object.GetName() == constants.CloudCredClusterOperatorName
 		},
 	}); err != nil {
 		return err

--- a/pkg/operator/status/status_controller.go
+++ b/pkg/operator/status/status_controller.go
@@ -110,7 +110,7 @@ func Add(mgr, rootCredentialManager manager.Manager, kubeConfig string) error {
 	}
 
 	// always reconcile status when the clusteroperator/cloud-credential changes.
-	if err := c.Watch(source.Kind(operatorCache, &configv1.ClusterOperator{}), &handler.EnqueueRequestForObject{}, predicate.Funcs{
+	if err := c.Watch(source.Kind(operatorCache, &configv1.ClusterOperator{}), handler.EnqueueRequestsFromMapFunc(alwaysReconcileCCOConfigObject), predicate.Funcs{
 		GenericFunc: func(genericEvent event.GenericEvent) bool {
 			if genericEvent.Object == nil {
 				return false


### PR DESCRIPTION
Previously the status controller erroneously:
- watches all ClusterOperators. 
- enqueues ClusterOperator/XXX instead of CloudCredential/cluster when informed by ClusterOperator-related events

This PR restricts the watch to ClusterOperator/cloud-credential and make sure the EventHandler always enqueues the same namespaced name (i.e. CloudCredential/cluster). 

See the comment section of the attached JIRA card for a comparison of metrics pre vs post bug fix. 