### PR TITLE
NO-JIRA: Fix user-facing typos

### DIFF
--- a/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
+++ b/bindata/bootstrap/cloudcredential_v1_credentialsrequest_crd.yaml
@@ -148,7 +148,7 @@ spec:
               lastSyncCloudCredsSecretResourceVersion:
                 description: LastSyncCloudCredsSecretResourceVersion is the resource
                   version of the cloud credentials secret resource when the credentials
-                  request resource was last synced. Used to determine if the the cloud
+                  request resource was last synced. Used to determine if the cloud
                   credentials have been updated since the last sync.
                 type: string
               lastSyncGeneration:

--- a/manifests/0000_03_cloud-credential-operator_01_crd.yaml
+++ b/manifests/0000_03_cloud-credential-operator_01_crd.yaml
@@ -148,7 +148,7 @@ spec:
               lastSyncCloudCredsSecretResourceVersion:
                 description: LastSyncCloudCredsSecretResourceVersion is the resource
                   version of the cloud credentials secret resource when the credentials
-                  request resource was last synced. Used to determine if the the cloud
+                  request resource was last synced. Used to determine if the cloud
                   credentials have been updated since the last sync.
                 type: string
               lastSyncGeneration:

--- a/manifests/0000_90_cloud-credential-operator_03_alertrules.yaml
+++ b/manifests/0000_90_cloud-credential-operator_03_alertrules.yaml
@@ -25,7 +25,7 @@ spec:
       annotations:
         message: CredentialsRequest(s) unable to be fulfilled
         summary: One or more CredentialsRequest CRs are unable to be processed.
-        description: While processing a CredentialsRequest, the Cloud Credential Operator encountered an issue. Check the conditions of all CredentialsRequets with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .stats.condition showing a condition type of CredentialsProvisionFailure set to True for more details on the issue.
+        description: While processing a CredentialsRequest, the Cloud Credential Operator encountered an issue. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .stats.condition showing a condition type of CredentialsProvisionFailure set to True for more details on the issue.
       expr: cco_credentials_requests_conditions{condition="CredentialsProvisionFailure"}
         > 0
       for: 5m
@@ -55,7 +55,7 @@ spec:
       annotations:
         message: 1 or more credentials requests are stale and should be deleted. Check the status.conditions on CredentialsRequest CRs to identify the stale one(s).
         summary: One or more CredentialsRequest CRs are stale and should be deleted.
-        description: The Cloud Credential Operator (CCO) has detected one or more stale CredentialsRequest CRs that need to be manually deleted. When the CCO is in Manual credentials mode, it will not automatially clean up stale CredentialsRequest CRs (that may no longer be necessary in the present version of OpenShift because it could involve needing to clean up manually created cloud resources. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .status.condition showing a condition type of StaleCredentials set to True. Determine the appropriate steps to clean up/deprovision any previously provisioned cloud resources. Finally, delete the CredentialsRequest with an 'oc delete'.
+        description: The Cloud Credential Operator (CCO) has detected one or more stale CredentialsRequest CRs that need to be manually deleted. When the CCO is in Manual credentials mode, it will not automatically clean up stale CredentialsRequest CRs (that may no longer be necessary in the present version of OpenShift because it could involve needing to clean up manually created cloud resources. Check the conditions of all CredentialsRequests with 'oc get credentialsrequest -A' to find any CredentialsRequest(s) with a .status.condition showing a condition type of StaleCredentials set to True. Determine the appropriate steps to clean up/deprovision any previously provisioned cloud resources. Finally, delete the CredentialsRequest with an 'oc delete'.
       expr: cco_credentials_requests_conditions{condition="StaleCredentials"}
         > 0
       for: 5m

--- a/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
+++ b/pkg/apis/cloudcredential/v1/types_credentialsrequest.go
@@ -97,7 +97,7 @@ type CredentialsRequestStatus struct {
 
 	// LastSyncCloudCredsSecretResourceVersion is the resource version of the
 	// cloud credentials secret resource when the credentials request resource
-	// was last synced. Used to determine if the the cloud credentials have
+	// was last synced. Used to determine if the cloud credentials have
 	// been updated since the last sync.
 	// +optional
 	LastSyncCloudCredsSecretResourceVersion string `json:"lastSyncCloudCredsSecretResourceVersion,omitempty"`

--- a/pkg/assets/bootstrap/bindata.go
+++ b/pkg/assets/bootstrap/bindata.go
@@ -206,7 +206,7 @@ spec:
               lastSyncCloudCredsSecretResourceVersion:
                 description: LastSyncCloudCredsSecretResourceVersion is the resource
                   version of the cloud credentials secret resource when the credentials
-                  request resource was last synced. Used to determine if the the cloud
+                  request resource was last synced. Used to determine if the cloud
                   credentials have been updated since the last sync.
                 type: string
               lastSyncGeneration:


### PR DESCRIPTION
Fix a few user-facing typos:
- in alert descriptions which are visible in the console
- in the description for `credentialsrequests.status.lastSyncCloudCredsSecretResourceVersion`