### PR TITLE
NO-JIRA: Fix update-codegen.sh

### DIFF
--- a/hack/update-codegen.sh
+++ b/hack/update-codegen.sh
@@ -3,6 +3,8 @@
 set -x
 
 verify="${VERIFY:-}"
+SED_CMD=${SED_CMD:-$(if [[ $(uname) == Darwin ]]; then echo gsed; else echo sed; fi)}
+echo "Using $SED_CMD as the sed command"
 
 # set the passed in directory as a usable GOPATH
 # that deepcopy-gen can operate in
@@ -22,10 +24,10 @@ cd ${REPO_FULL_PATH}
 CODEGEN_PKG=${CODEGEN_PKG:-$(cd ${SCRIPT_ROOT}; ls -d -1 ./vendor/k8s.io/code-generator 2>/dev/null || echo ../../../k8s.io/code-generator)}
 
 # HACK 1: For some reason this script is not executable.
-sed -i 's,^exec \(".*/generate-internal-groups.sh"\),bash \1,g' ${CODEGEN_PKG}/generate-groups.sh
+${SED_CMD} -i 's,^exec \(".*/generate-internal-groups.sh"\),bash \1,g' ${CODEGEN_PKG}/generate-groups.sh
 # HACK 2: For verification we need to ensure we don't remove files
 if test -n "$verify"; then
-  sed -i 's/xargs \-0 rm \-f/xargs -0 echo ""/g' ${CODEGEN_PKG}/generate-internal-groups.sh
+  ${SED_CMD} -i 's/xargs \-0 rm \-f/xargs -0 echo ""/g' ${CODEGEN_PKG}/generate-internal-groups.sh
 fi
 # ...but we have to put it back, or `verify` will puke.
 trap "git checkout ${CODEGEN_PKG}/generate-internal-groups.sh ${CODEGEN_PKG}/generate-groups.sh" EXIT


### PR DESCRIPTION
The following issues are found on update-codegen.sh:
- On MacOS, `sed` interprets the string following `-i` as the `extension` passed to this flag, resulting in the following:
```shell
$ ./hack/update-codegen.sh
...
+ sed -i 's,^exec \(".*/generate-internal-groups.sh"\),bash \1,g' ./vendor/k8s.io/code-generator/generate-groups.sh
sed: 1: "./vendor/k8s.io/code-ge ...": invalid command code .
```
- Two traps could be set on the same signal (EXIT)

This PR:
- Use gsed (aka gnu-sed) for MacOS, sed otherwise. Also see: https://github.com/openshift/hive/pull/2183. 
- Aggregate all cleanup logics into the `cleanup` function so we end up with one single trap
