### PR TITLE
OCPBUGS-28231: Guard upgrading GCP from 4.14 to 4.15 without RoleAdmin permissions

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1380,7 +1380,7 @@ func awsSTSIAMRoleARN(codec *minterv1.ProviderCodec, credentialsRequest *minterv
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *AWSActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, configv1.AWSPlatformType, a.GetCredentialsRootSecretLocation())
 }
 
 func generateAWSCredentialsConfig(accessKeyID, secretAccessKey string) []byte {

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -564,7 +564,7 @@ func (a *Actuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldLogger {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *Actuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.client.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.client.RootCredClient, mode, configv1.AzurePlatformType, a.GetCredentialsRootSecretLocation())
 }
 
 func validateAzureProviderSpec(azureProviderSpec minterv1.AzureProviderSpec) error {

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -856,5 +856,5 @@ func checkServicesEnabled(gcpClient ccgcp.Client, permList []string, logger log.
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *Actuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, configv1.GCPPlatformType, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/kubevirt/actuator.go
+++ b/pkg/kubevirt/actuator.go
@@ -233,5 +233,5 @@ func (a *KubevirtActuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldL
 }
 
 func (a *KubevirtActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, configv1.KubevirtPlatformType, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -209,5 +209,5 @@ func (a *OpenStackActuator) getLogger(cr *minterv1.CredentialsRequest) log.Field
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *OpenStackActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, configv1.OpenStackPlatformType, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -363,7 +363,7 @@ func IsValidMode(operatorMode operatorv1.CloudCredentialsMode) bool {
 //	Manual: check that the CCO's config CR has been annotated properly to signal that the user has performed the pre-upgrade credentials tasks.
 //
 // Note: the upgradeable flag can only stop upgrades from 4.x to 4.y, not 4.x.y to 4.x.z.
-func UpgradeableCheck(kubeClient client.Client, mode operatorv1.CloudCredentialsMode, rootSecret types.NamespacedName) *configv1.ClusterOperatorStatusCondition {
+func UpgradeableCheck(kubeClient client.Client, mode operatorv1.CloudCredentialsMode, platformType configv1.PlatformType, rootSecret types.NamespacedName) *configv1.ClusterOperatorStatusCondition {
 	upgradeableCondition := &configv1.ClusterOperatorStatusCondition{
 		Type: configv1.OperatorUpgradeable,
 	}

--- a/pkg/operator/utils/utils_test.go
+++ b/pkg/operator/utils/utils_test.go
@@ -189,7 +189,7 @@ func TestUpgradeableCheck(t *testing.T) {
 			fakeKubeClient := fake.NewClientBuilder().WithRuntimeObjects(runtimeObjects...).Build()
 
 			// Test
-			returnedCondition := UpgradeableCheck(fakeKubeClient, test.mode, test.rootSecretNameParam)
+			returnedCondition := UpgradeableCheck(fakeKubeClient, test.mode, configv1.NonePlatformType, test.rootSecretNameParam)
 
 			// Assert
 			if test.expectedCondition != nil {

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -287,5 +287,5 @@ func secretDataFrom(ovirtCreds *OvirtCreds) map[string][]byte {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *OvirtActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, configv1.OvirtPlatformType, a.GetCredentialsRootSecretLocation())
 }

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -370,5 +370,5 @@ func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.
 func (a *VSphereActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {
-	return utils.UpgradeableCheck(a.RootCredClient, mode, a.GetCredentialsRootSecretLocation())
+	return utils.UpgradeableCheck(a.RootCredClient, mode, configv1.VSpherePlatformType, a.GetCredentialsRootSecretLocation())
 }


### PR DESCRIPTION
After adding granular permissions to the GCP platform in 4.15, new permission are required on the root credential service account. The GCP platform in mint mode now requires the upgradeable annotation to upgrade from 4.14.x to a newer minor version such as 4.15.0.

This PR should only be applied to 4.14.