### PR TITLE
OCPBUGS-29027: dynamically obtain permissions required for passthrough

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -232,7 +232,6 @@ func CheckPermissionsAgainstActions(awsClient Client, actionList []string, param
 // CheckCloudCredPassthrough will see if the provided creds are good enough to pass through
 // to other components as-is based on the static list of permissions needed by the various
 // users of CredentialsRequests
-// TODO: move away from static list (to dynamic passthrough validation?)
 func CheckCloudCredPassthrough(awsClient Client, params *SimulateParams, logger log.FieldLogger) (bool, error) {
 	return CheckPermissionsAgainstActions(awsClient, credPassthroughActions, params, logger)
 }


### PR DESCRIPTION
On AWS, when CCO is in the default mode and the root credential is not sufficient for mint mode, the secret annotator controller checks if the root credential is good enough for passthrough against a static list of permissions
https://github.com/openshift/cloud-credential-operator/blob/3cf3099b60fbd886dd9582c55373f36419c96fff/pkg/aws/utils.go#L35-L93
This list of perms is outdated. 