### PR TITLE
OCPBUGS-28230: add FallbackToLogsOnError for easier debugging

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -38,6 +38,7 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: webhook-certs
           mountPath: /var/run/app/certs

--- a/bindata/v4.1.0/azure-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/azure-pod-identity-webhook/deployment.yaml
@@ -68,6 +68,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /certs
               name: webhook-certs

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -104,6 +104,7 @@ spec:
           requests:
             cpu: 10m
             memory: 10Mi
+        terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
         - name: webhook-certs
           mountPath: /var/run/app/certs
@@ -264,6 +265,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+          terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /certs
               name: webhook-certs


### PR DESCRIPTION
All openshift operators must include FallbackToLogsOnError to ease debugging.