### PR TITLE
OCPBUGS-31678: aws: remove non-existent permission

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -54,7 +54,6 @@ var (
 		"s3:GetLifecycleConfiguration",
 		"s3:GetBucketLocation",
 		"s3:ListBucket",
-		"s3:HeadBucket",
 		"s3:GetObject",
 		"s3:PutObject",
 		"s3:DeleteObject",


### PR DESCRIPTION
The `HeadBucket` API call requires `s3:ListBucket` instead [1]

[1] https://docs.aws.amazon.com/AmazonS3/latest/API/API_HeadBucket.html