### PR TITLE
OCPBUGS-31290: Dockerfile should keep prior rhel8 behavior for ccoctl default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ FROM registry.ci.openshift.org/ocp/4.16:base-rhel9
 COPY --from=builder_rhel9 /go/src/github.com/openshift/cloud-credential-operator/cloud-credential-operator /usr/bin/cloud-credential-operator
 COPY --from=builder_rhel8 /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/ccoctl.rhel8
 COPY --from=builder_rhel9 /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/ccoctl.rhel9
-COPY --from=builder_rhel9 /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/ccoctl
+COPY --from=builder_rhel8 /go/src/github.com/openshift/cloud-credential-operator/ccoctl /usr/bin/ccoctl
 COPY manifests /manifests
 
 # Update perms so we can copy updated CA if needed


### PR DESCRIPTION
Previously we updated the Dockerfile to default to RHEL9 ccoctl binary. However, in order to remain consistent with prior behavior, we should instead default to the RHEL8 binary.