### PR TITLE
WIP: CCO-579: new ccoctl azure flag to enable selection of cloud environment

### DIFF
--- a/pkg/cmd/provisioning/azure/azure.go
+++ b/pkg/cmd/provisioning/azure/azure.go
@@ -1,12 +1,16 @@
 package azure
 
 import (
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore/cloud"
 	"github.com/spf13/cobra"
 
 	"github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning"
 )
 
 type azureOptions struct {
+	Cloud              string
 	CredRequestDir     string
 	IssuerURL          string
 	Name               string
@@ -69,4 +73,18 @@ func NewAzureCmd() *cobra.Command {
 	createCmd.AddCommand(NewDeleteCmd())
 
 	return createCmd
+}
+
+// SelectCloudConfiguration selects the cloud configuration
+func SelectCloudConfiguration(cloudName string) (cloud.Configuration, error) {
+	switch cloudName {
+	case "AzureChina":
+		return cloud.AzureChina, nil
+	case "AzureGovernment":
+		return cloud.AzureGovernment, nil
+	case "AzurePublic":
+		return cloud.AzurePublic, nil
+	default:
+		return cloud.Configuration{}, fmt.Errorf("invalid cloud name: %s", cloudName)
+	}
 }

--- a/pkg/cmd/provisioning/azure/create_all.go
+++ b/pkg/cmd/provisioning/azure/create_all.go
@@ -25,7 +25,16 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	azureClientWrapper, err := azureclients.NewAzureClientWrapper(CreateAllOpts.SubscriptionID, cred, &policy.ClientOptions{}, false)
+	clientOptions := &policy.ClientOptions{}
+	if CreateAllOpts.Cloud != "" {
+		cloud, err := SelectCloudConfiguration(CreateAllOpts.Cloud)
+		if err != nil {
+			log.Fatalf("Unable to determine cloud configuration: %s", err)
+		}
+		clientOptions.Cloud = cloud
+	}
+
+	azureClientWrapper, err := azureclients.NewAzureClientWrapper(CreateAllOpts.SubscriptionID, cred, clientOptions, false)
 	if err != nil {
 		log.Fatalf("Failed to create Azure client: %s", err)
 	}
@@ -169,6 +178,12 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.MarkPersistentFlagRequired("dnszone-resource-group-name")
 
 	// Optional parameters
+	createAllCmd.PersistentFlags().StringVar(
+		&CreateAllOpts.Cloud,
+		"cloud",
+		"",
+		"The Azure cloud in which to create the resources: AzurePublic, AzureChina, AzureGovernment",
+	)
 	createAllCmd.PersistentFlags().StringVar(
 		&CreateAllOpts.OIDCResourceGroupName,
 		"oidc-resource-group-name",

--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -671,7 +671,16 @@ func createManagedIdentitiesCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	azureClientWrapper, err := azureclients.NewAzureClientWrapper(CreateManagedIdentitiesOpts.SubscriptionID, cred, &policy.ClientOptions{}, false)
+	clientOptions := &policy.ClientOptions{}
+	if CreateManagedIdentitiesOpts.Cloud != "" {
+		cloud, err := SelectCloudConfiguration(CreateManagedIdentitiesOpts.Cloud)
+		if err != nil {
+			log.Fatalf("Unable to determine cloud configuration: %s", err)
+		}
+		clientOptions.Cloud = cloud
+	}
+
+	azureClientWrapper, err := azureclients.NewAzureClientWrapper(CreateManagedIdentitiesOpts.SubscriptionID, cred, clientOptions, false)
 	if err != nil {
 		log.Fatalf("Failed to create Azure client: %s", err)
 	}
@@ -790,6 +799,12 @@ func NewCreateManagedIdentitiesCmd() *cobra.Command {
 	createManagedIdentitiesCmd.MarkPersistentFlagRequired("issuer-url")
 
 	// Optional
+	createManagedIdentitiesCmd.PersistentFlags().StringVar(
+		&CreateManagedIdentitiesOpts.Cloud,
+		"cloud",
+		"",
+		"The Azure cloud in which to create the resources: AzurePublic, AzureChina, AzureGovernment",
+	)
 	createManagedIdentitiesCmd.PersistentFlags().StringVar(
 		&CreateManagedIdentitiesOpts.OIDCResourceGroupName,
 		"oidc-resource-group-name",

--- a/pkg/cmd/provisioning/azure/create_oidc_issuer.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer.go
@@ -474,7 +474,16 @@ func createOIDCIssuerCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	azureClientWrapper, err := azureclients.NewAzureClientWrapper(CreateOIDCIssuerOpts.SubscriptionID, cred, &policy.ClientOptions{}, false)
+	clientOptions := &policy.ClientOptions{}
+	if CreateOIDCIssuerOpts.Cloud != "" {
+		cloud, err := SelectCloudConfiguration(CreateOIDCIssuerOpts.Cloud)
+		if err != nil {
+			log.Fatalf("Unable to determine cloud configuration: %s", err)
+		}
+		clientOptions.Cloud = cloud
+	}
+
+	azureClientWrapper, err := azureclients.NewAzureClientWrapper(CreateOIDCIssuerOpts.SubscriptionID, cred, clientOptions, false)
 	if err != nil {
 		log.Fatalf("Failed to create Azure client: %s", err)
 	}
@@ -580,6 +589,12 @@ func NewCreateOIDCIssuerCmd() *cobra.Command {
 	createOIDCIssuerCmd.MarkPersistentFlagRequired("public-key-file")
 
 	// Optional parameters
+	createOIDCIssuerCmd.PersistentFlags().StringVar(
+		&CreateOIDCIssuerOpts.Cloud,
+		"cloud",
+		"",
+		"The Azure cloud in which to create the resources: AzurePublic, AzureChina, AzureGovernment",
+	)
 	createOIDCIssuerCmd.PersistentFlags().StringVar(
 		&CreateOIDCIssuerOpts.OIDCResourceGroupName,
 		"oidc-resource-group-name",

--- a/pkg/cmd/provisioning/azure/delete.go
+++ b/pkg/cmd/provisioning/azure/delete.go
@@ -239,7 +239,16 @@ func deleteCmd(cmd *cobra.Command, args []string) {
 		log.Fatal(err)
 	}
 
-	azureClientWrapper, err := azureclients.NewAzureClientWrapper(DeleteOpts.SubscriptionID, cred, &policy.ClientOptions{}, false)
+	clientOptions := &policy.ClientOptions{}
+	if DeleteOpts.Cloud != "" {
+		cloud, err := SelectCloudConfiguration(DeleteOpts.Cloud)
+		if err != nil {
+			log.Fatalf("Unable to determine cloud configuration: %s", err)
+		}
+		clientOptions.Cloud = cloud
+	}
+
+	azureClientWrapper, err := azureclients.NewAzureClientWrapper(DeleteOpts.SubscriptionID, cred, clientOptions, false)
 	if err != nil {
 		log.Fatal("Failed to create Azure client")
 	}
@@ -315,6 +324,12 @@ func NewDeleteCmd() *cobra.Command {
 	deleteCmd.MarkPersistentFlagRequired("subscription-id")
 
 	// Optional
+	deleteCmd.PersistentFlags().StringVar(
+		&DeleteOpts.Cloud,
+		"cloud",
+		"",
+		"The Azure cloud in which to create the resources: AzurePublic, AzureChina, AzureGovernment",
+	)
 	deleteCmd.PersistentFlags().BoolVar(
 		&DeleteOpts.DeleteOIDCResourceGroup,
 		"delete-oidc-resource-group",


### PR DESCRIPTION
Add a new --cloud flag to the ccoctl azure subcommand to enable selection of the cloud environment. The options are AzureChina, AzureGovernment, and AzurePublic. If left empty, the default will be selected from azidenity.