### PR TITLE
OCPBUGS-37334: SNYK ignore go-client misreporting

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -4,3 +4,7 @@
 exclude:
   global:
     - vendor/**
+ignore:
+    'SNYK-GOLANG-K8SIOCLIENTGOTRANSPORT-7538822':
+     - '* > k8s.io/client-go/transport':
+        reason: 'Snyk mistakenly identifies v1.17.0-alpha.1 as newer than v0.29.7. client-go has a complicated history of versioning. Presumably, v1.20.0-alpha.1 referred to kubernetes-v1.20. kubernetes tags have since been prefaced by "kubernetes", whereas actual client-go versions resumed numbering from 0.x'


### PR DESCRIPTION
SNYK is misreporting a vulnerability in go-client because it thinks we need v1.17 or higher. However, k8s numbering changed after v1.17 to v0.xx and so SNYK calculates v0.30.2 as less than v1.17.