### PR TITLE
OCPBUGS-36644: Only attempt timed token credentials on supported platforms.

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1398,7 +1398,7 @@ func awsSTSIAMRoleARN(codec *minterv1.ProviderCodec, credentialsRequest *minterv
 }
 
 func (a *AWSActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
-	return false, nil
+	return utils.IsTimedTokenCluster(c, ctx, logger)
 }
 
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -1397,6 +1397,10 @@ func awsSTSIAMRoleARN(codec *minterv1.ProviderCodec, credentialsRequest *minterv
 	return awsSpec.STSIAMRoleARN, nil
 }
 
+func (a *AWSActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
+}
+
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -560,6 +560,10 @@ func (a *Actuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldLogger {
 	})
 }
 
+func (a *Actuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
+}
+
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.

--- a/pkg/azure/actuator.go
+++ b/pkg/azure/actuator.go
@@ -561,7 +561,7 @@ func (a *Actuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldLogger {
 }
 
 func (a *Actuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
-	return false, nil
+	return utils.IsTimedTokenCluster(c, ctx, logger)
 }
 
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -980,6 +980,10 @@ func validateSTSProviderSpec(providerSpec minterv1.GCPProviderSpec) error {
 	return nil
 }
 
+func (a *Actuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
+}
+
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.

--- a/pkg/gcp/actuator/actuator.go
+++ b/pkg/gcp/actuator/actuator.go
@@ -981,7 +981,7 @@ func validateSTSProviderSpec(providerSpec minterv1.GCPProviderSpec) error {
 }
 
 func (a *Actuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
-	return false, nil
+	return utils.IsTimedTokenCluster(c, ctx, logger)
 }
 
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type

--- a/pkg/kubevirt/actuator.go
+++ b/pkg/kubevirt/actuator.go
@@ -36,6 +36,8 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
+var _ actuatoriface.Actuator = (*KubevirtActuator)(nil)
+
 type KubevirtActuator struct {
 	Client         client.Client
 	RootCredClient client.Client
@@ -230,6 +232,10 @@ func (a *KubevirtActuator) getLogger(cr *minterv1.CredentialsRequest) log.FieldL
 		"targetSecret": fmt.Sprintf("%s/%s", cr.Spec.SecretRef.Namespace, cr.Spec.SecretRef.Name),
 		"cr":           fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 	})
+}
+
+func (a *KubevirtActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
 }
 
 func (a *KubevirtActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {

--- a/pkg/openstack/actuator.go
+++ b/pkg/openstack/actuator.go
@@ -37,6 +37,8 @@ import (
 	"github.com/openshift/cloud-credential-operator/pkg/operator/utils"
 )
 
+var _ actuatoriface.Actuator = (*OpenStackActuator)(nil)
+
 type OpenStackActuator struct {
 	Client         client.Client
 	RootCredClient client.Client
@@ -203,6 +205,10 @@ func (a *OpenStackActuator) getLogger(cr *minterv1.CredentialsRequest) log.Field
 		"actuator": "openstack",
 		"cr":       fmt.Sprintf("%s/%s", cr.Namespace, cr.Name),
 	})
+}
+
+func (a *OpenStackActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
 }
 
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type

--- a/pkg/operator/credentialsrequest/actuator/actuator.go
+++ b/pkg/operator/credentialsrequest/actuator/actuator.go
@@ -18,11 +18,14 @@ package actuator
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
+
 	configv1 "github.com/openshift/api/config/v1"
 	operatorv1 "github.com/openshift/api/operator/v1"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	minterv1 "github.com/openshift/cloud-credential-operator/pkg/apis/cloudcredential/v1"
 	"github.com/openshift/cloud-credential-operator/pkg/operator/constants"
@@ -41,6 +44,8 @@ type Actuator interface {
 	Exists(context.Context, *minterv1.CredentialsRequest) (bool, error)
 	// GetCredentialsRootSecretLocation returns the namespace and name where the credentials root secret is stored.
 	GetCredentialsRootSecretLocation() types.NamespacedName
+	// IsTimedTokenCluster returns true if the cluster is capable and configured to use timed token credentials.
+	IsTimedTokenCluster(client.Client, context.Context, log.FieldLogger) (bool, error)
 	// Upgradeable returns a ClusterOperator Upgradeable condition to indicate whether or not this cluster can
 	// be safely upgraded to the next "minor" (4.y) Openshift release.
 	Upgradeable(operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition
@@ -70,6 +75,10 @@ func (a *DummyActuator) Delete(ctx context.Context, cr *minterv1.CredentialsRequ
 // GetCredentialsRootSecretLocation returns the namespace and name where the parent credentials secret is stored.
 func (a *DummyActuator) GetCredentialsRootSecretLocation() types.NamespacedName {
 	return types.NamespacedName{Namespace: constants.CloudCredSecretNamespace, Name: constants.AWSCloudCredSecretName}
+}
+
+func (a *DummyActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
 }
 
 func (a *DummyActuator) Upgradeable(mode operatorv1.CloudCredentialsMode) *configv1.ClusterOperatorStatusCondition {

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -625,7 +625,7 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 	mode, conflict, err := utils.GetOperatorConfiguration(r.Client, logger)
 
 	stsDetected := false
-	stsDetected, _ = utils.IsTimedTokenCluster(r.Client, ctx, logger)
+	stsDetected, _ = r.Actuator.IsTimedTokenCluster(r.Client, ctx, logger)
 	if err != nil {
 		logger.WithError(err).Error("error checking if operator is disabled")
 		return reconcile.Result{}, err

--- a/pkg/ovirt/actuator.go
+++ b/pkg/ovirt/actuator.go
@@ -46,6 +46,8 @@ const (
 	cabundleKey = "ovirt_ca_bundle"
 )
 
+var _ actuatoriface.Actuator = (*OvirtActuator)(nil)
+
 type OvirtActuator struct {
 	Client         client.Client
 	RootCredClient client.Client
@@ -281,6 +283,10 @@ func secretDataFrom(ovirtCreds *OvirtCreds) map[string][]byte {
 		insecureKey: []byte(strconv.FormatBool(ovirtCreds.Insecure)),
 		cabundleKey: []byte(ovirtCreds.CABundle),
 	}
+}
+
+func (a *OvirtActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
 }
 
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type

--- a/pkg/vsphere/actuator/actuator.go
+++ b/pkg/vsphere/actuator/actuator.go
@@ -366,6 +366,10 @@ func isVSphereCredentials(providerSpec *runtime.RawExtension) (bool, error) {
 	return isVSphere, nil
 }
 
+func (a *VSphereActuator) IsTimedTokenCluster(c client.Client, ctx context.Context, logger log.FieldLogger) (bool, error) {
+	return false, nil
+}
+
 // Upgradeable returns a ClusterOperator status condition for the upgradeable type
 // if the system is considered not upgradeable. Otherwise, return nil as the default
 // value is for things to be upgradeable.


### PR DESCRIPTION
Prior to this change, all platforms attempted to reconcile credentials
when in manual mode as if they were in mint mode. At one point, a per
platform featuregate happened to limit which ones were attempting to do
so. However, once the featuregate was removed, there was no further
logic to limit this.
   
This change adds a function to the actuator in order to enable each
platform to decide for itself if time token credentials are supported in
addition to determining if they are configured. This ensures each
platform only attempts to sync in manual mode if it already has the
logic to do so.

The following platforms have timed token credentials enabled:
AWS, Azure, GCP