### PR TITLE
OSASINFRA-3657: Add support for storing OpenStack CA bundles

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ metadata:
 data:
   clouds.yaml: Base64encodeCloudCreds
   clouds.conf: Base64encodeCloudCredsINI
+  cacert: Base64encodeCACert
 ```
 
 ### Ovirt

--- a/pkg/operator/secretannotator/openstack/reconciler.go
+++ b/pkg/operator/secretannotator/openstack/reconciler.go
@@ -156,7 +156,7 @@ func (r *ReconcileCloudCredSecret) Reconcile(ctx context.Context, request reconc
 		return reconcile.Result{}, err
 	}
 
-	clouds, err := openstack.GetRootCloudCredentialsSecretData(secret, r.Logger)
+	clouds, cacert, err := openstack.GetRootCloudCredentialsSecretData(secret, r.Logger)
 	if err != nil {
 		r.Logger.WithError(err).Error("errored getting clouds.yaml from secret")
 		return reconcile.Result{}, err
@@ -169,7 +169,7 @@ func (r *ReconcileCloudCredSecret) Reconcile(ctx context.Context, request reconc
 	}
 
 	if cloudsUpdated {
-		openstack.SetRootCloudCredentialsSecretData(secret, clouds)
+		openstack.SetRootCloudCredentialsSecretData(secret, clouds, cacert)
 		err := r.RootCredClient.Update(context.TODO(), secret)
 		if err != nil {
 			r.Logger.WithError(err).Error("error writing updated root secret")


### PR DESCRIPTION
If a CA bundle is required to talk to your OpenStack then obviously all services that talk to the cloud need to have both credentials and said bundle. Currently, these users can get their credentials via cloud credential operator, but they need to source their CA bundle from elsewhere (typically by extracting it from the cloud controller manager's configuration). This makes configuration of services more complicated than necessary.

Begin the resolution of the issue by allowing users (i.e. the Installer) to store the CA bundle in their root secret and dole this out to anyone who asks for it via a `CredentialsRequest`. Follow-up changes will be needed in places like the Installer and csi-operator to start setting/consuming this.
