### PR TITLE
OCPBUGS-41727: Add AWS region to aws-pod-identity-webhook

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             drop: [ "ALL" ]
         command:
         - /usr/bin/aws-pod-identity-webhook
+        - --aws-default-region=us-east-1
         - --in-cluster=false
         - --tls-cert=/var/run/app/certs/tls.crt
         - --tls-key=/var/run/app/certs/tls.key

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -94,6 +94,7 @@ spec:
             drop: [ "ALL" ]
         command:
         - /usr/bin/aws-pod-identity-webhook
+        - --aws-default-region=us-east-1
         - --in-cluster=false
         - --tls-cert=/var/run/app/certs/tls.crt
         - --tls-key=/var/run/app/certs/tls.key

--- a/pkg/operator/podidentity/awspodidentitywebhook.go
+++ b/pkg/operator/podidentity/awspodidentitywebhook.go
@@ -4,8 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
+	log "github.com/sirupsen/logrus"
+
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	awsutils "github.com/openshift/cloud-credential-operator/pkg/operator/utils/aws"
 )
 
 const awsFolder = "v4.1.0/aws-pod-identity-webhook"
@@ -31,4 +38,23 @@ func (a AwsPodIdentity) GetImagePullSpec() string {
 
 func (a AwsPodIdentity) Name() string {
 	return "aws"
+}
+
+func (a AwsPodIdentity) ApplyDeploymentSubstitutionsInPlace(deployment *appsv1.Deployment, client client.Client, logger log.FieldLogger) error {
+	region, err := awsutils.LoadInfrastructureRegion(client, logger)
+	if err != nil {
+		return err
+	}
+
+	// adds --aws-default-region=${region} only when aws region is available from Infra object
+	// default falls back to us-east-1 (which was also formerely the global STS endpoint)
+	if region != "" {
+		for i := range deployment.Spec.Template.Spec.Containers[0].Command {
+			if strings.Contains(deployment.Spec.Template.Spec.Containers[0].Command[i], "--aws-default-region") {
+				deployment.Spec.Template.Spec.Containers[0].Command[i] = fmt.Sprintf("--aws-default-region=%s", region)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/operator/podidentity/azurepodidentitywebhook.go
+++ b/pkg/operator/podidentity/azurepodidentitywebhook.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -45,4 +48,8 @@ func (a AzurePodIdentity) GetImagePullSpec() string {
 
 func (a AzurePodIdentity) Name() string {
 	return "azure"
+}
+
+func (a AzurePodIdentity) ApplyDeploymentSubstitutionsInPlace(deployment *appsv1.Deployment, client client.Client, logger log.FieldLogger) error {
+	return nil
 }

--- a/pkg/operator/podidentity/gcppodidentitywebhook.go
+++ b/pkg/operator/podidentity/gcppodidentitywebhook.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const gcpFolder = "v4.1.0/gcp-pod-identity-webhook"
@@ -31,4 +34,8 @@ func (a GcpPodIdentity) GetImagePullSpec() string {
 
 func (a GcpPodIdentity) Name() string {
 	return "gcp"
+}
+
+func (a GcpPodIdentity) ApplyDeploymentSubstitutionsInPlace(deployment *appsv1.Deployment, client client.Client, logger log.FieldLogger) error {
+	return nil
 }

--- a/pkg/operator/podidentity/podidentitywebhook_controller_test.go
+++ b/pkg/operator/podidentity/podidentitywebhook_controller_test.go
@@ -19,6 +19,7 @@ package podidentity
 import (
 	"context"
 	"fmt"
+	"strings"
 	"testing"
 
 	clientgotesting "k8s.io/client-go/testing"
@@ -144,6 +145,46 @@ func TestPodIdentityWebhookController(t *testing.T) {
 			expectPDB:        true,
 			podIdentityType:  AzurePodIdentity{},
 		},
+		{
+			name: "AWS platform: Cluster infrastructure object has no AWS region set",
+			existing: []runtime.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster",
+					},
+					Status: configv1.InfrastructureStatus{
+						PlatformStatus: &configv1.PlatformStatus{
+							AWS: &configv1.AWSPlatformStatus{
+								Region: "",
+							},
+						},
+					},
+				}},
+			expectErr:        false,
+			expectedReplicas: 2,
+			expectPDB:        true,
+			podIdentityType:  AwsPodIdentity{},
+		},
+		{
+			name: "AWS platform: Cluster infrastructure object has AWS region",
+			existing: []runtime.Object{
+				&configv1.Infrastructure{
+					ObjectMeta: v1.ObjectMeta{
+						Name: "cluster",
+					},
+					Status: configv1.InfrastructureStatus{
+						PlatformStatus: &configv1.PlatformStatus{
+							AWS: &configv1.AWSPlatformStatus{
+								Region: "us-west-1",
+							},
+						},
+					},
+				}},
+			expectErr:        false,
+			expectedReplicas: 2,
+			expectPDB:        true,
+			podIdentityType:  AwsPodIdentity{},
+		},
 	}
 
 	for _, test := range tests {
@@ -170,9 +211,6 @@ func TestPodIdentityWebhookController(t *testing.T) {
 					Namespace: "testNamespace",
 				},
 			})
-			switch {
-
-			}
 
 			if err != nil && !test.expectErr {
 				require.NoError(t, err, "Unexpected error: %v", err)
@@ -194,6 +232,31 @@ func TestPodIdentityWebhookController(t *testing.T) {
 				}
 
 				assert.Equal(t, podIdentityWebhookDeployment.Spec.Template.Spec.Containers[0].Image, expectedImage, "container image matches expected one")
+
+				// Test ApplyDeploymentSubstitutionsInPlace()
+				switch test.podIdentityType {
+				case AwsPodIdentity{}:
+					infra, ok := test.existing[0].(*configv1.Infrastructure)
+					if !ok || infra.Status.PlatformStatus == nil || infra.Status.PlatformStatus.AWS == nil {
+						// skip
+						break
+					}
+
+					expectedRegion := infra.Status.PlatformStatus.AWS.Region
+					if expectedRegion == "" {
+						expectedRegion = "us-east-1"
+					}
+
+					matchesRegionFlag := false
+					for _, arg := range podIdentityWebhookDeployment.Spec.Template.Spec.Containers[0].Command {
+						if strings.Contains(arg, "--aws-default-region") && arg == fmt.Sprintf("--aws-default-region=%s", expectedRegion) {
+							matchesRegionFlag = true
+							break
+						}
+					}
+
+					assert.Equal(t, matchesRegionFlag, true, "cmd", podIdentityWebhookDeployment.Spec.Template.Spec.Containers[0].Command)
+				}
 
 				podDisruptionBudget, err := getPDB(fakeClientset, "pod-identity-webhook", "openshift-cloud-credential-operator")
 				if test.expectPDB {


### PR DESCRIPTION
AWS SDK Go Client v2 (v1 approaching EOL soon) does not allow STS sessions to authenticate without a valid AWS region set in the environment due to STS regional endpoints.

https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html#:~:text=SDK%20for%20Go%20V2%20(1.x)

The pod identity webhook binary injects the region only when the `--aws-default-region` flag is added. This is required for clients to continue authenticating with STS and avoid errors:

```
get identity: get credentials: failed to refresh cached credentials, failed to retrieve credentials, operation error STS: AssumeRoleWithWebIdentity, failed to resolve service endpoint, endpoint rule error, Invalid Configuration: Missing Region
```