### PR TITLE
[release-4.17] OCPBUGS-45938: Add AWS region to aws-pod-identity-webhook

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -26,6 +26,7 @@ spec:
             drop: [ "ALL" ]
         command:
         - /usr/bin/aws-pod-identity-webhook
+        - --aws-default-region=us-east-1
         - --in-cluster=false
         - --tls-cert=/var/run/app/certs/tls.crt
         - --tls-key=/var/run/app/certs/tls.key

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -94,6 +94,7 @@ spec:
             drop: [ "ALL" ]
         command:
         - /usr/bin/aws-pod-identity-webhook
+        - --aws-default-region=us-east-1
         - --in-cluster=false
         - --tls-cert=/var/run/app/certs/tls.crt
         - --tls-key=/var/run/app/certs/tls.key

--- a/pkg/operator/podidentity/awspodidentitywebhook.go
+++ b/pkg/operator/podidentity/awspodidentitywebhook.go
@@ -4,8 +4,15 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"strings"
 
+	log "github.com/sirupsen/logrus"
+
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	awsutils "github.com/openshift/cloud-credential-operator/pkg/operator/utils/aws"
 )
 
 const awsFolder = "v4.1.0/aws-pod-identity-webhook"
@@ -31,4 +38,23 @@ func (a AwsPodIdentity) GetImagePullSpec() string {
 
 func (a AwsPodIdentity) Name() string {
 	return "aws"
+}
+
+func (a AwsPodIdentity) ApplyDeploymentSubstitutionsInPlace(deployment *appsv1.Deployment, client client.Client, logger log.FieldLogger) error {
+	region, err := awsutils.LoadInfrastructureRegion(client, logger)
+	if err != nil {
+		return err
+	}
+
+	// adds --aws-default-region=${region} only when aws region is available from Infra object
+	// default falls back to us-east-1 (which was also formerely the global STS endpoint)
+	if region != "" {
+		for i := range deployment.Spec.Template.Spec.Containers[0].Command {
+			if strings.Contains(deployment.Spec.Template.Spec.Containers[0].Command[i], "--aws-default-region") {
+				deployment.Spec.Template.Spec.Containers[0].Command[i] = fmt.Sprintf("--aws-default-region=%s", region)
+			}
+		}
+	}
+
+	return nil
 }

--- a/pkg/operator/podidentity/azurepodidentitywebhook.go
+++ b/pkg/operator/podidentity/azurepodidentitywebhook.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const (
@@ -45,4 +48,8 @@ func (a AzurePodIdentity) GetImagePullSpec() string {
 
 func (a AzurePodIdentity) Name() string {
 	return "azure"
+}
+
+func (a AzurePodIdentity) ApplyDeploymentSubstitutionsInPlace(deployment *appsv1.Deployment, client client.Client, logger log.FieldLogger) error {
+	return nil
 }

--- a/pkg/operator/podidentity/gcppodidentitywebhook.go
+++ b/pkg/operator/podidentity/gcppodidentitywebhook.go
@@ -5,7 +5,10 @@ import (
 	"fmt"
 	"os"
 
+	log "github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/client-go/kubernetes"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 const gcpFolder = "v4.1.0/gcp-pod-identity-webhook"
@@ -31,4 +34,8 @@ func (a GcpPodIdentity) GetImagePullSpec() string {
 
 func (a GcpPodIdentity) Name() string {
 	return "gcp"
+}
+
+func (a GcpPodIdentity) ApplyDeploymentSubstitutionsInPlace(deployment *appsv1.Deployment, client client.Client, logger log.FieldLogger) error {
+	return nil
 }


### PR DESCRIPTION
Manual cherry-pick of https://github.com/openshift/cloud-credential-operator/pull/798 as bot cherry-picking automation failed to apply due to minor conflicts.