### PR TITLE
CCO-626: pkg/operator/utils: Log diff on CredentialsRequest status change

### DIFF
--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -3,7 +3,6 @@ package utils
 import (
 	"context"
 	"fmt"
-	"reflect"
 	"strconv"
 	"strings"
 
@@ -17,6 +16,7 @@ import (
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/google/go-cmp/cmp"
 	log "github.com/sirupsen/logrus"
 
 	configv1 "github.com/openshift/api/config/v1"
@@ -477,8 +477,8 @@ func UpdateStatus(client client.Client, origCR, newCR *minterv1.CredentialsReque
 	logger.Debug("updating credentials request status")
 
 	// Update Credentials Request status if changed:
-	if !reflect.DeepEqual(newCR.Status, origCR.Status) {
-		logger.Infof("status has changed, updating")
+	if diff := cmp.Diff(origCR.Status, newCR.Status); diff != "" {
+		logger.Infof("Updating status due to diff: %v", diff)
 		err := client.Status().Update(context.TODO(), newCR)
 		if err != nil {
 			logger.WithError(err).Error("error updating credentials request")

--- a/pkg/operator/utils/utils.go
+++ b/pkg/operator/utils/utils.go
@@ -478,7 +478,8 @@ func UpdateStatus(client client.Client, origCR, newCR *minterv1.CredentialsReque
 
 	// Update Credentials Request status if changed:
 	if diff := cmp.Diff(origCR.Status, newCR.Status); diff != "" {
-		logger.Infof("Updating status due to diff: %v", diff)
+		logger.Info("status has changed, updating")
+		logger.Debugf("Status diff: %v", diff)
 		err := client.Status().Update(context.TODO(), newCR)
 		if err != nil {
 			logger.WithError(err).Error("error updating credentials request")


### PR DESCRIPTION
`status has changed, updating` shows that *something* is changing. But without a diff, it's hard to figure out what.  For example in [this recent CI run][1]:

```console
$ curl -s https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_cloud-credential-operator/789/pull-ci-openshift-cloud-credential-operator-master-e2e-aws-manual-oidc/1864768460005838848/artifacts/e2e-aws-manual-oidc/gather-extra/artifacts/pods/openshift-cloud-credential-operator_cloud-credential-operator-64bcbb54cc-vzs5s_cloud-credential-operator.log | grep -1 ingress | tail -n13
--
time="2024-12-05T21:44:49Z" level=info msg="status has changed, updating" controller=credreq cr=openshift-cloud-credential-operator/aws-ebs-csi-driver-operator secret=openshift-cluster-csi-drivers/ebs-cloud-credentials
time="2024-12-05T21:44:49Z" level=info msg="operator detects timed access token enabled cluster (STS, Workload Identity, etc.)" controller=credreq cr=openshift-cloud-credential-operator/openshift-ingress
time="2024-12-05T21:44:49Z" level=info msg="syncing credentials request" controller=credreq cr=openshift-cloud-credential-operator/openshift-ingress
time="2024-12-05T21:44:49Z" level=info msg="status has changed, updating" controller=credreq cr=openshift-cloud-credential-operator/openshift-ingress secret=openshift-ingress-operator/cloud-credentials
time="2024-12-05T21:44:49Z" level=info msg="reconciling clusteroperator status"
--
time="2024-12-05T21:44:51Z" level=info msg="reconciling clusteroperator status"
time="2024-12-05T21:44:52Z" level=info msg="operator detects timed access token enabled cluster (STS, Workload Identity, etc.)" controller=credreq cr=openshift-cloud-credential-operator/openshift-ingress
time="2024-12-05T21:44:52Z" level=info msg="syncing credentials request" controller=credreq cr=openshift-cloud-credential-operator/openshift-ingress
time="2024-12-05T21:44:52Z" level=info msg="reconciling clusteroperator status"
time="2024-12-05T21:44:52Z" level=info msg="status has changed, updating" controller=credreq cr=openshift-cloud-credential-operator/openshift-ingress secret=openshift-ingress-operator/cloud-credentials
time="2024-12-05T21:44:52Z" level=info msg="operator detects timed access token enabled cluster (STS, Workload Identity, etc.)" controller=credreq cr=openshift-cloud-credential-operator/openshift-machine-api-aws
```

Is that a hot loop?  Is something really changing?  Hard to debug.

With this commit, we'll log the change we make.  It will increase the log level when there's a hot loop, but it will also make it easier for us to identify and fix hot loops, so overall log verbosity should go down (more text per update * orders of magnitude fewer updates).

[1]: https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cloud-credential-operator/789/pull-ci-openshift-cloud-credential-operator-master-e2e-aws-manual-oidc/1864768460005838848