### PR TITLE
NO-JIRA: Add dry-run on aws create-all command

### DIFF
--- a/pkg/cmd/provisioning/aws/create-iam-roles.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles.go
@@ -69,7 +69,7 @@ func createIAMRoles(client aws.Client, identityProviderARN, PermissionsBoundaryA
 
 func processCredentialsRequests(awsClient aws.Client, credReqs []*credreqv1.CredentialsRequest, identityProviderARN, PermissionsBoundaryARN, name, targetDir string, generateOnly bool) error {
 
-	issuerURL, err := getIssuerURLFromIdentityProvider(awsClient, identityProviderARN)
+	issuerURL, err := getIssuerURLFromIdentityProvider(awsClient, identityProviderARN, generateOnly)
 	if err != nil {
 		return err
 	}
@@ -270,7 +270,11 @@ func createRolePolicyDocument(oidcProviderARN, issuerURL, namespace string, serv
 	return policy, nil
 }
 
-func getIssuerURLFromIdentityProvider(awsClient aws.Client, idProviderARN string) (string, error) {
+func getIssuerURLFromIdentityProvider(awsClient aws.Client, idProviderARN string, dryRun bool) (string, error) {
+	if dryRun {
+		return "<enter_issuer_url_here>", nil
+	}
+
 	idProvider, err := awsClient.GetOpenIDConnectProvider(&iam.GetOpenIDConnectProviderInput{
 		OpenIDConnectProviderArn: awssdk.String(idProviderARN),
 	})

--- a/pkg/cmd/provisioning/aws/create_all.go
+++ b/pkg/cmd/provisioning/aws/create_all.go
@@ -37,13 +37,13 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		log.Fatalf("Failed to create public/private key pair: %s", err)
 	}
 
-	identityProviderARN, err := createIdentityProvider(awsClient, CreateAllOpts.Name, CreateAllOpts.Region, publicKeyPath, CreateAllOpts.TargetDir, CreateAllOpts.CreatePrivateS3Bucket, false)
+	identityProviderARN, err := createIdentityProvider(awsClient, CreateAllOpts.Name, CreateAllOpts.Region, publicKeyPath, CreateAllOpts.TargetDir, CreateAllOpts.CreatePrivateS3Bucket, CreateAllOpts.DryRun)
 	if err != nil {
 		log.Fatalf("Failed to create Identity provider: %s", err)
 	}
 
 	err = createIAMRoles(awsClient, identityProviderARN, CreateAllOpts.PermissionsBoundaryARN, CreateAllOpts.Name,
-		CreateAllOpts.CredRequestDir, CreateAllOpts.TargetDir, CreateAllOpts.EnableTechPreview, false)
+		CreateAllOpts.CredRequestDir, CreateAllOpts.TargetDir, CreateAllOpts.EnableTechPreview, CreateAllOpts.DryRun)
 	if err != nil {
 		log.Fatalf("Failed to process IAM Roles: %s", err)
 	}
@@ -106,6 +106,7 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
 	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.CreatePrivateS3Bucket, "create-private-s3-bucket", false, "Create private S3 bucket with public CloudFront OIDC endpoint")
+	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.DryRun, "dry-run", false, "Skip creating objects, and just save what would have been created into files")
 
 	return createAllCmd
 }


### PR DESCRIPTION
As per title, enable `--dry-run` when generating all AWS assets by running `ccoctl aws create-all`.
The change should be quite straightforward as the vast majority of the code is there, already implemented.
The sole relevant change is in `func getIssuerURLFromIdentityProvider`.