### PR TITLE
CCO-647:  Enable readOnlyRootFilesystem on all containers

### DIFF
--- a/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/aws-pod-identity-webhook/deployment.yaml
@@ -24,6 +24,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ "ALL" ]
+          readOnlyRootFilesystem: true
         command:
         - /usr/bin/aws-pod-identity-webhook
         - --aws-default-region=us-east-1
@@ -53,6 +54,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master

--- a/bindata/v4.1.0/azure-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/azure-pod-identity-webhook/deployment.yaml
@@ -69,6 +69,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /certs
@@ -94,6 +95,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
       volumes:
         - name: webhook-certs
           secret:

--- a/bindata/v4.1.0/gcp-pod-identity-webhook/deployment.yaml
+++ b/bindata/v4.1.0/gcp-pod-identity-webhook/deployment.yaml
@@ -42,6 +42,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs/
@@ -67,6 +68,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
       volumes:
         - name: webhook-certs
           secret:

--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -45,6 +45,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          readOnlyRootFilesystem: true
         ports:
         - containerPort: 8443
           name: metrics
@@ -77,6 +78,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: ["ALL"]
+          readOnlyRootFilesystem: true
         resources:
           requests:
             cpu: 10m

--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -58,16 +58,9 @@ spec:
         volumeMounts:
         - mountPath: /etc/tls/private
           name: cloud-credential-operator-serving-cert
-      - args:
-        - |
-          if [ -s /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem ]; then
-              echo "Copying system trust bundle"
-              cp -f /var/run/configmaps/trusted-ca-bundle/tls-ca-bundle.pem /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
-          fi
-          exec /usr/bin/cloud-credential-operator operator
-        command:
-        - /bin/bash
-        - -ec
+      - command:
+        - /usr/bin/cloud-credential-operator
+        - operator
         env:
         - name: RELEASE_VERSION
           value: 0.0.1-snapshot
@@ -90,7 +83,7 @@ spec:
             memory: 20Mi
         terminationMessagePolicy: FallbackToLogsOnError
         volumeMounts:
-        - mountPath: /var/run/configmaps/trusted-ca-bundle
+        - mountPath: /etc/pki/ca-trust/extracted/pem
           name: cco-trusted-ca
       nodeSelector:
         node-role.kubernetes.io/master: ""

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -92,6 +92,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop: [ "ALL" ]
+          readOnlyRootFilesystem: true
         command:
         - /usr/bin/aws-pod-identity-webhook
         - --aws-default-region=us-east-1
@@ -121,6 +122,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
       tolerations:
       - effect: NoSchedule
         key: node-role.kubernetes.io/master
@@ -270,6 +272,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /certs
@@ -295,6 +298,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
       volumes:
         - name: webhook-certs
           secret:
@@ -619,6 +623,7 @@ spec:
             allowPrivilegeEscalation: false
             capabilities:
               drop: [ "ALL" ]
+            readOnlyRootFilesystem: true
           terminationMessagePolicy: FallbackToLogsOnError
           volumeMounts:
             - mountPath: /tmp/k8s-webhook-server/serving-certs/
@@ -644,6 +649,7 @@ spec:
         runAsNonRoot: true
         seccompProfile:
           type: RuntimeDefault
+        readOnlyRootFilesystem: true
       volumes:
         - name: webhook-certs
           secret:


### PR DESCRIPTION
The readOnlyRootFilesystem is now explicitly set to True on all containers. In order to for this to work on the cloud-credential-operator container, the tls-ca-bundle.pem mount being reverted to the default location.