### PR TITLE
NO-JIRA: Report the error when syncing STS secrets

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -430,11 +430,11 @@ func (a *AWSActuator) syncSTSSecret(awsSTSIAMRoleARN string, cloudTokenPath stri
 		secret.Type = corev1.SecretTypeOpaque
 		return nil
 	})
-	sLog.WithField("operation", op).Info("processed secret")
+	sLog.WithField("operation", op).WithError(err).Info("processed secret")
 	if err != nil {
 		return &actuatoriface.ActuatorError{
 			ErrReason: minterv1.CredentialsProvisionFailure,
-			Message:   "error processing secret",
+			Message:   fmt.Sprintf("error processing secret: %v", err),
 		}
 	}
 	return nil


### PR DESCRIPTION
When the controller fails to create an STS secret, it doesn't surface the error generated by the k8s client.
The error message is instead quite generic and difficult to troubleshoot:
```
time="2025-03-10T08:58:38Z" level=error msg="error syncing credentials: error syncing creds in mint-mode: error processing secret" controller=credreq cr=openshift-cloud-credential-operator/cluster-init secret=ci/cluster-init-cloud-credentials
```