### PR TITLE
OCPBUGS-55777: Sync OpenStack CA Bundles from legacy location

### DIFF
--- a/pkg/operator/secretannotator/openstack/reconciler.go
+++ b/pkg/operator/secretannotator/openstack/reconciler.go
@@ -18,6 +18,7 @@ package openstack
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -134,7 +135,7 @@ func (r *ReconcileCloudCredSecret) Reconcile(ctx context.Context, request reconc
 	}
 	if conflict {
 		r.Logger.Error("configuration conflict between legacy configmap and operator config")
-		return reconcile.Result{}, fmt.Errorf("configuration conflict")
+		return reconcile.Result{}, errors.New("configuration conflict")
 	}
 	if mode == operatorv1.CloudCredentialsModeManual {
 		r.Logger.Info("operator in disabled / manual mode")
@@ -146,7 +147,7 @@ func (r *ReconcileCloudCredSecret) Reconcile(ctx context.Context, request reconc
 	default:
 		const msg = "OpenStack only supports Passthrough mode"
 		r.Logger.Error(msg)
-		return reconcile.Result{}, fmt.Errorf(msg)
+		return reconcile.Result{}, errors.New(msg)
 	}
 
 	secret := &corev1.Secret{}

--- a/pkg/operator/secretannotator/openstack/reconciler_test.go
+++ b/pkg/operator/secretannotator/openstack/reconciler_test.go
@@ -108,6 +108,14 @@ func TestReconcileCloudCredSecret_Reconcile(t *testing.T) {
 		},
 	}
 
+	ccmConfig := &corev1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cloud-provider-config",
+			Namespace: "openshift-config",
+		},
+		Data: map[string]string{},
+	}
+
 	/*
 		Test parsing of CCO configuration and the resulting annotation of the
 		root secret. Most of this is boilerplate behaviour.
@@ -181,7 +189,7 @@ func TestReconcileCloudCredSecret_Reconcile(t *testing.T) {
 				secret := testSecret(fmt.Sprintf(cloudsWithCACert, correctCACertFile))
 				existing := append(tc.existing, infra, testOperatorConfig(tc.mode))
 				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(existing...).Build()
-				fakeRootCredClient := fake.NewClientBuilder().WithRuntimeObjects(secret).Build()
+				fakeRootCredClient := fake.NewClientBuilder().WithRuntimeObjects(secret, ccmConfig).Build()
 
 				r := &ReconcileCloudCredSecret{
 					Client:         fakeClient,
@@ -270,7 +278,7 @@ func TestReconcileCloudCredSecret_Reconcile(t *testing.T) {
 			t.Run(tc.name, func(t *testing.T) {
 				secret := testSecret(tc.cloudsYAML)
 				fakeClient := fake.NewClientBuilder().WithRuntimeObjects(infra, passthrough).Build()
-				fakeRootCredClient := fake.NewClientBuilder().WithRuntimeObjects(secret).Build()
+				fakeRootCredClient := fake.NewClientBuilder().WithRuntimeObjects(secret, ccmConfig).Build()
 
 				t.Logf("clouds.yaml: %s", tc.cloudsYAML)
 				r := &ReconcileCloudCredSecret{


### PR DESCRIPTION
In #780, we added support for syncing CA bundles from the root credential secret to the generated credential secrets when running on OpenStack clouds. This is a big improvement for OpenShift developers, since it hugely simplifies how we obtain these in other operators and components and removes the need for a number of controllers. However, as things stand, it doesn't help users as it introduces a second place that they must consider when rotating credentials.

Long-term, we would like to remove the CA bundle from the cloud-providers config map. Doing so requires some rework of CCCMO as well as investigation into potential issues caused by CCMs role in early stage bootstrapping. This isn't going to happen in OpenShift 4.19, so for now we opt to leave the current documentation around cert rotation as-is and simply sync the CA cert from the CCM config map to the root credential, if it's set. We can then revert this down the line if needed.

/hold
