### PR TITLE
OCPBUGS-53429: Render: configure proxy on bootstrap static pod

### DIFF
--- a/pkg/cmd/render/render.go
+++ b/pkg/cmd/render/render.go
@@ -104,6 +104,10 @@ spec:
 				ImagePullPolicy: corev1.PullIfNotPresent,
 				Name:            "cloud-credential-operator",
 				VolumeMounts: []corev1.VolumeMount{{
+					MountPath: "/etc/pki/ca-trust/extracted/pem",
+					Name:      "cco-trusted-ca",
+					ReadOnly:  true,
+				}, {
 					MountPath: "/etc/kubernetes/secrets",
 					Name:      "secrets",
 					ReadOnly:  true,
@@ -111,6 +115,13 @@ spec:
 			}},
 			HostNetwork: true,
 			Volumes: []corev1.Volume{{
+				Name: "cco-trusted-ca",
+				VolumeSource: corev1.VolumeSource{
+					HostPath: &corev1.HostPathVolumeSource{
+						Path: "/etc/pki/ca-trust/extracted/pem",
+					},
+				},
+			}, {
 				Name: "secrets",
 				VolumeSource: corev1.VolumeSource{
 					HostPath: &corev1.HostPathVolumeSource{
@@ -221,6 +232,29 @@ func render() error {
 
 		staticPod.Spec.Containers[0].Image = renderOpts.ccoImage
 
+		if installConfig.Proxy != nil {
+			if installConfig.Proxy.HTTPProxy != "" {
+				staticPod.Spec.Containers[0].Env = append(staticPod.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  "HTTP_PROXY",
+					Value: installConfig.Proxy.HTTPProxy,
+				})
+			}
+
+			if installConfig.Proxy.HTTPSProxy != "" {
+				staticPod.Spec.Containers[0].Env = append(staticPod.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  "HTTPS_PROXY",
+					Value: installConfig.Proxy.HTTPSProxy,
+				})
+			}
+
+			if installConfig.Proxy.NoProxy != "" {
+				staticPod.Spec.Containers[0].Env = append(staticPod.Spec.Containers[0].Env, corev1.EnvVar{
+					Name:  "NO_PROXY",
+					Value: installConfig.Proxy.NoProxy,
+				})
+			}
+		}
+
 		podContent, err := sigsyaml.Marshal(&staticPod)
 		if err != nil {
 			return errors.Wrap(err, "failed to encode yaml")
@@ -302,9 +336,23 @@ func isDisabledViaConfigmap() bool {
 	return disabled
 }
 
+type Proxy struct {
+	// +optional
+	HTTPProxy string `json:"httpProxy,omitempty"`
+
+	// +optional
+	HTTPSProxy string `json:"httpsProxy,omitempty"`
+
+	// +optional
+	NoProxy string `json:"noProxy,omitempty"`
+}
+
 type basicInstallConfig struct {
 	CredentialsMode operatorv1.CloudCredentialsMode    `json:"credentialsMode"`
 	Capabilities    *v1.ClusterVersionCapabilitiesSpec `json:"capabilities"`
+
+	// +optional
+	Proxy *Proxy `json:"proxy,omitempty"`
 }
 
 func getInstallConfig() (*basicInstallConfig, error) {


### PR DESCRIPTION
Previously, the render command used string templates to generate the
static pod. This made it difficult to modify the values, forcing all
changes to adhere to the templating interface.

This change migrates the static pod template to a pod struct and uses
yaml marshal to generate the manifest. This enables the values to be set
on the struct prior to generating the manifest. The sigs yaml module is
used purposefully because it is capable of adhering to the json metadata
labels and therefore produce more concise yaml manifests.

Previously, the static pod on the bootstrap machine was not aware of the
cluster-wide proxy configuration. This caused the static pod to be
unable to reach sites that were not allowed directly from the bootstrap
host. This caused installation failure in Mint and Passthrough mode as
the bootstrap process depends on some credentials being populated.

This change injects the proxy env variables into the static pod manifest
when rendered. It also mounts the ca-trust from the bootstrap host into
the pod. This enables the cloud-credential-operator binary to use the
proxy as configured in the environment variables on the static pod.