### PR TITLE
Azure: resolve nil pointer exception when role assignment exists

### DIFF
--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -277,7 +277,9 @@ func ensureRolesAssignedToManagedIdentity(client *azureclients.AzureClientWrappe
 				if err != nil {
 					return errors.Wrapf(err, "failed to assign role %s to user-assigned managed identity", roleBinding.Role)
 				}
-				shouldExistRoleAssignments = append(shouldExistRoleAssignments, roleAssignment)
+				if roleAssignment != nil {
+					shouldExistRoleAssignments = append(shouldExistRoleAssignments, roleAssignment)
+				}
 			}
 		}
 	}
@@ -285,7 +287,7 @@ func ensureRolesAssignedToManagedIdentity(client *azureclients.AzureClientWrappe
 	for _, existingRoleAssignment := range existingRoleAssignments {
 		found := false
 		for _, shouldExistRoleAssignment := range shouldExistRoleAssignments {
-			if *shouldExistRoleAssignment.Name == *existingRoleAssignment.Name {
+			if shouldExistRoleAssignment != nil && *shouldExistRoleAssignment.Name == *existingRoleAssignment.Name {
 				found = true
 			}
 		}


### PR DESCRIPTION
Previously, there was a potential nil pionter exception when provisioning azure managed identies. It was experienced when a role assignment was being created due to it not being in the list of existing role assignemts as reported by Azure, and then Azure reponds that it already exists during creation.

This change checks that the role assignment returned form the create function is not nil before adding it to the list of expected roleAssignemts. It also checks that the expected role assignment entities are not nil before attempting to use their values.

The purpose of storing the expected role assignments is to facilitate deleting role assignments that should be deleted. It does this by comparing the existing role assignments with the list of expected role assignments. This change is compatible with this. The create function is only called when the role assignment is not in the list of existing role assignments. As a result, it will not be considered for deletion regardless of if it exists in the expected list or not.