### PR TITLE
CCO-681: Add network policies with default deny

### DIFF
--- a/manifests/02-networkpolicy-allow-egress.yaml
+++ b/manifests/02-networkpolicy-allow-egress.yaml
@@ -1,0 +1,33 @@
+# Allow egress from cloud-credential-operator to kube api
+# Allow egress from cloud-credential-operator to DNS
+# Allow egress from cloud-credential-operator to external cloud platforms
+# Allow egress from pod-identity-webhook to DNS
+# Allow egress from pod-identity-webhook to external cloud platforms
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-egress
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  egress:
+  - ports:
+    - protocol: TCP
+      port: 1
+      endPort: 65535
+  - ports:
+    - protocol: UDP
+      port: 1
+      endPort: 65535
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - cloud-credential-operator
+      - pod-identity-webhook
+  policyTypes:
+  - Egress

--- a/manifests/02-networkpolicy-allow-ingress-metrics.yaml
+++ b/manifests/02-networkpolicy-allow-ingress-metrics.yaml
@@ -1,0 +1,23 @@
+# Allow ingress to cloud-credential-operator:8443 (metrics)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-metrics
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 8443
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - cloud-credential-operator
+  policyTypes:
+  - Ingress

--- a/manifests/02-networkpolicy-allow-ingress-pprof.yaml
+++ b/manifests/02-networkpolicy-allow-ingress-pprof.yaml
@@ -1,0 +1,23 @@
+# Allow ingress to cloud-credential-operator:6060 (pprof)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-pprof
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 6060
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - cloud-credential-operator
+  policyTypes:
+  - Ingress

--- a/manifests/02-networkpolicy-allow-ingress-webhook.yaml
+++ b/manifests/02-networkpolicy-allow-ingress-webhook.yaml
@@ -1,0 +1,23 @@
+# Allow ingress to pod-identity-webhook:9443 (webhook)
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-ingress-webhook
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  ingress:
+  - ports:
+    - protocol: TCP
+      port: 9443
+  podSelector:
+    matchExpressions:
+    - key: app
+      operator: In
+      values:
+      - pod-identity-webhook
+  policyTypes:
+  - Ingress

--- a/manifests/02-networkpolicy-default-deny.yaml
+++ b/manifests/02-networkpolicy-default-deny.yaml
@@ -1,0 +1,15 @@
+# Default deny all ingress and egress
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: default-deny
+  namespace: openshift-cloud-credential-operator
+  annotations:
+    capability.openshift.io/name: CloudCredential
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+spec:
+  podSelector: {}
+  policyTypes:
+  - Ingress
+  - Egress


### PR DESCRIPTION
This change adds the network policies necessary to maintain functionality of the operator while enforcing a default deny for ingress and egress traffic. It provides the following:

Default deny all ingress and egress
Allow egress from cloud-credential-operator to kube api
Allow egress from cloud-credential-operator to DNS
Allow egress from cloud-credential-operator to external cloud platforms
Allow egress from pod-identity-webhook to DNS
Allow egress from pod-identity-webhook to external cloud platforms
Allow ingress to cloud-credential-operator:8443 (metrics)
Allow ingress to cloud-credential-operator:6060 (pprof)
Allow ingress to pod-identity-webhook:9443 (webhook)