### PR TITLE
OCPBUGS-57349: Use constant for first parameter of fmt.Errorf

### DIFF
--- a/pkg/operator/secretannotator/vsphere/reconciler.go
+++ b/pkg/operator/secretannotator/vsphere/reconciler.go
@@ -160,7 +160,7 @@ func (r *ReconcileCloudCredSecret) validateCloudCredsSecret(secret *corev1.Secre
 	if mode != operatorv1.CloudCredentialsModeDefault && mode != operatorv1.CloudCredentialsModePassthrough {
 		msg := fmt.Sprintf("operator config value of \"%s\" is invalid", mode)
 		r.Logger.Error(msg)
-		return fmt.Errorf(msg)
+		return fmt.Errorf("%s", msg)
 	}
 
 	// Check for any expected keys.

--- a/pkg/operator/utils/errorscrub_test.go
+++ b/pkg/operator/utils/errorscrub_test.go
@@ -32,7 +32,7 @@ func TestErrorScrubber(t *testing.T) {
 	}
 	for _, test := range cases {
 		t.Run(test.name, func(t *testing.T) {
-			assert.Equal(t, test.expected, ErrorScrub(fmt.Errorf(test.input)))
+			assert.Equal(t, test.expected, ErrorScrub(fmt.Errorf("%s", test.input)))
 		})
 	}
 }


### PR DESCRIPTION
Prior to this chance, some uses of fmt.Errorf passed a string variable as the one and only parameter. Starting with go v1.24, this throws an error when running go test.

This change modifies those cases to use a string constant the first variable configured to inject the string variable as the second parameter. This resolves the go test error.