### PR TITLE
CCO-649: make update-go-dependencies to also update indirects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -166,6 +166,7 @@ update-go-dependencies-direct:
 	@for module in $$(go list -f '{{ if and (not .Main) (not .Indirect) }}{{.Path}}{{end}}' -m -mod=mod all \
 		| grep -v "^k8s.io/" | grep -v "sigs.k8s.io/" \
 		| grep -v "github.com/nutanix-cloud-native/prism-go-client" \
+		| grep -v "github.com/microsoftgraph/msgraph-sdk-go" \
 		); do \
 		go get $$module; \
 	done
@@ -178,6 +179,7 @@ update-go-dependencies-indirect:
 	@for module in $$(go list -f '{{ if .Indirect }}{{.Path}}{{end}}' -m -mod=mod all \
 		| grep -v "^k8s.io/" | grep -v "sigs.k8s.io/" \
 		| grep -v "github.com/nutanix-cloud-native/prism-go-client" \
+		| grep -v "github.com/microsoftgraph/msgraph-sdk-go" \
 		); do \
 		go get $$module; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -165,6 +165,7 @@ update-go-dependencies: update-go-dependencies-direct update-go-dependencies-ind
 update-go-dependencies-direct:
 	@for module in $$(go list -f '{{ if and (not .Main) (not .Indirect) }}{{.Path}}{{end}}' -m -mod=mod all \
 		| grep -v "^k8s.io/" | grep -v "sigs.k8s.io/" \
+		| grep -v "github.com/nutanix-cloud-native/prism-go-client" \
 		); do \
 		go get $$module; \
 	done
@@ -176,6 +177,7 @@ update-go-dependencies-direct:
 update-go-dependencies-indirect:
 	@for module in $$(go list -f '{{ if .Indirect }}{{.Path}}{{end}}' -m -mod=mod all \
 		| grep -v "^k8s.io/" | grep -v "sigs.k8s.io/" \
+		| grep -v "github.com/nutanix-cloud-native/prism-go-client" \
 		); do \
 		go get $$module; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -158,13 +158,26 @@ coverage:
 	hack/codecov.sh
 .PHONY: coverage
 
-# Update all non k8s go dependencies
 .PHONY: update-go-dependencies
-update-go-dependencies:
-	@for module in $$(go list -f '{{ if and (not .Main) (not .Indirect) }}{{.Path}}{{end}}' -m -mod=mod all | grep -v "^k8s.io/" | grep -v "sigs.k8s.io/"); do \
+update-go-dependencies: update-go-dependencies-direct update-go-dependencies-indirect
+
+.PHONY: update-go-dependencies-direct
+update-go-dependencies-direct:
+	@for module in $$(go list -f '{{ if and (not .Main) (not .Indirect) }}{{.Path}}{{end}}' -m -mod=mod all \
+		| grep -v "^k8s.io/" | grep -v "sigs.k8s.io/" \
+		); do \
 		go get $$module; \
 	done
 	go mod tidy
-ifneq (,$(wildcard vendor))
 	go mod vendor
-endif
+
+# Update indirect go dependenceis
+.PHONY: update-go-dependencies-indirect
+update-go-dependencies-indirect:
+	@for module in $$(go list -f '{{ if .Indirect }}{{.Path}}{{end}}' -m -mod=mod all \
+		| grep -v "^k8s.io/" | grep -v "sigs.k8s.io/" \
+		); do \
+		go get $$module; \
+	done
+	go mod tidy
+	go mod vendor


### PR DESCRIPTION
make update-go-dependencies to also update indirects
exclude prism-go-client ([CCO-643](https://issues.redhat.com//browse/CCO-643))
exclude msgraph-sdk-go ([CCO-644](https://issues.redhat.com//browse/CCO-644))