### PR TITLE
OCPBUGS-53454: ccoctl: only add owned tag to azure resources on create

### DIFF
--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -622,7 +622,7 @@ func createManagedIdentities(client *azureclients.AzureClientWrapper, credReqDir
 
 	// Ensure the installation resource group exists
 	if !dryRun {
-		err := ensureResourceGroup(client, installationResourceGroupName, region, resourceTags)
+		err := ensureResourceGroup(client, name, installationResourceGroupName, region, resourceTags)
 		if err != nil {
 			return errors.Wrap(err, "failed to ensure resource group")
 		}

--- a/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
+++ b/pkg/cmd/provisioning/azure/create_oidc_issuer_test.go
@@ -214,7 +214,7 @@ func TestEnsureResourceGroup(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockAzureClientWrapper := test.mockAzureClientWrapper(mockCtrl)
-			err := ensureResourceGroup(mockAzureClientWrapper, testOIDCResourceGroupName, testRegionName, testUserTags)
+			err := ensureResourceGroup(mockAzureClientWrapper, testInfraName, testOIDCResourceGroupName, testRegionName, testUserTags)
 			if test.expectError {
 				require.Error(t, err, "expected error")
 			} else {
@@ -279,7 +279,7 @@ func TestEnsureStorageAccount(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockAzureClientWrapper := test.mockAzureClientWrapper(mockCtrl)
-			err := ensureStorageAccount(mockAzureClientWrapper, testStorageAccountName, testOIDCResourceGroupName, testRegionName, testUserTags)
+			err := ensureStorageAccount(mockAzureClientWrapper, testInfraName, testStorageAccountName, testOIDCResourceGroupName, testRegionName, testUserTags)
 			if test.expectError {
 				require.Error(t, err, "expected error")
 			} else {


### PR DESCRIPTION
Prior to this change, ccoctl always added the owned tag to the resource groups and storage accounts. This caused errors when the number of owned tags from multpiple clusters exceeded the maximum tag limit.

This change makes it so the owned tag is only added when a resource group or storage account is actually created. Any additional clusters using these resources will not attempt to add their own owned tag. This enables significantly more clusters to share the same resources without reaching the limit.