### PR TITLE
OCPBUGS-34993: ccoctl azure dnszone-resource-group-name now optional

### DIFF
--- a/pkg/cmd/provisioning/azure/create_all.go
+++ b/pkg/cmd/provisioning/azure/create_all.go
@@ -165,8 +165,13 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.MarkPersistentFlagRequired("tenant-id")
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing Azure CredentialsRequests files used to create user-assigned managed identities (can be created by running 'oc adm release extract --credentials-requests --cloud=azure' against an OpenShift release image)")
 	createAllCmd.MarkPersistentFlagRequired("credentials-requests-dir")
-	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.DNSZoneResourceGroupName, "dnszone-resource-group-name", "", "The existing Azure resource group which contains the DNS zone that will be used for the cluster's base domain. The cluster ingress operator will be scoped to allow management of DNS records in the DNS Zone resource group.")
-	createAllCmd.MarkPersistentFlagRequired("dnszone-resource-group-name")
+	createAllCmd.PersistentFlags().StringVar(
+		&CreateAllOpts.DNSZoneResourceGroupName,
+		"dnszone-resource-group-name",
+		"",
+		"The name of the Azure resource group which contains the DNS zone that will be used for the cluster's base domain. The cluster ingress operator will be scoped to allow management of DNS records in the DNS Zone resource group. "+
+			"This is an optional parameter that does not need to be specified when the cluster is a private cluster, or the DNS zone is in the same resource group as the cluster.",
+	)
 
 	// Optional parameters
 	createAllCmd.PersistentFlags().StringVar(

--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -664,7 +664,7 @@ func createManagedIdentities(client *azureclients.AzureClientWrapper, credReqDir
 		// Scope user-assigned managed identity within the installationResourceGroupName
 		scopingResourceGroupNames := []string{installationResourceGroupName}
 		// Additionally scope the ingress CredentialsRequest within the dnsZoneResourceGroupName
-		if credentialsRequest.Name == ingressCredentialRequestName {
+		if credentialsRequest.Name == ingressCredentialRequestName && dnsZoneResourceGroupName != "" {
 			scopingResourceGroupNames = append(scopingResourceGroupNames, dnsZoneResourceGroupName)
 		}
 		// Additionally scope vnet related CredentialRequest within the networkResourceGroupName,
@@ -788,8 +788,13 @@ func NewCreateManagedIdentitiesCmd() *cobra.Command {
 	createManagedIdentitiesCmd.MarkPersistentFlagRequired("region")
 	createManagedIdentitiesCmd.PersistentFlags().StringVar(&CreateManagedIdentitiesOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing Azure CredentialsRequests files used to create user-assigned managed identities (can be created by running 'oc adm release extract --credentials-requests --cloud=azure' against an OpenShift release image)")
 	createManagedIdentitiesCmd.MarkPersistentFlagRequired("credentials-requests-dir")
-	createManagedIdentitiesCmd.PersistentFlags().StringVar(&CreateManagedIdentitiesOpts.DNSZoneResourceGroupName, "dnszone-resource-group-name", "", "The existing Azure resource group which contains the DNS zone that will be used for the cluster's base domain. The cluster ingress operator will be scoped to allow management of DNS records in the DNS Zone resource group.")
-	createManagedIdentitiesCmd.MarkPersistentFlagRequired("dnszone-resource-group-name")
+	createManagedIdentitiesCmd.PersistentFlags().StringVar(
+		&CreateManagedIdentitiesOpts.DNSZoneResourceGroupName,
+		"dnszone-resource-group-name",
+		"",
+		"The name of the Azure resource group which contains the DNS zone that will be used for the cluster's base domain. The cluster ingress operator will be scoped to allow management of DNS records in the DNS Zone resource group. "+
+			"This is an optional parameter that does not need to be specified when the cluster is a private cluster, or the DNS zone is in the same resource group as the cluster.",
+	)
 	createManagedIdentitiesCmd.PersistentFlags().StringVar(
 		&CreateManagedIdentitiesOpts.InstallationResourceGroupName,
 		"installation-resource-group-name",


### PR DESCRIPTION
This changes the dnszone-resource-group-name parameter to no longer be required. This enables private clusters where the dns zone does not exists without requiring an arbitrary resource group name.