### PR TITLE
OCPBUGS-61475: set cloud-credential-operator as default-container

### DIFF
--- a/manifests/03-deployment.yaml
+++ b/manifests/03-deployment.yaml
@@ -22,6 +22,7 @@ spec:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
         openshift.io/required-scc: restricted-v2
+        kubectl.kubernetes.io/default-container: cloud-credential-operator
       labels:
         app: cloud-credential-operator
         control-plane: controller-manager


### PR DESCRIPTION
As we use `kubectl logs -n openshift-cloud-credential-operator  cloud-credential-operator-xxx`, we see the default container logs is kube-rbac-proxy, like :
```
Defaulted container "kube-rbac-proxy" out of: kube-rbac-proxy, cloud-credential-operator
W0707 04:28:43.641266       1 deprecated.go:66] 
==== Removed Flag Warning ======================

logtostderr is removed in the k8s upstream and has no effect any more.

===============================================
                
I0707 04:28:43.641998       1 kube-rbac-proxy.go:233] Valid token audiences: 
I0707 04:28:43.642069       1 kube-rbac-proxy.go:347] Reading certificate files
I0707 04:28:43.642557       1 kube-rbac-proxy.go:395] Starting TCP socket on 0.0.0.0:8443
```

But most of the time we just care about the container cloud-credential-operator logs , not the kube-rbac-proxy