### PR TITLE
OCPBUGS-55127: snyk to ignore SNYK-GOLANG-GOLANGORGXNETHTML-9572088

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -5,6 +5,9 @@ exclude:
   global:
     - vendor/**
 ignore:
+    'SNYK-GOLANG-GOLANGORGXNETHTML-9572088':
+     - '* > golang.org/x/net/html':
+        reason: 'The package is only used in the ccoctl binary, which does not have a web service'
     'SNYK-GOLANG-K8SIOCLIENTGOTRANSPORT-7538822':
      - '* > k8s.io/client-go/transport':
         reason: 'Snyk mistakenly identifies v1.17.0-alpha.1 as newer than v0.29.7. client-go has a complicated history of versioning. Presumably, v1.20.0-alpha.1 referred to kubernetes-v1.20. kubernetes tags have since been prefaced by "kubernetes", whereas actual client-go versions resumed numbering from 0.x'


### PR DESCRIPTION
The package golang.org/x/net/html is only used by ccoctl, which neither runs on the cluster nor has a web service.