### PR TITLE
CCO-435: Migrate away from deprecated ioutil package.

### DIFF
--- a/pkg/cmd/operator/cmd.go
+++ b/pkg/cmd/operator/cmd.go
@@ -19,7 +19,6 @@ package cmd
 import (
 	"context"
 	"flag"
-	"io/ioutil"
 	golog "log"
 	"os"
 	"os/signal"
@@ -380,7 +379,7 @@ func terminateWhenProxyChanges(path string, cancel context.CancelFunc, done <-ch
 	// read the contents of the configmap
 	fileContents := map[string][]byte{}
 	var filenames []string
-	fileBytes, err := ioutil.ReadFile(path)
+	fileBytes, err := os.ReadFile(path)
 	if err != nil {
 		log.WithError(err).Fatal("Unable to read proxy CA config map")
 	}

--- a/pkg/cmd/provisioning/aws/create-iam-roles.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles.go
@@ -3,7 +3,6 @@ package aws
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -144,7 +143,7 @@ func createRole(awsClient aws.Client, name string, credReq *credreqv1.Credential
 		roleFilename := fmt.Sprintf(roleFilenameFormat, roleNum, roleName)
 		roleFullPath := filepath.Join(targetDir, roleFilename)
 		log.Printf("Saving %s locally at %s", roleDescription, roleFullPath)
-		if err := ioutil.WriteFile(roleFullPath, roleJSON, fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(roleFullPath, roleJSON, fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save %s locally at %s", roleDescription, roleFullPath))
 		}
 
@@ -162,7 +161,7 @@ func createRole(awsClient aws.Client, name string, credReq *credreqv1.Credential
 		rolePolicyFilename := fmt.Sprintf(rolePolicyFilenameFormat, roleNum, roleName)
 		rolePolicyFullPath := filepath.Join(targetDir, rolePolicyFilename)
 		log.Printf("Saving policy for %s locally at %s", roleDescription, rolePolicyFullPath)
-		if err := ioutil.WriteFile(rolePolicyFullPath, rolePolicyJSON, fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(rolePolicyFullPath, rolePolicyJSON, fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save policy for %s locally at %s", roleDescription, rolePolicyFullPath))
 		}
 
@@ -358,7 +357,7 @@ func writeCredReqSecret(cr *credreqv1.CredentialsRequest, targetDir, roleARN str
 		fileData = fileData + "\nPOPULATE ROLE ARN AND DELETE THIS LINE"
 	}
 
-	if err := ioutil.WriteFile(filePath, []byte(fileData), 0600); err != nil {
+	if err := os.WriteFile(filePath, []byte(fileData), 0600); err != nil {
 		return errors.Wrap(err, "Failed to save Secret file")
 	}
 

--- a/pkg/cmd/provisioning/aws/create-iam-roles_test.go
+++ b/pkg/cmd/provisioning/aws/create-iam-roles_test.go
@@ -2,7 +2,6 @@ package aws
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -86,16 +85,16 @@ func TestIAMRoles(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no files in targetDir when no CredReqs to process")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -109,7 +108,7 @@ func TestIAMRoles(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName, false)
@@ -118,11 +117,11 @@ func TestIAMRoles(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Equal(t, 2, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 IAM Role JSON and 1 IAM Role Policy file for each CredReq")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -140,7 +139,7 @@ func TestIAMRoles(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName, false)
@@ -149,11 +148,11 @@ func TestIAMRoles(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files when not in generate mode")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -171,7 +170,7 @@ func TestIAMRoles(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, "validcredreq", "namespace1", "secretName1", tempDirName, false)
@@ -183,11 +182,11 @@ func TestIAMRoles(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files when not in generate mode")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one valid CredReq, CredReq marked for deletion should be ignored")
 			},
@@ -205,7 +204,7 @@ func TestIAMRoles(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName, false)
@@ -227,7 +226,7 @@ func TestIAMRoles(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName, false)
@@ -236,7 +235,7 @@ func TestIAMRoles(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -253,7 +252,7 @@ func TestIAMRoles(t *testing.T) {
 			credReqDir := test.setup(t)
 			defer os.RemoveAll(credReqDir)
 
-			targetDir, err := ioutil.TempDir(os.TempDir(), "iamroletest")
+			targetDir, err := os.MkdirTemp(os.TempDir(), "iamroletest")
 			require.NoError(t, err, "unexpected error creating target dir for test")
 			defer os.RemoveAll(targetDir)
 
@@ -281,7 +280,7 @@ func testCredentialsRequest(t *testing.T, crName, targetSecretNamespace, targetS
 		credReq = fmt.Sprintf(credReqTemplate, crName, targetSecretNamespace, targetSecretName)
 	}
 
-	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
+	f, err := os.CreateTemp(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 

--- a/pkg/cmd/provisioning/aws/create_identity_provider.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"crypto/sha1"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -306,7 +305,7 @@ func createIAMIdentityProvider(client aws.Client, issuerURL, name, targetDir str
 		oidcIdentityProviderJSON := fmt.Sprintf(iamIdentityProviderTemplate, issuerURL, "<enter_tls_fingerprint_for_issuer_url_here>")
 		iamIdentityProviderFullPath := filepath.Join(targetDir, iamIdentityProviderFilename)
 		log.Printf("Saving AWS IAM Identity Provider locally at %s", iamIdentityProviderFullPath)
-		if err := ioutil.WriteFile(iamIdentityProviderFullPath, []byte(oidcIdentityProviderJSON), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(iamIdentityProviderFullPath, []byte(oidcIdentityProviderJSON), fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save AWS IAM Identity Provider locally at %s", iamIdentityProviderFullPath))
 		}
 
@@ -383,7 +382,7 @@ func createJSONWebKeySet(client aws.Client, publicKeyFilepath, bucketName, name,
 	if generateOnly {
 		oidcKeysFullPath := filepath.Join(targetDir, oidcKeysFilename)
 		log.Printf("Saving JSON web key set (JWKS) locally at %s", oidcKeysFullPath)
-		if err := ioutil.WriteFile(oidcKeysFullPath, jwks, fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(oidcKeysFullPath, jwks, fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save JSON web key set (JWKS) locally at %s", oidcKeysFullPath))
 		}
 	} else {
@@ -407,7 +406,7 @@ func createOIDCConfiguration(client aws.Client, bucketName, issuerURL, name, tar
 	if generateOnly {
 		oidcConfigurationFullPath := filepath.Join(targetDir, oidcConfigurationFilename)
 		log.Printf("Saving discovery document locally at %s", oidcConfigurationFullPath)
-		if err := ioutil.WriteFile(oidcConfigurationFullPath, []byte(discoveryDocumentJSON), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(oidcConfigurationFullPath, []byte(discoveryDocumentJSON), fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save discovery document locally at %s", oidcConfigurationFullPath))
 		}
 	} else {
@@ -443,7 +442,7 @@ func createOIDCEndpoint(client aws.Client, bucketName, name, region, targetDir s
 		}
 
 		log.Printf("Saving OIDC S3 bucket locally at %s", oidcBucketFilepath)
-		if err := ioutil.WriteFile(oidcBucketFilepath, []byte(oidcBucketJSON), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(oidcBucketFilepath, []byte(oidcBucketJSON), fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save OIDC S3 bucket locally at %s", oidcBucketFilepath))
 		}
 
@@ -451,28 +450,28 @@ func createOIDCEndpoint(client aws.Client, bucketName, name, region, targetDir s
 			cloudFrontOriginAccessIdentityFilepath := filepath.Join(targetDir, cloudFrontOriginAccessIdentityFilename)
 			cloudFrontOriginAccessIdentityJSON := fmt.Sprintf(cloudFrontOriginAccessIdentityTemplate, name, fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, name))
 			log.Printf("Saving JSON to create CloudFront Origin Access Identity locally at %s", cloudFrontOriginAccessIdentityFilepath)
-			if err := ioutil.WriteFile(cloudFrontOriginAccessIdentityFilepath, []byte(cloudFrontOriginAccessIdentityJSON), fileModeCcoctlDryRun); err != nil {
+			if err := os.WriteFile(cloudFrontOriginAccessIdentityFilepath, []byte(cloudFrontOriginAccessIdentityJSON), fileModeCcoctlDryRun); err != nil {
 				return "", errors.Wrap(err, fmt.Sprintf("Failed to save JSON to create CloudFront Origin Access Identity locally at %s", cloudFrontOriginAccessIdentityFilepath))
 			}
 
 			putBucketPolicyToAllowOriginAccessIdentityFilepath := filepath.Join(targetDir, putBucketPolicyToAllowOriginAccessIdentityFilename)
 			putBucketPolicyToAllowOriginAccessIdentityJSON := fmt.Sprintf(putBucketPolicyToAllowOriginAccessIdentityTemplate, bucketName, bucketName)
 			log.Printf("Saving JSON to put bucket policy allowing access from CloudFront Origin Access Identity locally at %s", putBucketPolicyToAllowOriginAccessIdentityFilepath)
-			if err := ioutil.WriteFile(putBucketPolicyToAllowOriginAccessIdentityFilepath, []byte(putBucketPolicyToAllowOriginAccessIdentityJSON), fileModeCcoctlDryRun); err != nil {
+			if err := os.WriteFile(putBucketPolicyToAllowOriginAccessIdentityFilepath, []byte(putBucketPolicyToAllowOriginAccessIdentityJSON), fileModeCcoctlDryRun); err != nil {
 				return "", errors.Wrap(err, fmt.Sprintf("Failed to save JSON to put bucket policy allowing access from CloudFront Origin Access Identity locally at %s", putBucketPolicyToAllowOriginAccessIdentityFilepath))
 			}
 
 			blockPublicAccessToOidcBucketFilepath := filepath.Join(targetDir, blockPublicAccessToOidcBucketFilename)
 			blockPublicAccessToOidcBucketJSON := fmt.Sprintf(blockPublicAccessToOidcBucketTemplate, bucketName)
 			log.Printf("Saving JSON to block public access to OIDC S3 bucket locally at %s", oidcBucketFilepath)
-			if err := ioutil.WriteFile(blockPublicAccessToOidcBucketFilepath, []byte(blockPublicAccessToOidcBucketJSON), fileModeCcoctlDryRun); err != nil {
+			if err := os.WriteFile(blockPublicAccessToOidcBucketFilepath, []byte(blockPublicAccessToOidcBucketJSON), fileModeCcoctlDryRun); err != nil {
 				return "", errors.Wrap(err, fmt.Sprintf("Failed to save JSON to block public access to OIDC S3 bucket locally at %s", blockPublicAccessToOidcBucketFilepath))
 			}
 
 			cloudFrontDistributionFilepath := filepath.Join(targetDir, cloudFrontDistributionFilename)
 			cloudFrontDistributionJSON := fmt.Sprintf(cloudFrontDistributionWithTagsTemplate, name, bucketName, region, dnsSuffix, bucketName, region, dnsSuffix, bucketName, region, dnsSuffix, fmt.Sprintf("%s/%s", ccoctlAWSResourceTagKeyPrefix, name), name)
 			log.Printf("Saving JSON to create CloudFront Distribution locally at %s", cloudFrontDistributionFilepath)
-			if err := ioutil.WriteFile(cloudFrontDistributionFilepath, []byte(cloudFrontDistributionJSON), fileModeCcoctlDryRun); err != nil {
+			if err := os.WriteFile(cloudFrontDistributionFilepath, []byte(cloudFrontDistributionJSON), fileModeCcoctlDryRun); err != nil {
 				return "", errors.Wrap(err, fmt.Sprintf("Failed to save JSON to create CloudFront Distribution locally at %s", cloudFrontDistributionFilepath))
 			}
 

--- a/pkg/cmd/provisioning/aws/create_identity_provider_test.go
+++ b/pkg/cmd/provisioning/aws/create_identity_provider_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -71,7 +70,7 @@ func TestCreateIdentityProvider(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
@@ -92,10 +91,10 @@ func TestCreateIdentityProvider(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
@@ -122,10 +121,10 @@ func TestCreateIdentityProvider(t *testing.T) {
 			},
 			createPrivateS3: true,
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
@@ -140,17 +139,17 @@ func TestCreateIdentityProvider(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
 				// Validating the issuer URL in the discovery document
-				discoveryDocument, err := ioutil.ReadFile(filepath.Join(tempDirName, oidcConfigurationFilename))
+				discoveryDocument, err := os.ReadFile(filepath.Join(tempDirName, oidcConfigurationFilename))
 				require.NoError(t, err, "error reading in discovery document")
 
 				var discoveryDocumentJSON map[string]interface{}
@@ -167,7 +166,7 @@ func TestCreateIdentityProvider(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("%s/%s", issuerURL, provisioning.KeysURI), jwksURI, "unexpected jwks uri")
 
 				// Comparing key ID from the JSON web key with the one generated from the public key
-				jwks, err := ioutil.ReadFile(filepath.Join(tempDirName, oidcKeysFilename))
+				jwks, err := os.ReadFile(filepath.Join(tempDirName, oidcKeysFilename))
 				require.NoError(t, err, "error reading in JSON web key set (JWKS)")
 
 				var jwksJSON map[string]interface{}
@@ -196,17 +195,17 @@ func TestCreateIdentityProvider(t *testing.T) {
 				return mockAWSClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
 				// Validating the issuer URL in the discovery document
-				discoveryDocument, err := ioutil.ReadFile(filepath.Join(tempDirName, oidcConfigurationFilename))
+				discoveryDocument, err := os.ReadFile(filepath.Join(tempDirName, oidcConfigurationFilename))
 				require.NoError(t, err, "error reading in discovery document")
 
 				var discoveryDocumentJSON map[string]interface{}
@@ -222,7 +221,7 @@ func TestCreateIdentityProvider(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("%s/%s", placeholderCloudFrontURL, provisioning.KeysURI), jwksURI, "unexpected jwks uri")
 
 				// Comparing key ID from the JSON web key with the one generated from the public key
-				jwks, err := ioutil.ReadFile(filepath.Join(tempDirName, oidcKeysFilename))
+				jwks, err := os.ReadFile(filepath.Join(tempDirName, oidcKeysFilename))
 				require.NoError(t, err, "error reading in JSON web key set (JWKS)")
 
 				var jwksJSON map[string]interface{}

--- a/pkg/cmd/provisioning/azure/create_managed_identities_test.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities_test.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -141,11 +140,11 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no files in targetDir when no CredReqs to process")
 
-				files, err = ioutil.ReadDir(filepath.Join(targetDir, provisioning.ManifestsDirName))
+				files, err = os.ReadDir(filepath.Join(targetDir, provisioning.ManifestsDirName))
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -199,12 +198,12 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
-				files, err := ioutil.ReadDir(tempDirName)
+				files, err := os.ReadDir(tempDirName)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files in targetDir")
 
 				manifestsDirPath := filepath.Join(tempDirName, provisioning.ManifestsDirName)
-				files, err = ioutil.ReadDir(manifestsDirPath)
+				files, err = os.ReadDir(manifestsDirPath)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -235,12 +234,12 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
-				files, err := ioutil.ReadDir(tempDirName)
+				files, err := os.ReadDir(tempDirName)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files in targetDir")
 
 				manifestsDirPath := filepath.Join(tempDirName, provisioning.ManifestsDirName)
-				files, err = ioutil.ReadDir(manifestsDirPath)
+				files, err = os.ReadDir(manifestsDirPath)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -295,12 +294,12 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
-				files, err := ioutil.ReadDir(tempDirName)
+				files, err := os.ReadDir(tempDirName)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files in targetDir")
 
 				manifestsDirPath := filepath.Join(tempDirName, provisioning.ManifestsDirName)
-				files, err = ioutil.ReadDir(manifestsDirPath)
+				files, err = os.ReadDir(manifestsDirPath)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -333,11 +332,11 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no files in targetDir when no CredReqs to process")
 
-				files, err = ioutil.ReadDir(filepath.Join(targetDir, provisioning.ManifestsDirName))
+				files, err = os.ReadDir(filepath.Join(targetDir, provisioning.ManifestsDirName))
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -395,12 +394,12 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
-				files, err := ioutil.ReadDir(tempDirName)
+				files, err := os.ReadDir(tempDirName)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files in targetDir")
 
 				manifestsDirPath := filepath.Join(tempDirName, provisioning.ManifestsDirName)
-				files, err = ioutil.ReadDir(manifestsDirPath)
+				files, err = os.ReadDir(manifestsDirPath)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -455,12 +454,12 @@ func TestCreateManagedIdentities(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
-				files, err := ioutil.ReadDir(tempDirName)
+				files, err := os.ReadDir(tempDirName)
 				require.NoError(t, err, "unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files in targetDir")
 
 				manifestsDirPath := filepath.Join(tempDirName, provisioning.ManifestsDirName)
-				files, err = ioutil.ReadDir(manifestsDirPath)
+				files, err = os.ReadDir(manifestsDirPath)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 
@@ -826,7 +825,7 @@ func testCredentialsRequest(t *testing.T, crName, targetSecretNamespace, targetS
 		credReq = fmt.Sprintf(credReqTemplate, crName, targetSecretName, targetSecretNamespace)
 	}
 
-	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
+	f, err := os.CreateTemp(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 

--- a/pkg/cmd/provisioning/create_key_pair_test.go
+++ b/pkg/cmd/provisioning/create_key_pair_test.go
@@ -3,7 +3,6 @@ package provisioning
 import (
 	"crypto/x509"
 	"encoding/pem"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -28,7 +27,7 @@ func TestKeyPair(t *testing.T) {
 			setup: func(t *testing.T) string {
 				tempDirName := prepTempDir(t)
 
-				err := ioutil.WriteFile(filepath.Join(tempDirName, PrivateKeyFile), []byte("some data"), 0600)
+				err := os.WriteFile(filepath.Join(tempDirName, PrivateKeyFile), []byte("some data"), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
@@ -37,12 +36,12 @@ func TestKeyPair(t *testing.T) {
 				_, err := os.Stat(filepath.Join(tempDirName, PublicKeyFile))
 				require.Error(t, err, "expected public key file to not exist")
 
-				fileData, err := ioutil.ReadFile(filepath.Join(tempDirName, PrivateKeyFile))
+				fileData, err := os.ReadFile(filepath.Join(tempDirName, PrivateKeyFile))
 				require.NoError(t, err, "unexpected error reading in test private key data")
 
 				assert.Equal(t, []byte("some data"), fileData, "unexpected change in test private key data")
 
-				tlsFileData, err := ioutil.ReadFile(filepath.Join(tempDirName, TLSDirName, boundSAKeyFilename))
+				tlsFileData, err := os.ReadFile(filepath.Join(tempDirName, TLSDirName, boundSAKeyFilename))
 				require.NoError(t, err, "unexpected error reading in copied file %s/%s", TLSDirName, boundSAKeyFilename)
 
 				assert.Equal(t, []byte("some data"), tlsFileData, "unexpected file contents for %s/%s", TLSDirName, boundSAKeyFilename)
@@ -56,10 +55,10 @@ func TestKeyPair(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
-				pubFileBytes, err := ioutil.ReadFile(filepath.Join(tempDirName, PublicKeyFile))
+				pubFileBytes, err := os.ReadFile(filepath.Join(tempDirName, PublicKeyFile))
 				require.NoError(t, err, "error reading in generated public key file")
 
-				privFile, err := ioutil.ReadFile(filepath.Join(tempDirName, PrivateKeyFile))
+				privFile, err := os.ReadFile(filepath.Join(tempDirName, PrivateKeyFile))
 				require.NoError(t, err, "error reading in test private key file")
 
 				block, _ := pem.Decode(privFile)
@@ -82,7 +81,7 @@ func TestKeyPair(t *testing.T) {
 
 				assert.Equal(t, pubFileBytes, calculatedPubKeyBytes, "Missmatch between written public key file and caluclated public key (from private key)")
 
-				tlsFileData, err := ioutil.ReadFile(filepath.Join(tempDirName, TLSDirName, boundSAKeyFilename))
+				tlsFileData, err := os.ReadFile(filepath.Join(tempDirName, TLSDirName, boundSAKeyFilename))
 				require.NoError(t, err, "unexpected error reading in copied file %s/%s", TLSDirName, boundSAKeyFilename)
 
 				assert.Equal(t, privFile, tlsFileData, "unexpected file contents for %s/%s", TLSDirName, boundSAKeyFilename)
@@ -109,7 +108,7 @@ func TestKeyPair(t *testing.T) {
 }
 
 func prepTempDir(t *testing.T) string {
-	tempDirName, err := ioutil.TempDir(os.TempDir(), keypairTestDirPrefix)
+	tempDirName, err := os.MkdirTemp(os.TempDir(), keypairTestDirPrefix)
 
 	require.NoError(t, err, "unexpected error setting up temp directory")
 

--- a/pkg/cmd/provisioning/gcp/create_service_accounts.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -170,7 +169,7 @@ func createServiceAccount(ctx context.Context, client gcp.Client, name string, c
 		createSvcAcctScriptName := fmt.Sprintf(createIAMServiceAccountScriptName, serviceAccountNum, serviceAccountName)
 		createSvcAcctScriptFullPath := filepath.Join(targetDir, createSvcAcctScriptName)
 		log.Printf("Saving script to create service account %s locally at %s", serviceAccountName, createSvcAcctScriptFullPath)
-		if err := ioutil.WriteFile(createSvcAcctScriptFullPath, []byte(createSvcAcctScript), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(createSvcAcctScriptFullPath, []byte(createSvcAcctScript), fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save script to create service account %s locally at %s", serviceAccountName, createSvcAcctScriptFullPath))
 		}
 
@@ -183,7 +182,7 @@ func createServiceAccount(ctx context.Context, client gcp.Client, name string, c
 			createCustomRoleScriptName := fmt.Sprintf(createIAMCustomRoleScriptName, serviceAccountNum, serviceAccountName)
 			createCustomRoleScriptFullPath := filepath.Join(targetDir, createCustomRoleScriptName)
 			log.Printf("Saving script to create custom role %s locally at %s", roleName, createCustomRoleScriptFullPath)
-			if err := ioutil.WriteFile(createCustomRoleScriptFullPath, []byte(createCustomRoleScript), fileModeCcoctlDryRun); err != nil {
+			if err := os.WriteFile(createCustomRoleScriptFullPath, []byte(createCustomRoleScript), fileModeCcoctlDryRun); err != nil {
 				return "", errors.Wrap(err, fmt.Sprintf("Failed to save script to create custom role %s locally at %s", roleName, createCustomRoleScriptFullPath))
 			}
 			// add full resource name of the role
@@ -204,7 +203,7 @@ func createServiceAccount(ctx context.Context, client gcp.Client, name string, c
 		addPolicyBindingScriptName := fmt.Sprintf(addIAMPolicyBindingScriptName, serviceAccountNum, serviceAccountName)
 		addPolicyBindingScriptFullPath := filepath.Join(targetDir, addPolicyBindingScriptName)
 		log.Printf("Saving script to add policy bindings for service account %s locally at %s", serviceAccountName, addPolicyBindingScriptFullPath)
-		if err := ioutil.WriteFile(addPolicyBindingScriptFullPath, []byte(addPolicyBindingScript), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(addPolicyBindingScriptFullPath, []byte(addPolicyBindingScript), fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save script to add policy bindings for service account %s locally at %s", serviceAccountName, addPolicyBindingScriptFullPath))
 		}
 
@@ -217,7 +216,7 @@ func createServiceAccount(ctx context.Context, client gcp.Client, name string, c
 		generateCredentialsConfigScriptName := fmt.Sprintf(generateCredentialsConfigScriptName, serviceAccountNum, serviceAccountName)
 		generateCredentialsConfigScriptFullPath := filepath.Join(targetDir, generateCredentialsConfigScriptName)
 		log.Printf("Saving script to generate credentials config for service account %s locally at %s", serviceAccountName, generateCredentialsConfigScriptFullPath)
-		if err := ioutil.WriteFile(generateCredentialsConfigScriptFullPath, []byte(generateCredentialsConfigScript), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(generateCredentialsConfigScriptFullPath, []byte(generateCredentialsConfigScript), fileModeCcoctlDryRun); err != nil {
 			return "", errors.Wrap(err, fmt.Sprintf("Failed to save script to generate credentials config for service account %s locally at %s", serviceAccountName, generateCredentialsConfigScriptFullPath))
 		}
 
@@ -432,7 +431,7 @@ func writeCredReqSecret(cr *credreqv1.CredentialsRequest, targetDir, encodedCred
 		fileData = fileData + fmt.Sprintf("\nPOPULATE service_account.json FIELD WITH BASE 64 ENCODED CREDENTIALS CONFIG JSON GENERATED FROM SCRIPT %s", generateCredentialsConfigScriptPath)
 	}
 
-	if err := ioutil.WriteFile(filePath, []byte(fileData), 0600); err != nil {
+	if err := os.WriteFile(filePath, []byte(fileData), 0600); err != nil {
 		return errors.Wrap(err, "Failed to save Secret file")
 	}
 

--- a/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
+++ b/pkg/cmd/provisioning/gcp/create_service_accounts_test.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -56,16 +55,16 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Zero(t, countNonDirectoryFiles(files), "Should be no files in targetDir when no CredReqs to process")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "Unexpected error listing files in manifestsDir")
 				assert.Zero(t, countNonDirectoryFiles(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -80,7 +79,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, testCredReqName, testTargetNamespaceName, testTargetSecretName, tempDirName)
@@ -89,11 +88,11 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Equal(t, 4, countNonDirectoryFiles(files), "Should be exactly 4 shell scripts")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "Unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -116,7 +115,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, testCredReqName, testTargetNamespaceName, testTargetSecretName, tempDirName)
@@ -125,11 +124,11 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir, manifestsDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Zero(t, countNonDirectoryFiles(files), "Should be no generated files when not in generate mode")
 
-				files, err = ioutil.ReadDir(manifestsDir)
+				files, err = os.ReadDir(manifestsDir)
 				require.NoError(t, err, "Unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -147,7 +146,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, testCredReqName, testTargetNamespaceName, testTargetSecretName, tempDirName)
@@ -174,7 +173,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				err = testCredentialsRequest(t, testCredReqName, testTargetNamespaceName, testTargetSecretName, tempDirName)
@@ -196,7 +195,7 @@ func TestCreateServiceAccounts(t *testing.T) {
 			credReqDir := test.setup(t)
 			defer os.RemoveAll(credReqDir)
 
-			targetDir, err := ioutil.TempDir(os.TempDir(), "create_service_account_test")
+			targetDir, err := os.MkdirTemp(os.TempDir(), "create_service_account_test")
 			require.NoError(t, err, "Unexpected error creating target dir for test")
 			defer os.RemoveAll(targetDir)
 
@@ -244,7 +243,7 @@ spec:
 
 	credReq := fmt.Sprintf(credReqTemplate, crName, targetSecretNamespace, targetSecretName)
 
-	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
+	f, err := os.CreateTemp(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 
@@ -255,7 +254,7 @@ spec:
 }
 
 // countNonDirectoryFiles counts files which are not a directory
-func countNonDirectoryFiles(files []os.FileInfo) int {
+func countNonDirectoryFiles(files []os.DirEntry) int {
 	NonDirectoryFiles := 0
 	for _, f := range files {
 		if !f.IsDir() {

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_pool.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_pool.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -92,7 +91,7 @@ func createWorkloadIdentityPool(ctx context.Context, client gcp.Client, name, pr
 		})
 		createIdentityPoolScriptFullPath := filepath.Join(targetDir, createIdentityPoolScriptName)
 		log.Printf("Saving script to create workload identity pool %s locally at %s", name, createIdentityPoolScriptFullPath)
-		if err := ioutil.WriteFile(createIdentityPoolScriptFullPath, []byte(createWorkloadIdentityPoolScript), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(createIdentityPoolScriptFullPath, []byte(createWorkloadIdentityPoolScript), fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save script to create workload identity pool %s locally at %s", name, createIdentityPoolScriptFullPath))
 		}
 	} else {

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_pool_test.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_pool_test.go
@@ -2,7 +2,6 @@ package gcp
 
 import (
 	"context"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -40,12 +39,12 @@ func TestCreateWorkloadIdentityPool(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Equal(t, 1, provisioning.CountNonDirectoryFiles(files), "Should be exactly 1 shell script")
 			},
@@ -60,12 +59,12 @@ func TestCreateWorkloadIdentityPool(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files when not in generate mode")
 			},
@@ -81,12 +80,12 @@ func TestCreateWorkloadIdentityPool(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files when not in generate mode")
 			},
@@ -102,12 +101,12 @@ func TestCreateWorkloadIdentityPool(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string) {
-				files, err := ioutil.ReadDir(targetDir)
+				files, err := os.ReadDir(targetDir)
 				require.NoError(t, err, "Unexpected error listing files in targetDir")
 				assert.Zero(t, provisioning.CountNonDirectoryFiles(files), "Should be no generated files when not in generate mode")
 			},
@@ -123,7 +122,7 @@ func TestCreateWorkloadIdentityPool(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_provider.go
@@ -3,7 +3,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -116,7 +115,7 @@ func createOIDCBucket(ctx context.Context, client gcp.Client, bucketName, region
 		createOidcBucketScriptFilepath := filepath.Join(targetDir, createOidcBucketScriptName)
 		script := fmt.Sprintf(createOidcBucketScript, region, project, bucketName, bucketName)
 		log.Printf("Saving shell script to create OIDC bucket locally at %s", createOidcBucketScriptFilepath)
-		if err := ioutil.WriteFile(createOidcBucketScriptFilepath, []byte(script), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(createOidcBucketScriptFilepath, []byte(script), fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save shell script to create OIDC bucket locally at %s", createOidcBucketScriptFilepath))
 		}
 	} else {
@@ -182,7 +181,7 @@ func createOIDCConfiguration(ctx context.Context, client gcp.Client, bucketName,
 	if generateOnly {
 		discoveryDocumentFilepath := filepath.Join(targetDir, gcpOidcConfigurationFilename)
 		log.Printf("Saving discovery document locally at %s", discoveryDocumentFilepath)
-		if err := ioutil.WriteFile(discoveryDocumentFilepath, []byte(discoveryDocumentJSON), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(discoveryDocumentFilepath, []byte(discoveryDocumentJSON), fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save discovery document locally at %s", discoveryDocumentFilepath))
 		}
 	} else {
@@ -204,7 +203,7 @@ func createJSONWebKeySet(ctx context.Context, client gcp.Client, publicKeyFilepa
 	if generateOnly {
 		JWKSFilePath := filepath.Join(targetDir, gcpOidcKeysFilename)
 		log.Printf("Saving JSON web key set (JWKS) locally at %s", JWKSFilePath)
-		if err := ioutil.WriteFile(JWKSFilePath, jwks, fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(JWKSFilePath, jwks, fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save JSON web key set (JWKS) locally at %s", JWKSFilePath))
 		}
 	} else {
@@ -223,7 +222,7 @@ func createIdentityProvider(ctx context.Context, client gcp.Client, name, projec
 		createIdentityProviderScriptFilepath := filepath.Join(targetDir, createIdentityProviderScriptName)
 		script := fmt.Sprintf(createIdentityProviderScript, name, workloadIdentityPool, name, createdByCcoctl, issuerURL, openShiftAudience)
 		log.Printf("Saving shell script to create workload identity provider locally at %s", createIdentityProviderScriptFilepath)
-		if err := ioutil.WriteFile(createIdentityProviderScriptFilepath, []byte(script), fileModeCcoctlDryRun); err != nil {
+		if err := os.WriteFile(createIdentityProviderScriptFilepath, []byte(script), fileModeCcoctlDryRun); err != nil {
 			return errors.Wrap(err, fmt.Sprintf("Failed to save shell script to create workload identity provider locally at %s", createIdentityProviderScriptFilepath))
 		}
 	} else {

--- a/pkg/cmd/provisioning/gcp/create_workload_identity_provider_test.go
+++ b/pkg/cmd/provisioning/gcp/create_workload_identity_provider_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -68,7 +67,7 @@ func TestCreateWorkloadIdentityProvider(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
@@ -88,10 +87,10 @@ func TestCreateWorkloadIdentityProvider(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
@@ -109,10 +108,10 @@ func TestCreateWorkloadIdentityProvider(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
@@ -127,17 +126,17 @@ func TestCreateWorkloadIdentityProvider(t *testing.T) {
 				return mockGCPClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
-				err = ioutil.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
+				err = os.WriteFile(filepath.Join(tempDirName, testPublicKeyFile), []byte(testPublicKeyData), 0600)
 				require.NoError(t, err, "errored while setting up environment for test")
 
 				return tempDirName
 			},
 			verify: func(t *testing.T, tempDirName string) {
 				// Validating the issuer URL in the discovery document
-				discoveryDocument, err := ioutil.ReadFile(filepath.Join(tempDirName, gcpOidcConfigurationFilename))
+				discoveryDocument, err := os.ReadFile(filepath.Join(tempDirName, gcpOidcConfigurationFilename))
 				require.NoError(t, err, "error reading in discovery document")
 
 				var discoveryDocumentJSON map[string]interface{}
@@ -154,7 +153,7 @@ func TestCreateWorkloadIdentityProvider(t *testing.T) {
 				assert.Equal(t, fmt.Sprintf("%s/%s", issuerURL, provisioning.KeysURI), jwksURI, "unexpected jwks uri")
 
 				// Comparing key ID from the JSON web key with the one generated from the public key
-				jwks, err := ioutil.ReadFile(filepath.Join(tempDirName, gcpOidcKeysFilename))
+				jwks, err := os.ReadFile(filepath.Join(tempDirName, gcpOidcKeysFilename))
 				require.NoError(t, err, "error reading in JSON web key set (JWKS)")
 
 				var jwksJSON map[string]interface{}

--- a/pkg/cmd/provisioning/gcp/credentials.go
+++ b/pkg/cmd/provisioning/gcp/credentials.go
@@ -9,7 +9,6 @@ package gcp
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -73,7 +72,7 @@ func getCredentials(ctx context.Context) (*google.Credentials, error) {
 	if err := os.MkdirAll(filepath.Dir(filePath), 0700); err != nil {
 		return nil, err
 	}
-	if err := ioutil.WriteFile(filePath, creds.JSON, 0600); err != nil {
+	if err := os.WriteFile(filePath, creds.JSON, 0600); err != nil {
 		return nil, err
 	}
 	return creds, nil
@@ -134,7 +133,7 @@ type fileLoader struct {
 }
 
 func (f *fileLoader) Load(ctx context.Context) (*google.Credentials, error) {
-	content, err := ioutil.ReadFile(f.path)
+	content, err := os.ReadFile(f.path)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/provisioning/ibmcloud/create_service_id_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/create_service_id_test.go
@@ -2,7 +2,6 @@ package ibmcloud
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -51,7 +50,7 @@ func TestCreateSecretsCmd(t *testing.T) {
 			name: "CreateSharedSecretsCmd with unset API key environment variable should fail",
 			setup: func(t *testing.T) string {
 				os.Setenv(APIKeyEnvVars[0], "")
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -73,7 +72,7 @@ func TestCreateSecretsCmd(t *testing.T) {
 			credReqDir := test.setup(t)
 			defer os.RemoveAll(credReqDir)
 
-			targetDir, err := ioutil.TempDir(os.TempDir(), "ibmcloudcreatetest")
+			targetDir, err := os.MkdirTemp(os.TempDir(), "ibmcloudcreatetest")
 			require.NoError(t, err, "Unexpected error creating temp dir for test")
 
 			manifestsDir := filepath.Join(targetDir, manifestsDirName)
@@ -116,12 +115,12 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, countNonDirectoryFiles(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -138,7 +137,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -146,7 +145,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -163,7 +162,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequestPowerVS(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -171,7 +170,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -190,7 +189,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -199,7 +198,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
 				//TODO(mkumatag): add validation to check for the rules created for the resource group if mentioned
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 1, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -213,7 +212,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -222,7 +221,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
 				//TODO(mkumatag): add validation to check for the rules created for the resource group if mentioned
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 0, countNonDirectoryFiles(files), "Should not any secret in manifestsDir")
 			},
@@ -237,7 +236,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -254,7 +253,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequestNonIBM(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -262,7 +261,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return tempDirName
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 0, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -278,7 +277,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return "non-existingdir"
 			},
 			verify: func(t *testing.T, targetDir string, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Equal(t, 0, countNonDirectoryFiles(files), "Should be exactly 1 secret in manifestsDir for one CredReq")
 			},
@@ -293,7 +292,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -314,7 +313,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -336,7 +335,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -358,7 +357,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -376,7 +375,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -394,7 +393,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -415,7 +414,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 			credReqDir := tt.setup(t)
 			defer os.RemoveAll(credReqDir)
 
-			targetDir, err := ioutil.TempDir(os.TempDir(), "iamroletest")
+			targetDir, err := os.MkdirTemp(os.TempDir(), "iamroletest")
 			require.NoError(t, err, "unexpected error creating target dir for test")
 			defer os.RemoveAll(targetDir)
 
@@ -454,7 +453,7 @@ func TestCreateSharedSecretsInvalidTargetDir(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secretName1", tempDirName)
@@ -485,7 +484,7 @@ func TestCreateSharedSecretsInvalidTargetDir(t *testing.T) {
 }
 
 func writeToTempFile(t *testing.T, targetDir, content string) {
-	f, err := ioutil.TempFile(targetDir, "testCredReq*.yaml")
+	f, err := os.CreateTemp(targetDir, "testCredReq*.yaml")
 	require.NoError(t, err, "error creating temp file for CredentialsRequest")
 	defer f.Close()
 
@@ -697,7 +696,7 @@ func mockDeleteAPIKey(client *mockibmcloud.MockClient, fail bool, times int) {
 
 // countNonDirectoryFiles counts files which are not a directory
 // TODO(mkumatag): duplicate code from aws tests, need to explore moving to some common location
-func countNonDirectoryFiles(files []os.FileInfo) int {
+func countNonDirectoryFiles(files []os.DirEntry) int {
 	NonDirectoryFiles := 0
 	for _, f := range files {
 		if !f.IsDir() {

--- a/pkg/cmd/provisioning/ibmcloud/delete_service_id_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/delete_service_id_test.go
@@ -2,7 +2,6 @@ package ibmcloud
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -62,7 +61,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 				return tempDirName
 			},
@@ -77,7 +76,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secret-name-0", tempDirName)
@@ -96,7 +95,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secret-name", tempDirName)
@@ -117,7 +116,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secret-name", tempDirName)
@@ -134,7 +133,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secret-name-0", tempDirName)
@@ -153,7 +152,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secret-name-0", tempDirName)
@@ -172,7 +171,7 @@ func Test_deleteServiceIDs(t *testing.T) {
 				return mockIBMCloudClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, "firstcredreq", "namespace1", "secret-name-0", tempDirName)

--- a/pkg/cmd/provisioning/ibmcloud/refresh-keys_test.go
+++ b/pkg/cmd/provisioning/ibmcloud/refresh-keys_test.go
@@ -2,7 +2,6 @@ package ibmcloud
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -59,7 +58,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fakeClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -78,7 +77,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fake.NewSimpleClientset()
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -107,7 +106,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fakeClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -128,7 +127,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fake.NewSimpleClientset()
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -148,7 +147,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fake.NewSimpleClientset()
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -169,7 +168,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fake.NewSimpleClientset()
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -195,7 +194,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fakeClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -220,7 +219,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fakeClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)
@@ -247,7 +246,7 @@ func Test_refreshKeys(t *testing.T) {
 				return fakeClient
 			},
 			setup: func(t *testing.T) string {
-				tempDirName, err := ioutil.TempDir(os.TempDir(), testDirPrefix)
+				tempDirName, err := os.MkdirTemp(os.TempDir(), testDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory")
 
 				testCredentialsRequest(t, testCRName, targetNamespace, targetSecretName, tempDirName)

--- a/pkg/cmd/provisioning/ibmcloud/service_id.go
+++ b/pkg/cmd/provisioning/ibmcloud/service_id.go
@@ -3,7 +3,6 @@ package ibmcloud
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"net/url"
 	"os"
@@ -173,7 +172,7 @@ func (s *ServiceID) Dump(targetDir string) error {
 		return errors.Wrapf(err, "Failed to marshal the secret for the serviceID: %s", s.name)
 	}
 
-	if err := ioutil.WriteFile(filePath, data, 0600); err != nil {
+	if err := os.WriteFile(filePath, data, 0600); err != nil {
 		return errors.Wrap(err, "Failed to save Secret file")
 	}
 

--- a/pkg/cmd/provisioning/nutanix/create_shared_secrets.go
+++ b/pkg/cmd/provisioning/nutanix/create_shared_secrets.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/user"
@@ -92,7 +91,7 @@ func getCredentialsFromFile(filePath string) (*kubernetes.NutanixCredentials, er
 		return nil, errors.Wrapf(err, "source credentials file %s does not exist", filePath)
 	}
 
-	bytes, err := ioutil.ReadFile(filePath)
+	bytes, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to read the credentials file %s", filePath)
 	}
@@ -163,7 +162,7 @@ func writeCredReqSecret(cr *credreqv1.CredentialsRequest, targetDir string, cred
 
 	b64CredsJson := base64.StdEncoding.EncodeToString(credsJsonBytes)
 	fileData := fmt.Sprintf(secretManifestsTemplate, cr.Spec.SecretRef.Name, cr.Spec.SecretRef.Namespace, b64CredsJson)
-	if err := ioutil.WriteFile(filePath, []byte(fileData), 0600); err != nil {
+	if err := os.WriteFile(filePath, []byte(fileData), 0600); err != nil {
 		return errors.Wrap(err, "failed to save secret manifest")
 	}
 

--- a/pkg/cmd/provisioning/nutanix/create_shared_secrets_test.go
+++ b/pkg/cmd/provisioning/nutanix/create_shared_secrets_test.go
@@ -5,7 +5,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -68,19 +67,19 @@ func TestCreateSharedSecrets(t *testing.T) {
 		{
 			name: "No CredentialsRequest manifests in directory",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
-				credReqDir, err := ioutil.TempDir(os.TempDir(), testCredReqDirPrefix)
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				targetDir, err = ioutil.TempDir(os.TempDir(), testTargetDirPrefix)
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				credentialsDir, err := ioutil.TempDir(os.TempDir(), testCredentialsDirPrefix)
+				credentialsDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials")
 				credentialsSourceFilepath = testBasicAuthCredentials(t, "username", "password", credentialsDir)
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, len(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -89,20 +88,20 @@ func TestCreateSharedSecrets(t *testing.T) {
 		{
 			name: "One CredentialsRequest manifests in directory",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
-				credReqDir, err := ioutil.TempDir(os.TempDir(), testCredReqDirPrefix)
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 				testCredentialsRequest(t, "credreq-test", "NutanixProviderSpec", "secret-ns", "secret-name", credReqDir)
 
-				targetDir, err = ioutil.TempDir(os.TempDir(), testTargetDirPrefix)
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				credentialsDir, err := ioutil.TempDir(os.TempDir(), testCredentialsDirPrefix)
+				credentialsDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials")
 				credentialsSourceFilepath = testBasicAuthCredentials(t, "username", "password", credentialsDir)
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Len(t, files, 1, "Should be exactly one files in manifestsDir when one CredReq to process")
 			},
@@ -111,20 +110,20 @@ func TestCreateSharedSecrets(t *testing.T) {
 		{
 			name: "Credential generated based on credentials source file with only Prism Central Credentials",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
-				credReqDir, err := ioutil.TempDir(os.TempDir(), testCredReqDirPrefix)
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 				testCredentialsRequest(t, "credreq-test", "NutanixProviderSpec", "secret-ns", "secret-name", credReqDir)
 
-				targetDir, err = ioutil.TempDir(os.TempDir(), testTargetDirPrefix)
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				credentialsDir, err := ioutil.TempDir(os.TempDir(), testCredentialsDirPrefix)
+				credentialsDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials")
 				credentialsSourceFilepath = testBasicAuthCredentials(t, "username", "password", credentialsDir)
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Len(t, files, 1, "Should be exactly one files in manifestsDir when one CredReq to process")
 				contents := getSecretFromFileContents(t, filepath.Join(manifestsDir, files[0].Name()))
@@ -137,20 +136,20 @@ func TestCreateSharedSecrets(t *testing.T) {
 		{
 			name: "Credential generated based on credentials source file with Prism Element Credentials included",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
-				credReqDir, err := ioutil.TempDir(os.TempDir(), testCredReqDirPrefix)
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 				testCredentialsRequest(t, "credreq-test", "NutanixProviderSpec", "secret-ns", "secret-name", credReqDir)
 
-				targetDir, err = ioutil.TempDir(os.TempDir(), testTargetDirPrefix)
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				credentialsDir, err := ioutil.TempDir(os.TempDir(), testCredentialsDirPrefix)
+				credentialsDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials")
 				credentialsSourceFilepath = testBasicAuthCredentialsWithPE(t, "username", "password", "pe", "username", "password", credentialsDir)
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Len(t, files, 1, "Should be exactly one files in manifestsDir when one CredReq to process")
 				contents := getSecretFromFileContents(t, filepath.Join(manifestsDir, files[0].Name()))
@@ -166,17 +165,17 @@ func TestCreateSharedSecrets(t *testing.T) {
 		{
 			name: "Non-existent source credentials file",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
-				credReqDir, err := ioutil.TempDir(os.TempDir(), testCredReqDirPrefix)
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				targetDir, err = ioutil.TempDir(os.TempDir(), testTargetDirPrefix)
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
 				credentialsSourceFilepath = "does/not/exist"
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, len(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -187,16 +186,16 @@ func TestCreateSharedSecrets(t *testing.T) {
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
 				credReqDir = "does/not/exist"
 
-				targetDir, err := ioutil.TempDir(os.TempDir(), testTargetDirPrefix)
+				targetDir, err := os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials requests")
 
-				credentialsDir, err := ioutil.TempDir(os.TempDir(), testCredentialsDirPrefix)
+				credentialsDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials")
 				credentialsSourceFilepath = testBasicAuthCredentials(t, "username", "password", credentialsDir)
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Zero(t, len(files), "Should be no files in manifestsDir when no CredReqs to process")
 			},
@@ -205,7 +204,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 		{
 			name: "Same directory for credentials requests, credentials source, and credentials",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
-				tmpDir, err := ioutil.TempDir(os.TempDir(), testCredentialsDirPrefix)
+				tmpDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
 				require.NoError(t, err, "Failed to create temp directory for credentials")
 				credReqDir = tmpDir
 				targetDir = tmpDir
@@ -214,7 +213,7 @@ func TestCreateSharedSecrets(t *testing.T) {
 				return
 			},
 			verify: func(t *testing.T, manifestsDir string) {
-				files, err := ioutil.ReadDir(manifestsDir)
+				files, err := os.ReadDir(manifestsDir)
 				require.NoError(t, err, "unexpected error listing files in manifestsDir")
 				assert.Len(t, files, 1, "Should be exactly one files in manifestsDir when one CredReq to process")
 				contents := getSecretFromFileContents(t, filepath.Join(manifestsDir, files[0].Name()))
@@ -283,7 +282,7 @@ func getBasicAuthCredentialsWithPE(pcUsername, pcPassword, peName, peUsername, p
 
 func writeToTempFile(t *testing.T, targetDir, content, prefix, extension string) string {
 	filePattern := fmt.Sprintf("%s*.%s", prefix, extension)
-	f, err := ioutil.TempFile(targetDir, filePattern)
+	f, err := os.CreateTemp(targetDir, filePattern)
 	require.NoError(t, err, "error creating temp file for %s", filePattern)
 	defer f.Close()
 
@@ -293,7 +292,7 @@ func writeToTempFile(t *testing.T, targetDir, content, prefix, extension string)
 }
 
 func getSecretFromFileContents(t *testing.T, path string) *kubernetes.BasicAuthCredential {
-	contents, err := ioutil.ReadFile(path)
+	contents, err := os.ReadFile(path)
 	require.NoError(t, err, "should be able to real contents of file")
 
 	data := struct {

--- a/pkg/cmd/provisioning/utils.go
+++ b/pkg/cmd/provisioning/utils.go
@@ -9,7 +9,6 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -54,7 +53,7 @@ func CreateShellScript(commands []string) string {
 }
 
 // CountNonDirectoryFiles counts files which are not a directory
-func CountNonDirectoryFiles(files []os.FileInfo) int {
+func CountNonDirectoryFiles(files []os.DirEntry) int {
 	NonDirectoryFiles := 0
 	for _, f := range files {
 		if !f.IsDir() {
@@ -76,7 +75,7 @@ spec:
 	clusterAuthFile := filepath.Join(targetDir, ManifestsDirName, "cluster-authentication-02-config.yaml")
 
 	fileData := fmt.Sprintf(clusterAuthenticationTemplate, issuerURL)
-	if err := ioutil.WriteFile(clusterAuthFile, []byte(fileData), 0600); err != nil {
+	if err := os.WriteFile(clusterAuthFile, []byte(fileData), 0600); err != nil {
 		return errors.Wrap(err, "failed to save cluster authentication file")
 	}
 	log.Printf("Wrote cluster authentication manifest at path %s", clusterAuthFile)
@@ -88,7 +87,7 @@ spec:
 // BuildJsonWebKeySet builds JSON web key set from the public key
 func BuildJsonWebKeySet(publicKeyPath string) ([]byte, error) {
 	log.Print("Reading public key")
-	publicKeyContent, err := ioutil.ReadFile(publicKeyPath)
+	publicKeyContent, err := os.ReadFile(publicKeyPath)
 
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to read public key")
@@ -153,7 +152,7 @@ func KeyIDFromPublicKey(publicKey interface{}) (string, error) {
 // GetListOfCredentialsRequests decodes manifests in a given directory and returns a list of CredentialsRequests
 func GetListOfCredentialsRequests(dir string, enableTechPreview bool) ([]*credreqv1.CredentialsRequest, error) {
 	credRequests := make([]*credreqv1.CredentialsRequest, 0)
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/provisioning/utils_test.go
+++ b/pkg/cmd/provisioning/utils_test.go
@@ -1,7 +1,6 @@
 package provisioning
 
 import (
-	"io/ioutil"
 	"os"
 	"testing"
 
@@ -203,7 +202,7 @@ func saveCredReq(t *testing.T, credReq *credreqv1.CredentialsRequest) {
 	out, err := re.MarshalJSON()
 	require.NoError(t, err, "error marshaling CredReq")
 
-	f, err := ioutil.TempFile(testDirPath, "credreq-testing-*.yaml")
+	f, err := os.CreateTemp(testDirPath, "credreq-testing-*.yaml")
 	require.NoError(t, err, "error creating temp file")
 	defer f.Close()
 


### PR DESCRIPTION
The io/ioutil package has been depreciated since Go v1.16. This change migrates the usage of this package to the same functionality provided in the io and os packages.

Assisted-by: gemini-2.5-pro