### PR TITLE
OCPBUGS-62184: aws: remove endpoint overrides for s3 and cf clients

### DIFF
--- a/pkg/aws/client.go
+++ b/pkg/aws/client.go
@@ -345,12 +345,6 @@ func NewClientFromConfig(cfg awssdk.Config, endpoint string) (Client, error) {
 		iamOpts = append(iamOpts, func(o *iam.Options) {
 			o.BaseEndpoint = &endpoint
 		})
-		s3Opts = append(s3Opts, func(o *s3.Options) {
-			o.BaseEndpoint = &endpoint
-		})
-		cfOpts = append(cfOpts, func(o *cloudfront.Options) {
-			o.BaseEndpoint = &endpoint
-		})
 	}
 
 	return &awsClient{


### PR DESCRIPTION
During the migration to aws-ask-go-v2, the iam client endpoint was used to override the baseEndpoint for all of the services. This did not cause any issues in the operator because it does not use these clients. And, it did not cause any issues in the ccoctl binary because it does not override the endpoints. However, this is causing issues with other projects which include the relevant code.

This change removes the assignemnt of the overrides for the s3 and cf clients. This removes the ability to override the s3 and cf client endpoints. However, this is not currently an issue because they are not used in combination at this time. If either of these clients become needed in the future, or the ccoctl gains the ability to override the endpoints, then this functionality will need to be sorted out such that the proper endpoint override is being assigned to each client.