### PR TITLE
CCO-714: Add preserve-existing-roles flag to ccoctl auzre

### DIFF
--- a/pkg/cmd/provisioning/azure/azure.go
+++ b/pkg/cmd/provisioning/azure/azure.go
@@ -52,6 +52,10 @@ type azureOptions struct {
 	// (cluster-network-operator, machine-api-operator, and cluster-storage-operator(file)) will be
 	// scoped to the NetworkResourceGroupName.
 	NetworkResourceGroupName string
+
+	// PreserveExistingRoles is a bool indicating that ccoctl should not remove existing role assignments
+	// from a managed identity.
+	PreserveExistingRoles bool
 }
 
 // NewAzureCmd implements the "azure" subcommand for credentials provisioning

--- a/pkg/cmd/provisioning/azure/create_all.go
+++ b/pkg/cmd/provisioning/azure/create_all.go
@@ -95,6 +95,7 @@ func createAllCmd(cmd *cobra.Command, args []string) {
 		CreateAllOpts.NetworkResourceGroupName,
 		CreateAllOpts.UserTags,
 		CreateAllOpts.EnableTechPreview,
+		CreateAllOpts.PreserveExistingRoles,
 		// dryRun may only be invoked by subcommands create-oidc-issuer and create-managed-identities
 		false)
 	if err != nil {
@@ -223,6 +224,7 @@ func NewCreateAllCmd() *cobra.Command {
 	createAllCmd.PersistentFlags().StringVar(&CreateAllOpts.OutputDir, "output-dir", "", "Directory to place generated manifest files. Defaults to the current directory.")
 	createAllCmd.PersistentFlags().StringToStringVar(&CreateAllOpts.UserTags, "user-tags", map[string]string{}, "User tags to be applied to Azure resources, multiple tags may be specified comma-separated for example: --user-tags key1=value1,key2=value2")
 	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests annotated with TechPreviewNoUpgrade")
+	createAllCmd.PersistentFlags().BoolVar(&CreateAllOpts.PreserveExistingRoles, "preserve-existing-roles", false, "Do not remove existing role assignments from managed identities")
 
 	return createAllCmd
 }

--- a/pkg/cmd/provisioning/azure/create_managed_identities_test.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities_test.go
@@ -499,6 +499,7 @@ func TestCreateManagedIdentities(t *testing.T) {
 				testNetworkResourceGroupName,
 				testUserTags,
 				test.enableTechPreview,
+				false, // preserveExistingRoles
 				test.dryRun)
 			if test.expectError {
 				require.Error(t, err, "expected error")
@@ -640,6 +641,7 @@ func TestEnsureRolesAssignedToManagedIdentity(t *testing.T) {
 	tests := []struct {
 		name                   string
 		mockAzureClientWrapper func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper
+		preserveExistingRoles  bool
 		roleBindings           []credreqv1.RoleBinding
 		expectError            bool
 	}{
@@ -798,13 +800,59 @@ func TestEnsureRolesAssignedToManagedIdentity(t *testing.T) {
 				return wrapper
 			},
 		},
+		{
+			name: "Extra role assignments preserved when preserve-existing-roles",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			preserveExistingRoles: true,
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+						// This existing role assignment isn't enumerated in the credreqv1.RoleBindings
+						{
+							Name: to.Ptr("DNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "DNSZoneContributorRoleDefinitionID")),
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			mockCtrl := gomock.NewController(t)
 			mockAzureClientWrapper := test.mockAzureClientWrapper(mockCtrl)
-			err := ensureRolesAssignedToManagedIdentity(mockAzureClientWrapper, testManagedIdentityPrincipalID, testSubscriptionID, test.roleBindings, testScopingResourceGroupNames)
+			err := ensureRolesAssignedToManagedIdentity(mockAzureClientWrapper, testManagedIdentityPrincipalID, testSubscriptionID, test.roleBindings, testScopingResourceGroupNames, test.preserveExistingRoles)
 			if test.expectError {
 				require.Error(t, err, "expected error")
 			} else {


### PR DESCRIPTION
By default, ccoctl reconciles the roles assigned to a managed identity, removing any roles that are not explicitly defined in the CredentialsRequest. This can be problematic if a user has manually assigned additional roles to the identity for other purposes, as they will be removed on the next run.

This commit introduces a new `--preserve-existing-roles` flag to the Azure provisioning commands. When this flag is enabled, ccoctl will no longer remove existing role assignments. It will only ensure that the roles specified in the CredentialsRequest are present, making the operation additive rather than a full reconciliation.

Assisted-by: gemini-2.5-pro