### PR TITLE
OCPBUGS-58181: Fix nil pointer dereference in ensureRolesAssignedToManagedIdentity

### DIFF
--- a/pkg/cmd/provisioning/azure/create_managed_identities.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities.go
@@ -268,6 +268,10 @@ func ensureRolesAssignedToManagedIdentity(client *azureclients.AzureClientWrappe
 			// at the specified scope
 			roleAssignmentExists := false
 			for _, roleAssignment := range existingRoleAssignments {
+				if roleAssignment.Properties == nil || roleAssignment.Properties.RoleDefinitionID == nil || roleAssignment.Properties.Scope == nil {
+					log.Printf("skipping incomplete role assignment (nil Properties, RoleDefinitionID, or Scope)")
+					continue
+				}
 				if *roleDefinition.Properties.RoleName == roleBinding.Role && *roleAssignment.Properties.RoleDefinitionID == *roleDefinition.ID && *roleAssignment.Properties.Scope == scope {
 					roleAssignmentExists = true
 					log.Printf("Found existing role assignment %s for user-assigned managed identity with principal ID %s at scope %s", roleBinding.Role, managedIdentityPrincipalID, scope)
@@ -300,6 +304,10 @@ func ensureRolesAssignedToManagedIdentity(client *azureclients.AzureClientWrappe
 	}
 
 	for _, existingRoleAssignment := range existingRoleAssignments {
+		if existingRoleAssignment.Name == nil || existingRoleAssignment.Properties == nil || existingRoleAssignment.Properties.RoleDefinitionID == nil || existingRoleAssignment.Properties.Scope == nil {
+			log.Printf("skipping incomplete existing role assignment during cleanup (nil Name, Properties, RoleDefinitionID, or Scope)")
+			continue
+		}
 		found := false
 		for _, shouldExistRoleAssignment := range shouldExistRoleAssignments {
 			if shouldExistRoleAssignment != nil && *shouldExistRoleAssignment.Name == *existingRoleAssignment.Name {

--- a/pkg/cmd/provisioning/azure/create_managed_identities_test.go
+++ b/pkg/cmd/provisioning/azure/create_managed_identities_test.go
@@ -800,6 +800,313 @@ func TestEnsureRolesAssignedToManagedIdentity(t *testing.T) {
 			},
 		},
 		{
+			name: "Existing role assignment with nil Properties is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						// Incomplete role assignment with nil Properties (simulates Azure eventual consistency)
+						{
+							Name:       to.Ptr("IncompleteRoleAssignmentName"),
+							Properties: nil,
+						},
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
+			name: "Existing role assignment with nil RoleDefinitionID is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						// Role assignment with Properties present but nil RoleDefinitionID
+						{
+							Name: to.Ptr("IncompleteRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: nil,
+							},
+						},
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
+			name: "Existing role assignment with nil Scope is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						// Role assignment with Properties and RoleDefinitionID present but nil Scope
+						{
+							Name: to.Ptr("IncompleteRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            nil,
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
+			name: "Extra role assignment with nil Properties in cleanup loop is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+						// Incomplete role assignment that is not in shouldExistRoleAssignments — would reach the cleanup loop
+						{
+							Name:       to.Ptr("IncompleteExtraRoleAssignmentName"),
+							Properties: nil,
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
+			name: "Extra role assignment with nil RoleDefinitionID in cleanup loop is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+						// Role assignment with nil RoleDefinitionID that is not in shouldExistRoleAssignments — would reach the cleanup loop
+						{
+							Name: to.Ptr("NilRoleDefIDExtraRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: nil,
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
+			name: "Extra role assignment with nil Name in cleanup loop is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+						// Role assignment with nil Name that would reach the cleanup loop
+						{
+							Name: nil,
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
+			name: "Extra role assignment with nil Scope in cleanup loop is skipped without panic",
+			roleBindings: []credreqv1.RoleBinding{
+				{
+					Role: "Private DNS Zone Contributor",
+				},
+			},
+			mockAzureClientWrapper: func(mockCtrl *gomock.Controller) *azureclients.AzureClientWrapper {
+				wrapper := mockAzureClientWrapper(mockCtrl)
+				mockRoleAssignmentsListForScopePager(wrapper,
+					[]*armauthorization.RoleAssignment{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            to.Ptr("/subscriptions/" + testSubscriptionID + "/resourceGroups/" + testInstallResourceGroupName),
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+						// Role assignment with nil Scope that is not in shouldExistRoleAssignments — would reach the cleanup loop
+						{
+							Name: to.Ptr("NilScopeExtraRoleAssignmentName"),
+							Properties: &armauthorization.RoleAssignmentProperties{
+								Scope:            nil,
+								PrincipalID:      to.Ptr(testManagedIdentityPrincipalID),
+								RoleDefinitionID: to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							},
+						},
+					},
+					testManagedIdentityPrincipalID,
+					testSubscriptionID,
+				)
+				mockRoleDefinitionsListPager(wrapper, "/subscriptions/"+testSubscriptionID,
+					[]*armauthorization.RoleDefinition{
+						{
+							Name: to.Ptr("PrivateDNSZoneContibutorRoleDefinitionName"),
+							ID:   to.Ptr(fmt.Sprintf("/subscriptions/%s/providers/Microsoft.Authorization/roleDefinitions/%s", testSubscriptionID, "PrivateDNSZoneContibutorRoleDefinitionID")),
+							Properties: &armauthorization.RoleDefinitionProperties{
+								RoleName: to.Ptr("Private DNS Zone Contributor"),
+							},
+						},
+					})
+				return wrapper
+			},
+		},
+		{
 			name: "Extra role assignments preserved when preserve-existing-roles",
 			roleBindings: []credreqv1.RoleBinding{
 				{


### PR DESCRIPTION
Add nil checks for Properties, RoleDefinitionID, and Scope fields before dereferencing role assignments. This prevents panics during retry scenarios when Azure API returns role assignments with nil properties.

Assisted-by: Claude Sonnet 4.6

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness when reconciling Azure managed identity role assignments by ignoring incomplete or malformed role-assignment entries, preventing crashes during detection and cleanup.

* **Tests**
  * Added unit tests covering partially populated or missing role-assignment data to ensure reconciliation and cleanup complete without errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->