### PR TITLE
OCPBUGS-83449: test-ext: hypershift skip CCO metrics endpoint validation

### DIFF
--- a/test/extend/cloudcredential.go
+++ b/test/extend/cloudcredential.go
@@ -791,6 +791,8 @@ spec:
 	})
 
 	g.It("[Suite:cco/conformance/parallel][PolarionID:88196] NonHyperShiftHOST-High-CCO metrics endpoint validation", ote.Informing(), func() {
+		skipIfHypershiftHostedCluster(oc)
+
 		g.By("Validate CCO container exposes metrics on port 8443")
 		ports, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("deployment", "cloud-credential-operator", "-n", DefaultNamespace, "-o=jsonpath={.spec.template.spec.containers[?(@.name==\"cloud-credential-operator\")].ports}").Output()
 		o.Expect(err).NotTo(o.HaveOccurred())


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added skip condition for Hypershift-hosted clusters in CCO metrics endpoint conformance test to ensure proper test execution across different cluster configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->