### PR TITLE
CCO-711: docs: improve the filter when getting the capi pod

### DIFF
--- a/docs/sts-migrate-to-private-bucket.md
+++ b/docs/sts-migrate-to-private-bucket.md
@@ -121,6 +121,7 @@ TOKEN_PATH=$(oc get secrets aws-cloud-credentials \
 # Get Controler's pod
 CAPI_POD=$(oc get pods -n openshift-machine-api \
     -l api=clusterapi \
+    -l k8s-app=controller \
     -o jsonpath='{.items[*].metadata.name}')
 
 # Extract tokens from the pod


### PR DESCRIPTION
Previously, a validation step in sts-migrate-to-private-bucket.md fetched the name of the CAPI pod from the cluster. However, it was fetching more than the desired pod, which caused a followup command to fail.

This change adds additional filters to the command fetching the pod in order to ensure it is only fetching the desired pod. As a result, the followup command will now succeed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced STS private bucket migration documentation with additional pod selection constraints. Users migrating to private buckets will now find more precise guidance for identifying the correct Kubernetes pod when extracting authentication tokens, ensuring more reliable and accurate token retrieval during the migration process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->