### PR TITLE
CCO-845: use AlwaysAllow UnhealthyPodEvictionPolicy option in PDBs

### DIFF
--- a/bindata/v4.1.0/common/poddisruptionbudget.yaml
+++ b/bindata/v4.1.0/common/poddisruptionbudget.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: pod-identity-webhook

--- a/pkg/assets/v410_00_assets/bindata.go
+++ b/pkg/assets/v410_00_assets/bindata.go
@@ -435,6 +435,7 @@ metadata:
   namespace: openshift-cloud-credential-operator
 spec:
   minAvailable: 1
+  unhealthyPodEvictionPolicy: AlwaysAllow
   selector:
     matchLabels:
       app: pod-identity-webhook


### PR DESCRIPTION
Allow eviction of unhealthy (not ready) pods even if there are no disruptions
allowed on a PodDisruptionBudget. This can help to drain/maintain a node and
recover without a manual intervention when multiple instances of nodes or pods
are misbehaving.

Conventions change: https://github.com/openshift/enhancements/pull/1995

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Configuration**
  * PodDisruptionBudget updated to include unhealthyPodEvictionPolicy: AlwaysAllow, permitting eviction of unhealthy pods during disruptions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->