### PR TITLE
OCPBUGS-87029: nutanix: fix ccoctl to accept directory for --credentials-source-filepath

### DIFF
--- a/pkg/cmd/provisioning/nutanix/create_shared_secrets.go
+++ b/pkg/cmd/provisioning/nutanix/create_shared_secrets.go
@@ -53,7 +53,7 @@ func createSharedSecretsCmd() *cobra.Command {
 
 	cmd.PersistentFlags().StringVar(&CreateSharedSecretsOpts.CredRequestDir, "credentials-requests-dir", "", "Directory containing files of CredentialsRequests (can be created by running 'oc adm release extract --credentials-requests --cloud=nutanix' against an OpenShift release image)")
 	cmd.MarkPersistentFlagRequired("credentials-requests-dir")
-	cmd.PersistentFlags().StringVar(&CreateSharedSecretsOpts.CredentialsSourceFilePath, "credentials-source-filepath", "", "The filepath of the nutanix credentials data. If not specified, will use the default path ~/.nutanix/credentials")
+	cmd.PersistentFlags().StringVar(&CreateSharedSecretsOpts.CredentialsSourceFilePath, "credentials-source-filepath", "", "The path to the nutanix credentials data file, or the directory containing a file named 'credentials'. If not specified, will use the default path ~/.nutanix/credentials")
 	cmd.PersistentFlags().StringVar(&CreateSharedSecretsOpts.TargetDir, "output-dir", "", "Directory to place generated files (defaults to current directory)")
 	cmd.PersistentFlags().BoolVar(&CreateSharedSecretsOpts.EnableTechPreview, "enable-tech-preview", false, "Opt into processing CredentialsRequests marked as tech-preview")
 
@@ -87,8 +87,15 @@ func createSecretsCmd(cmd *cobra.Command, args []string) error {
 
 // Retrieve the credentials data
 func getCredentialsFromFile(filePath string) (*kubernetes.NutanixCredentials, error) {
-	if _, err := os.Stat(filePath); err != nil {
+	fileInfo, err := os.Stat(filePath)
+	if err != nil {
 		return nil, errors.Wrapf(err, "source credentials file %s does not exist", filePath)
+	}
+	if fileInfo.IsDir() {
+		filePath = filepath.Join(filePath, "credentials")
+		if _, err := os.Stat(filePath); err != nil {
+			return nil, errors.Wrapf(err, "credentials file not found in directory; expected at %s", filePath)
+		}
 	}
 
 	bytes, err := os.ReadFile(filePath)

--- a/pkg/cmd/provisioning/nutanix/create_shared_secrets_test.go
+++ b/pkg/cmd/provisioning/nutanix/create_shared_secrets_test.go
@@ -182,6 +182,58 @@ func TestCreateSharedSecrets(t *testing.T) {
 			expectedErr: "source credentials file does/not/exist does not exist",
 		},
 		{
+			name: "Directory provided for credentials-source-filepath with credentials file inside",
+			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory for credentials requests")
+				testCredentialsRequest(t, "credreq-test", "NutanixProviderSpec", "secret-ns", "secret-name", credReqDir)
+
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory for credentials requests")
+
+				// Create a directory with a "credentials" file inside it (as the docs describe)
+				credentialsDir, err := os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory for credentials")
+				credentialsFilePath := filepath.Join(credentialsDir, "credentials")
+				err = os.WriteFile(credentialsFilePath, []byte(getBasicAuthCredentials("username", "password")), 0600)
+				require.NoError(t, err, "Failed to write credentials file")
+
+				// Pass the directory, not the file
+				credentialsSourceFilepath = credentialsDir
+				return
+			},
+			verify: func(t *testing.T, manifestsDir string) {
+				files, err := os.ReadDir(manifestsDir)
+				require.NoError(t, err, "unexpected error listing files in manifestsDir")
+				assert.Len(t, files, 1, "Should be exactly one file in manifestsDir when directory with credentials file is provided")
+				contents := getSecretFromFileContents(t, filepath.Join(manifestsDir, files[0].Name()))
+				assert.Equal(t, "username", contents.PrismCentral.Username)
+				assert.Equal(t, "password", contents.PrismCentral.Password)
+			},
+			expectedErr: "",
+		},
+		{
+			name: "Directory provided for credentials-source-filepath without credentials file inside",
+			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
+				credReqDir, err := os.MkdirTemp(os.TempDir(), testCredReqDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory for credentials requests")
+
+				targetDir, err = os.MkdirTemp(os.TempDir(), testTargetDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory for credentials requests")
+
+				// Pass a directory with no credentials file inside
+				credentialsSourceFilepath, err = os.MkdirTemp(os.TempDir(), testCredentialsDirPrefix)
+				require.NoError(t, err, "Failed to create temp directory for credentials")
+				return
+			},
+			verify: func(t *testing.T, manifestsDir string) {
+				files, err := os.ReadDir(manifestsDir)
+				require.NoError(t, err, "unexpected error listing files in manifestsDir")
+				assert.Zero(t, len(files), "Should be no files in manifestsDir when no credentials file in directory")
+			},
+			expectedErr: "credentials file not found in directory",
+		},
+		{
 			name: "Non-existent credentials requests directory",
 			setup: func(t *testing.T) (credReqDir, targetDir, credentialsSourceFilepath string) {
 				credReqDir = "does/not/exist"


### PR DESCRIPTION
## Problem

When a directory path is passed to `--credentials-source-filepath`, `ccoctl nutanix create-shared-secrets` fails with a cryptic error:

```
Error: credentials data read from file <dir>/ is invalid: failed to read the credentials file <dir>/: read <dir>/: is a directory
```

The root cause is that `os.Stat()` succeeds silently for directories, and `os.ReadFile()` then throws an unhelpful OS-level error.

This is also inconsistent with the official OCP documentation (4.16, 4.21), which describes `--credentials-source-filepath` as accepting a directory path.

## Fix

- In `getCredentialsFromFile()`, added an `IsDir()` check after `os.Stat()`. If a directory is provided, the code now automatically appends `credentials` to construct the full file path (e.g. `install-dir/` → `install-dir/credentials`), consistent with how the default `~/.nutanix/credentials` path is constructed.
- Updated the flag description in the binary help (`-h`) to clearly state that both a file path and a directory containing a file named `credentials` are accepted.

## Testing

Added two new test cases:
- `Directory provided for credentials-source-filepath with credentials file inside` — verifies successful secret generation when a directory is passed
- `Directory provided for credentials-source-filepath without credentials file inside` — verifies a clear error message when the directory has no `credentials` file

All 9 tests pass.

```
ok  github.com/openshift/cloud-credential-operator/pkg/cmd/provisioning/nutanix  2.097s
```

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* The `--credentials-source-filepath` flag now accepts both direct credentials file paths and directories containing a `credentials` file.
* Enhanced error handling provides clearer messages when credential files are missing or invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->