### PR TITLE
NO-ISSUE: Update OWNERS: remove 2uasimojo, suhanime

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,6 +1,4 @@
 approvers:
-- 2uasimojo
-- suhanime
 - dlom
 - jstuever
 


### PR DESCRIPTION
We were never truly owners of this repo, just backups due to arbitrary org chart lines. In the advent of PIXAA, we're *really* not owners anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal approver configuration.

---

*This release contains no user-facing changes.*

<!-- end of auto-generated comment: release notes by coderabbit.ai -->