### PR TITLE
OCPBUGS-33994: Don't unnecessarily re-reconcile when secrets are externally managed

### DIFF
--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -129,9 +129,25 @@ func (a *AWSActuator) Exists(ctx context.Context, cr *minterv1.CredentialsReques
 	}
 
 	existingSecret := &corev1.Secret{}
-	err = a.Client.Get(context.TODO(), types.NamespacedName{Namespace: cr.Spec.SecretRef.Namespace, Name: cr.Spec.SecretRef.Name}, existingSecret)
+	secretKey := types.NamespacedName{Namespace: cr.Spec.SecretRef.Namespace, Name: cr.Spec.SecretRef.Name}
+	err = a.Client.Get(ctx, secretKey, existingSecret)
 	if err != nil {
 		if k8serrors.IsNotFound(err) {
+			if a.LiveClient != nil {
+				// The cached client filters secrets by label; manually-managed
+				// secrets (e.g. in manual mode) won't have the label and will
+				// appear missing from the cache. Fall back to a direct API lookup.
+				err = a.LiveClient.Get(ctx, secretKey, existingSecret)
+				if err != nil {
+					if k8serrors.IsNotFound(err) {
+						logger.Debug("target secret does not exist")
+						return false, nil
+					}
+					return false, err
+				}
+				logger.Debug("target secret exists (found via live lookup)")
+				return true, nil
+			}
 			logger.Debug("target secret does not exist")
 			return false, nil
 		}
@@ -308,6 +324,25 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 	logger := a.getLogger(cr)
 	logger.Debug("running sync")
 
+	// On STS clusters, CRs without an IAM Role ARN have their secrets managed
+	// externally. Return early before needsUpdate, which would attempt to load
+	// the secret through the label-filtered cache and fail.
+	stsDetected, err := utils.IsTimedTokenCluster(a.Client, ctx, logger)
+	if err != nil {
+		return err
+	}
+	logger.Debugf("stsDetected: %v", stsDetected)
+	if stsDetected {
+		awsSTSIAMRoleARN, err := awsSTSIAMRoleARN(minterv1.Codec, cr)
+		if err != nil {
+			return err
+		}
+		if awsSTSIAMRoleARN == "" {
+			logger.Debug("CredentialsRequest has no awsSTSIAMRoleARN, no reason to sync")
+			return nil
+		}
+	}
+
 	// Should we update anything
 	needsUpdate, err := a.needsUpdate(ctx, cr)
 	if err != nil {
@@ -323,21 +358,9 @@ func (a *AWSActuator) sync(ctx context.Context, cr *minterv1.CredentialsRequest)
 		return nil
 	}
 
-	stsDetected, err := utils.IsTimedTokenCluster(a.Client, ctx, logger)
-	if err != nil {
-		return err
-	}
-	logger.Debugf("stsDetected: %v", stsDetected)
 	if stsDetected {
 		logger.Debug("actuator detected STS enabled cluster, enabling STS secret brokering for CredentialsRequests providing an IAM Role ARN")
-		awsSTSIAMRoleARN, err := awsSTSIAMRoleARN(minterv1.Codec, cr)
-		if err != nil {
-			return err
-		}
-		if awsSTSIAMRoleARN == "" {
-			logger.Debug("CredentialsRequest has no awsSTSIAMRoleARN, no reason to sync")
-			return nil
-		}
+		awsSTSIAMRoleARN, _ := awsSTSIAMRoleARN(minterv1.Codec, cr)
 		cloudTokenPath := cr.Spec.CloudTokenPath
 		if cr.Spec.CloudTokenPath == "" {
 			logger.Debug("CredentialsRequest has no cloudTokenPath, defaulting cloudTokenPath to /var/run/secrets/kubernetes.io/serviceaccount/token")

--- a/pkg/operator/credentialsrequest/credentialsrequest_controller.go
+++ b/pkg/operator/credentialsrequest/credentialsrequest_controller.go
@@ -800,6 +800,17 @@ func (r *ReconcileCredentialsRequest) Reconcile(ctx context.Context, request rec
 			return reconcile.Result{}, err
 		}
 
+		// Unlike the non-STS guard, we omit cloudCredsSecretUpdated and
+		// isInfrastructureUpdated: STS secrets reference an IAM role ARN and
+		// token path, not root credentials or infrastructure tags.
+		isStale := cr.Generation != cr.Status.LastSyncGeneration
+		hasRecentlySynced := cr.Status.LastSyncTimestamp != nil && cr.Status.LastSyncTimestamp.Add(syncPeriod).After(time.Now())
+		hasActiveFailureConditions := checkForFailureConditions(cr)
+		if !isStale && hasRecentlySynced && credsExists && !hasActiveFailureConditions && cr.Status.Provisioned {
+			logger.Debug("STS: recently synced and target secret exists, no need to sync")
+			return reconcile.Result{RequeueAfter: defaultRequeueTime}, nil
+		}
+
 		var syncErr error
 		syncErr = r.CreateOrUpdateOnCredsExist(ctx, credsExists, syncErr, cr)
 		if syncErr != nil {


### PR DESCRIPTION
xref: OCPBUGS-33994

> When the cloud-credential-operator is used in manual mode, and awsSTSIAMRoleARN is not present in a credentialRequest (such as core operators), it continually attempts to reconcile. This started happening when we began filtering the secrets. Because the manually managed secrets do not have the proper annotation, cloud-credential-operator is no longer able to see them. As a result, when attempting to see if the credentialRequest needs to be updated (needsupdate), it always returns true due to no secret found.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved secret existence verification to properly handle manually-managed credentials with fallback mechanism
  * Optimized credential synchronization workflow in secure token service environments, reducing unnecessary operations
  * Enhanced error resilience in credential request processing with better condition monitoring and early validation checks

<!-- end of auto-generated comment: release notes by coderabbit.ai -->