### PR TITLE
OCPBUGS-96412: Move ec2 volume attach/detach to unscoped section

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -116,11 +116,9 @@ var (
 	// and modify this map in pkg/aws/utils.go.
 	infraResourceTagScopedActions = map[string]bool{
 		// EC2 — actions on existing, cluster-owned tagged resources
-		"ec2:AttachVolume":                    true,
 		"ec2:CreateSnapshot":                  true,
 		"ec2:DeleteSnapshot":                  true,
 		"ec2:DeleteVolume":                    true,
-		"ec2:DetachVolume":                    true,
 		"ec2:EnableFastSnapshotRestores":      true,
 		"ec2:ModifyNetworkInterfaceAttribute": true,
 		"ec2:ModifyVolume":                    true,
@@ -182,6 +180,12 @@ var (
 		"ec2:AssignPrivateIpAddresses":   true,
 		"ec2:UnassignIpv6Addresses":      true,
 		"ec2:UnassignPrivateIpAddresses": true,
+		// EC2 — Attach/Detach volume are multi-resource actions (volume +
+		// instance). AWS evaluates aws:ResourceTag against both resources, so
+		// the condition fails when the instance does not carry the cluster tag
+		// (common in UPI and externally-managed infrastructure).
+		"ec2:AttachVolume": true,
+		"ec2:DetachVolume": true,
 		// EC2 — Create/Delete for fleet resources (not cluster-tagged)
 		"ec2:AllocateHosts":        true,
 		"ec2:CreateFleet":          true,

--- a/pkg/aws/utils_test.go
+++ b/pkg/aws/utils_test.go
@@ -26,7 +26,7 @@ type payloadAWSAction struct {
 // CredentialsRequest manifests in the payload.
 var payloadAWSActions = []payloadAWSAction{
 	// aws-ebs-csi-driver-operator / openshift-machine-api-aws (shared)
-	{"ec2:AttachVolume", true},
+	{"ec2:AttachVolume", false},
 	{"ec2:CreateSnapshot", true},
 	{"ec2:CreateTags", false},
 	{"ec2:CreateVolume", false},
@@ -38,7 +38,7 @@ var payloadAWSActions = []payloadAWSAction{
 	{"ec2:DescribeTags", false},
 	{"ec2:DescribeVolumes", false},
 	{"ec2:DescribeVolumesModifications", false},
-	{"ec2:DetachVolume", true},
+	{"ec2:DetachVolume", false},
 	{"ec2:ModifyVolume", true},
 	{"ec2:DescribeAvailabilityZones", false},
 	{"ec2:EnableFastSnapshotRestores", true},


### PR DESCRIPTION
xref: OCPBUGS-96412

followup for OCPBUGS-87829

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated how certain EC2 volume actions are treated for cluster tag-based access checks.
  * `AttachVolume` and `DetachVolume` now follow the correct unscoped behavior, preventing unexpected policy matches when related resources don’t share the same ownership tag.
  * Aligned automated checks with the updated access classification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->