### PR TITLE
OCPBUGS-95187: Reclassify ec2:ModifyNetworkInterfaceAttribute as unscoped

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -116,16 +116,15 @@ var (
 	// and modify this map in pkg/aws/utils.go.
 	infraResourceTagScopedActions = map[string]bool{
 		// EC2 — actions on existing, cluster-owned tagged resources
-		"ec2:AttachVolume":                    true,
-		"ec2:CreateSnapshot":                  true,
-		"ec2:DeleteSnapshot":                  true,
-		"ec2:DeleteVolume":                    true,
-		"ec2:DetachVolume":                    true,
-		"ec2:EnableFastSnapshotRestores":      true,
-		"ec2:ModifyNetworkInterfaceAttribute": true,
-		"ec2:ModifyVolume":                    true,
-		"ec2:ReleaseHosts":                    true,
-		"ec2:TerminateInstances":              true,
+		"ec2:AttachVolume":               true,
+		"ec2:CreateSnapshot":             true,
+		"ec2:DeleteSnapshot":             true,
+		"ec2:DeleteVolume":               true,
+		"ec2:DetachVolume":               true,
+		"ec2:EnableFastSnapshotRestores": true,
+		"ec2:ModifyVolume":               true,
+		"ec2:ReleaseHosts":               true,
+		"ec2:TerminateInstances":         true,
 		// ELB — mutating actions on tagged resources
 		"elasticloadbalancing:DeregisterTargets":                 true,
 		"elasticloadbalancing:RegisterInstancesWithLoadBalancer": true,
@@ -182,6 +181,9 @@ var (
 		"ec2:AssignPrivateIpAddresses":   true,
 		"ec2:UnassignIpv6Addresses":      true,
 		"ec2:UnassignPrivateIpAddresses": true,
+		// EC2 — AWS evaluates the aws:ResourceTag condition against the security groups
+		// referenced by this action, which may not carry the cluster ownership tag.
+		"ec2:ModifyNetworkInterfaceAttribute": true,
 		// EC2 — Create/Delete for fleet resources (not cluster-tagged)
 		"ec2:AllocateHosts":        true,
 		"ec2:CreateFleet":          true,

--- a/pkg/aws/utils_test.go
+++ b/pkg/aws/utils_test.go
@@ -126,7 +126,7 @@ var payloadAWSActions = []payloadAWSAction{
 	{"ec2:DescribeInstanceStatus", false},
 	{"ec2:DescribeNetworkInterfaceAttribute", false},
 	{"ec2:DescribeNetworkInterfaces", false},
-	{"ec2:ModifyNetworkInterfaceAttribute", true},
+	{"ec2:ModifyNetworkInterfaceAttribute", false},
 	{"ec2:AssignIpv6Addresses", false},
 	{"ec2:AssignPrivateIpAddresses", false},
 	{"ec2:UnassignIpv6Addresses", false},


### PR DESCRIPTION
## Summary

- Moves `ec2:ModifyNetworkInterfaceAttribute` from `infraResourceTagScopedActions` to `infraResourceTagUnscopedActions` in `pkg/aws/utils.go`
- Updates the corresponding payload classification test expectation from `true` → `false`

## Root cause

#1043 added an `aws:ResourceTag/kubernetes.io/cluster/<id>: owned` condition to all actions in `infraResourceTagScopedActions`, including `ec2:ModifyNetworkInterfaceAttribute`. However, AWS evaluates this condition not only against the ENI (primary resource of the action) but also against each security group passed as a parameter. Security groups created by some providers carry only their own provider-specific tag and not the `kubernetes.io/cluster/` ownership tag, causing a 403 on the call.

The fix reclassifies this action as unscoped — consistent with the existing precedent for other ENI-related actions (`ec2:AssignIpv6Addresses`, etc.) — so no `aws:ResourceTag` condition is applied.

This is directly affecting `CAPA` operations on `CCAPIO` `pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview` and `pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview-post-install` CI jobs
Investigation details: https://redhat.atlassian.net/browse/OCPBUGS-95187?focusedCommentId=17472155

Policy modification in live job run resulted in [success](https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_cluster-capi-operator/611/pull-ci-openshift-cluster-capi-operator-main-e2e-aws-capi-techpreview/2072659655389089792).

## Open questions

- [x] Backport it to the places where #1043 was backported?
- [x] Are other CAPA actions also affected after this one is fixed? Not for what e2e tests cover.
