### PR TITLE
WIP: OCPBUGS-96892: move snapshot actions to unscoped

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -117,8 +117,6 @@ var (
 	infraResourceTagScopedActions = map[string]bool{
 		// EC2 — actions on existing, cluster-owned tagged resources
 		"ec2:AttachVolume":                    true,
-		"ec2:CreateSnapshot":                  true,
-		"ec2:DeleteSnapshot":                  true,
 		"ec2:DeleteVolume":                    true,
 		"ec2:DetachVolume":                    true,
 		"ec2:EnableFastSnapshotRestores":      true,
@@ -176,6 +174,9 @@ var (
 		// it, so an aws:ResourceTag condition is unsatisfiable at call time.
 		"ec2:CreateTags": true,
 		"ec2:DeleteTags": true,
+		// EC2 — Create/Delete snapshots
+		"ec2:CreateSnapshot": true,
+		"ec2:DeleteSnapshot": true,
 		// EC2 — ENI IP assignment actions target network interfaces that
 		// are not tagged with the cluster ownership tag.
 		"ec2:AssignIpv6Addresses":        true,

--- a/pkg/aws/utils_test.go
+++ b/pkg/aws/utils_test.go
@@ -27,10 +27,10 @@ type payloadAWSAction struct {
 var payloadAWSActions = []payloadAWSAction{
 	// aws-ebs-csi-driver-operator / openshift-machine-api-aws (shared)
 	{"ec2:AttachVolume", true},
-	{"ec2:CreateSnapshot", true},
+	{"ec2:CreateSnapshot", false},
 	{"ec2:CreateTags", false},
 	{"ec2:CreateVolume", false},
-	{"ec2:DeleteSnapshot", true},
+	{"ec2:DeleteSnapshot", false},
 	{"ec2:DeleteTags", false},
 	{"ec2:DeleteVolume", true},
 	{"ec2:DescribeInstances", false},


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated AWS permission handling so EC2 snapshot creation and deletion actions are no longer treated as tag-scoped.
  * Improved the accuracy of tag-condition checks for snapshot-related IAM actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->