### PR TITLE
OCPBUGS-97666: Classify ec2 instance management actions as scoped

### DIFF
--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -123,7 +123,10 @@ var (
 		"ec2:DetachVolume":               true,
 		"ec2:EnableFastSnapshotRestores": true,
 		"ec2:ModifyVolume":               true,
+		"ec2:RebootInstances":           true,
 		"ec2:ReleaseHosts":               true,
+		"ec2:StartInstances":            true,
+		"ec2:StopInstances":             true,
 		"ec2:TerminateInstances":         true,
 		// ELB — mutating actions on tagged resources
 		"elasticloadbalancing:DeregisterTargets":                 true,

--- a/pkg/aws/utils_test.go
+++ b/pkg/aws/utils_test.go
@@ -151,6 +151,14 @@ func TestSupportsInfraResourceTagCondition(t *testing.T) {
 		assert.True(t, supported)
 	})
 
+	t.Run("ec2 instance management actions are scoped", func(t *testing.T) {
+		for _, action := range []string{"ec2:StartInstances", "ec2:StopInstances", "ec2:RebootInstances"} {
+			supported, err := SupportsInfraResourceTagCondition(action)
+			require.NoError(t, err, "action %q should be classified", action)
+			assert.True(t, supported, "action %q should be scoped (supports aws:ResourceTag)", action)
+		}
+	})
+
 	t.Run("unscoped action returns false", func(t *testing.T) {
 		supported, err := SupportsInfraResourceTagCondition("ec2:DescribeInstances")
 		require.NoError(t, err)


### PR DESCRIPTION
Hi all\! First-time contributor here 😄 
I'm from the [Medik8s](https://www.medik8s.io/) team. We maintain several node remediation operators for OpenShift, including Fence Agents Remediation (FAR).

## Summary

Add `ec2:StartInstances`, `ec2:StopInstances`, and `ec2:RebootInstances` to `infraResourceTagScopedActions` in `pkg/aws/utils.go`.

These three EC2 instance management actions support the `aws:ResourceTag` condition (per the [AWS Service Authorization Reference](https://docs.aws.amazon.com/service-authorization/latest/reference/list_amazonec2.html)) and belong alongside `ec2:TerminateInstances`, which is already classified as scoped.

## Why

PR #1043 introduced strict IAM policy scoping — any action not classified in either `infraResourceTagScopedActions` or `infraResourceTagUnscopedActions` now causes CCO to error.

[Fence Agents Remediation (FAR)](https://github.com/medik8s/fence-agents-remediation) is a Medik8s operator for automated node remediation using fence agents across multiple platforms. When running e2e tests on [OCP CI](https://docs.ci.openshift.org/) against AWS clusters, FAR provisions AWS credentials via a [CredentialsRequest](https://github.com/medik8s/fence-agents-remediation/blob/main/config/ocp_aws/fence_aws_credentials_request.yaml) that declares `ec2:StartInstances`, `ec2:StopInstances`, and `ec2:RebootInstances` for EC2 fencing. Since these actions are missing from both classification maps, credential provisioning fails ([source](https://github.com/medik8s/fence-agents-remediation/pull/208#issuecomment-4866535985)):

```
error syncing credentials: error syncing creds in mint-mode: cannot build scoped IAM policy:
unrecognized AWS action "ec2:StartInstances" has no aws:ResourceTag classification;
file a bug against openshift/cloud-credential-operator to add it to
infraResourceTagScopedActions or infraResourceTagUnscopedActions in pkg/aws/utils.go
```

This blocks all FAR e2e tests on OCP 4.23+ and 5.0:
- https://github.com/medik8s/fence-agents-remediation/pull/208 — e2e tests failing on 4.23/5.0
- https://github.com/openshift/release/pull/81176 — CI config update blocked by same failure

## Relationship to PR #1057

This PR is a surgical fix for the three missing actions. PR #1057 proposes a full revert of #1043 due to broader CSI snapshot failures (OCPBUGS-96892). If #1057 merges first, this PR becomes a no-op (the maps it adds to would no longer exist). If this PR merges first, it unblocks FAR independently of the revert.

Tracked in [OCPBUGS-97666](https://redhat.atlassian.net/browse/OCPBUGS-97666).

## Changes

- `pkg/aws/utils.go`: Add 3 actions to `infraResourceTagScopedActions` (alphabetically, next to `ec2:TerminateInstances`)
- `pkg/aws/utils_test.go`: Add test verifying the 3 new actions are classified as scoped

## Testing

```
$ go test ./pkg/aws/... -v -run TestSupportsInfraResourceTagCondition
--- PASS: TestSupportsInfraResourceTagCondition/ec2_instance_management_actions_are_scoped (0.00s)
PASS
```