### PR TITLE
permissions scope tightening with type scoping

### DIFF
--- a/hack/verify-action-maps.sh
+++ b/hack/verify-action-maps.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env bash
+#
+# Extracts AWS CredentialsRequest manifests from an OpenShift release payload
+# and compares the IAM actions they declare against the hardcoded classification
+# maps in pkg/aws/utils.go.
+#
+# Usage:
+#   ./hack/verify-action-maps.sh [RELEASE_IMAGE]
+#
+# If RELEASE_IMAGE is omitted, the script pulls the latest 5.0.0 nightly.
+# Set REGISTRY_AUTH_FILE to point to a pull secret (default: $HOME/.pull-secret).
+# Requires: oc, jq, yq, curl
+
+set -euo pipefail
+
+AUTHFILE="${REGISTRY_AUTH_FILE:-$HOME/.pull-secret}"
+RELEASE_IMAGE="${1:-}"
+TMPDIR=$(mktemp -d)
+trap 'rm -rf "$TMPDIR"' EXIT
+
+for cmd in oc jq yq curl; do
+  if ! command -v "$cmd" &>/dev/null; then
+    echo "ERROR: $cmd not found in PATH" >&2
+    exit 1
+  fi
+done
+
+# Resolve release image if not provided
+if [[ -z "$RELEASE_IMAGE" ]]; then
+  echo "No release image specified, resolving "
+  RELEASE_IMAGE=$(curl -sfL 'https://amd64.ocp.releases.ci.openshift.org/api/v1/releasestream/5.0.0-0.nightly/latest' | jq -r '.pullSpec // empty') || true
+  if [[ -z "$RELEASE_IMAGE" ]]; then
+    echo "ERROR: could not resolve latest nightly (curl or jq failed). Pass a release image explicitly." >&2
+    exit 1
+  fi
+  echo "Using: $RELEASE_IMAGE"
+fi
+
+# Extract CredentialsRequest manifests from the payload
+echo "Extracting CredentialsRequests from payload..."
+AUTH_ARGS=()
+if [[ -f "$AUTHFILE" ]]; then
+  AUTH_ARGS=(-a "$AUTHFILE")
+fi
+if ! oc adm release extract \
+  "${AUTH_ARGS[@]}" \
+  --credentials-requests \
+  --to="$TMPDIR/credrequests" \
+  "$RELEASE_IMAGE" 2>/dev/null; then
+  echo "ERROR: oc adm release extract failed for $RELEASE_IMAGE" >&2
+  [[ ! -f "$AUTHFILE" ]] && echo "  No authfile found at $AUTHFILE — set REGISTRY_AUTH_FILE or place a pull secret there" >&2
+  exit 1
+fi
+
+# Filter to AWS-only CredentialsRequests and extract actions
+echo "Parsing AWS actions from CredentialsRequests..."
+PAYLOAD_ACTIONS="$TMPDIR/payload-actions.txt"
+: > "$PAYLOAD_ACTIONS"
+
+for f in "$TMPDIR"/credrequests/*.yaml; do
+  [[ -f "$f" ]] || continue
+
+  # Check if this is an AWS CredentialsRequest (has AWSProviderSpec)
+  if ! grep -q 'AWSProviderSpec' "$f" 2>/dev/null; then
+    continue
+  fi
+
+  CR_NAME=$(grep -m1 'name:' "$f" | awk '{print $2}')
+
+  # Extract action strings using yq (handles YAML reliably)
+  if ! yq '(.spec.providerSpec.value // .spec.providerSpec).statementEntries[].action[]' "$f" >> "$PAYLOAD_ACTIONS" 2>/dev/null; then
+    echo "WARNING: yq parsing failed for $f (CR: ${CR_NAME:-unknown}), falling back to grep" >&2
+    grep -oP '^\s*- \K\S+:\S+' "$f" >> "$PAYLOAD_ACTIONS" 2>/dev/null || true
+  fi
+done
+
+# Filter to AWS IAM actions only (service:Action pattern, e.g. ec2:DescribeInstances).
+# This excludes IBM Cloud CRN strings (crn:v1:bluemix:...) and other non-AWS entries.
+grep -P '^[a-z][a-z0-9-]+:[A-Z]' "$PAYLOAD_ACTIONS" > "$PAYLOAD_ACTIONS.filtered" 2>/dev/null || true
+mv "$PAYLOAD_ACTIONS.filtered" "$PAYLOAD_ACTIONS"
+
+# Deduplicate and sort
+sort -u "$PAYLOAD_ACTIONS" -o "$PAYLOAD_ACTIONS"
+PAYLOAD_COUNT=$(wc -l < "$PAYLOAD_ACTIONS")
+if [[ "$PAYLOAD_COUNT" -eq 0 ]]; then
+  echo "ERROR: no AWS actions found in payload CredentialsRequests — extraction may have failed" >&2
+  exit 1
+fi
+echo "Found $PAYLOAD_COUNT unique AWS actions in payload CredentialsRequests"
+
+# Extract actions from the scoped+unscoped maps in utils.go
+UTILS_GO="pkg/aws/utils.go"
+if [[ ! -f "$UTILS_GO" ]]; then
+  echo "ERROR: $UTILS_GO not found (run from repo root)" >&2
+  exit 1
+fi
+
+CODE_ACTIONS="$TMPDIR/code-actions.txt"
+grep -oP '"\K[a-zA-Z0-9]+:[a-zA-Z0-9*]+(?="\s*:)' "$UTILS_GO" | sort -u > "$CODE_ACTIONS"
+CODE_COUNT=$(wc -l < "$CODE_ACTIONS")
+if [[ "$CODE_COUNT" -eq 0 ]]; then
+  echo "ERROR: no actions extracted from $UTILS_GO — grep pattern may need updating" >&2
+  exit 1
+fi
+echo "Found $CODE_COUNT unique AWS actions in $UTILS_GO maps"
+
+# Extract actions from the test list in utils_test.go
+UTILS_TEST="pkg/aws/utils_test.go"
+TEST_ACTIONS="$TMPDIR/test-actions.txt"
+if [[ -f "$UTILS_TEST" ]]; then
+  sed -n '/^var payloadAWSActions/,/^func /p' "$UTILS_TEST" | grep -oP '"\K[a-zA-Z0-9]+:[a-zA-Z0-9*]+(?=")' | sort -u > "$TEST_ACTIONS"
+  TEST_COUNT=$(wc -l < "$TEST_ACTIONS")
+  echo "Found $TEST_COUNT unique AWS actions in $UTILS_TEST payloadAWSActions"
+else
+  : > "$TEST_ACTIONS"
+  echo "WARNING: $UTILS_TEST not found, skipping test list comparison"
+fi
+
+echo ""
+
+# Compare: actions in payload but missing from code maps
+MISSING_FROM_CODE="$TMPDIR/missing-from-code.txt"
+comm -23 "$PAYLOAD_ACTIONS" "$CODE_ACTIONS" > "$MISSING_FROM_CODE"
+
+# Compare: actions in payload but missing from test list
+MISSING_FROM_TEST="$TMPDIR/missing-from-test.txt"
+comm -23 "$PAYLOAD_ACTIONS" "$TEST_ACTIONS" > "$MISSING_FROM_TEST"
+
+# Compare: actions in code but not in payload (stale?)
+STALE_IN_CODE="$TMPDIR/stale-in-code.txt"
+comm -23 "$CODE_ACTIONS" "$PAYLOAD_ACTIONS" > "$STALE_IN_CODE"
+
+# Report
+EXIT=0
+
+if [[ -s "$MISSING_FROM_CODE" ]]; then
+  echo "FAIL: Actions in payload but MISSING from utils.go maps:"
+  sed 's/^/  /' "$MISSING_FROM_CODE"
+  echo ""
+  echo "  Add these to infraResourceTagScopedActions or infraResourceTagUnscopedActions"
+  echo "  in $UTILS_GO."
+  echo ""
+  EXIT=1
+fi
+
+if [[ -s "$MISSING_FROM_TEST" ]]; then
+  echo "FAIL: Actions in payload but MISSING from utils_test.go payloadAWSActions:"
+  sed 's/^/  /' "$MISSING_FROM_TEST"
+  echo ""
+  echo "  Add these to payloadAWSActions in $UTILS_TEST."
+  echo ""
+  EXIT=1
+fi
+
+if [[ -s "$STALE_IN_CODE" ]]; then
+  echo "INFO: Actions in utils.go maps but NOT in current payload (may be stale or defensive):"
+  sed 's/^/  /' "$STALE_IN_CODE"
+  echo ""
+fi
+
+if [[ $EXIT -eq 0 ]]; then
+  echo "OK: All $PAYLOAD_COUNT payload actions are covered in both utils.go and utils_test.go"
+fi
+
+exit $EXIT

--- a/pkg/aws/actuator/actuator.go
+++ b/pkg/aws/actuator/actuator.go
@@ -249,7 +249,7 @@ func (a *AWSActuator) needsUpdate(ctx context.Context, cr *minterv1.CredentialsR
 		}
 
 		// Check whether the current policy attached to the creds match what is being requested
-		desiredUserPolicy, err := a.getDesiredUserPolicy(awsSpec.StatementEntries, *user.User.Arn)
+		desiredUserPolicy, err := a.getDesiredUserPolicy(awsSpec.StatementEntries, *user.User.Arn, infra.Status.InfrastructureName)
 		if err != nil {
 			return false, err
 		}
@@ -641,7 +641,7 @@ func (a *AWSActuator) syncMint(ctx context.Context, cr *minterv1.CredentialsRequ
 	}
 
 	// TODO: check if user policy needs to be set? user generation and last set time.
-	desiredUserPolicy, err := a.getDesiredUserPolicy(awsSpec.StatementEntries, *userOut.Arn)
+	desiredUserPolicy, err := a.getDesiredUserPolicy(awsSpec.StatementEntries, *userOut.Arn, infra.Status.InfrastructureName)
 	if err != nil {
 		return err
 	}
@@ -754,8 +754,8 @@ func userHasExpectedTags(logger log.FieldLogger, user *iamtypes.User, clusterUUI
 
 	if infraResource != nil && infraResource.Status.InfrastructureName != "" {
 		clusterTag := fmt.Sprintf("kubernetes.io/cluster/%s", infraResource.Status.InfrastructureName)
-		if !userHasTag(user, clusterTag, "owned") {
-			log.Warnf("user missing tag: %s=%s", clusterTag, "owned")
+		if !userHasTag(user, clusterTag, ccaws.InfraResourceTagValue) {
+			log.Warnf("user missing tag: %s=%s", clusterTag, ccaws.InfraResourceTagValue)
 			return false
 		}
 	} else {
@@ -911,7 +911,7 @@ func (a *AWSActuator) tagUser(ctx context.Context, logger log.FieldLogger, awsCl
 	if infra.Status.InfrastructureName != "" {
 		tags = append(tags, iamtypes.Tag{
 			Key:   awssdk.String(fmt.Sprintf("kubernetes.io/cluster/%s", infra.Status.InfrastructureName)),
-			Value: awssdk.String("owned"),
+			Value: awssdk.String(ccaws.InfraResourceTagValue),
 		})
 	} else {
 		tags = append(tags, iamtypes.Tag{
@@ -1077,20 +1077,76 @@ func (a *AWSActuator) syncAccessKeySecret(ctx context.Context, cr *minterv1.Cred
 	return nil
 }
 
-func (a *AWSActuator) getDesiredUserPolicy(entries []minterv1.StatementEntry, userARN string) (string, error) {
+func (a *AWSActuator) getDesiredUserPolicy(entries []minterv1.StatementEntry, userARN, infraName string) (string, error) {
 
 	policyDoc := PolicyDocument{
 		Version:   "2012-10-17",
 		Statement: []StatementEntry{},
 	}
+
+	var infraConditionKey string
+	if infraName != "" {
+		infraConditionKey = ccaws.InfraResourceTagKeyPrefix + infraName
+	}
+
 	for _, se := range entries {
-		policyDoc.Statement = append(policyDoc.Statement,
-			StatementEntry{
-				Effect:    se.Effect,
-				Action:    se.Action,
-				Resource:  se.Resource,
-				Condition: se.PolicyCondition,
-			})
+		if infraConditionKey == "" || se.Effect != "Allow" {
+			policyDoc.Statement = append(policyDoc.Statement,
+				StatementEntry{
+					Effect:    se.Effect,
+					Action:    se.Action,
+					Resource:  se.Resource,
+					Condition: se.PolicyCondition,
+				})
+			continue
+		}
+
+		// Partition actions by aws:ResourceTag compatibility.
+		var unscopedActions, scopedActions []string
+		for _, action := range se.Action {
+			supported, err := ccaws.SupportsInfraResourceTagCondition(action)
+			if err != nil {
+				return "", fmt.Errorf("cannot build scoped IAM policy: %w", err)
+			}
+			if supported {
+				scopedActions = append(scopedActions, action)
+			} else {
+				unscopedActions = append(unscopedActions, action)
+			}
+		}
+
+		// Emit scoped statement with the infra tag condition
+		if len(scopedActions) > 0 {
+			var condition minterv1.IAMPolicyCondition
+			if se.PolicyCondition != nil {
+				condition = *se.PolicyCondition.DeepCopy()
+			} else {
+				condition = minterv1.IAMPolicyCondition{}
+			}
+			if condition["StringEquals"] == nil {
+				condition["StringEquals"] = minterv1.IAMPolicyConditionKeyValue{}
+			}
+			condition["StringEquals"][infraConditionKey] = ccaws.InfraResourceTagValue
+
+			policyDoc.Statement = append(policyDoc.Statement,
+				StatementEntry{
+					Effect:    se.Effect,
+					Action:    scopedActions,
+					Resource:  se.Resource,
+					Condition: condition,
+				})
+		}
+
+		// Emit unscoped statement without the infra tag condition
+		if len(unscopedActions) > 0 {
+			policyDoc.Statement = append(policyDoc.Statement,
+				StatementEntry{
+					Effect:    se.Effect,
+					Action:    unscopedActions,
+					Resource:  se.Resource,
+					Condition: se.PolicyCondition,
+				})
+		}
 	}
 
 	// Always allow a statment that enables iam:GetUser on yourself (to allow access_key/awsClient to username lookups)

--- a/pkg/aws/actuator/actuator_test.go
+++ b/pkg/aws/actuator/actuator_test.go
@@ -18,6 +18,7 @@ package actuator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
@@ -716,4 +717,275 @@ func testAuthentication(issuer string) *configv1.Authentication {
 		},
 	}
 	return conf
+}
+
+func TestGetDesiredUserPolicyInfraCondition(t *testing.T) {
+	a := &AWSActuator{}
+	infraName := "test-infra"
+	conditionKey := ccaws.InfraResourceTagKeyPrefix + infraName
+	userARN := "arn:aws:iam::123456789012:user/test-user"
+
+	t.Run("scoped actions get infra condition", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:TerminateInstances"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 2)
+		strEq := doc.Statement[0].Condition["StringEquals"]
+		assert.Equal(t, ccaws.InfraResourceTagValue, strEq[conditionKey])
+	})
+
+	t.Run("existing StringEquals condition preserved on scoped action", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{
+				Effect:   "Allow",
+				Action:   []string{"ec2:TerminateInstances"},
+				Resource: "*",
+				PolicyCondition: minterv1.IAMPolicyCondition{
+					"StringEquals": minterv1.IAMPolicyConditionKeyValue{
+						"ec2:Region": "us-east-1",
+					},
+				},
+			},
+		}
+		snapshot := entries[0].PolicyCondition.DeepCopy()
+
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		assert.Equal(t, *snapshot, entries[0].PolicyCondition)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		strEq := doc.Statement[0].Condition["StringEquals"]
+		assert.Equal(t, "us-east-1", strEq["ec2:Region"])
+		assert.Equal(t, ccaws.InfraResourceTagValue, strEq[conditionKey])
+	})
+
+	t.Run("unscoped actions do not get infra condition", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:DescribeInstances"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 2)
+		assert.Nil(t, doc.Statement[0].Condition)
+	})
+
+	t.Run("snapshot actions are unscoped", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:CreateSnapshot", "ec2:DeleteSnapshot"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 2)
+		assert.ElementsMatch(t, []string{"ec2:CreateSnapshot", "ec2:DeleteSnapshot"}, doc.Statement[0].Action)
+		assert.Nil(t, doc.Statement[0].Condition)
+	})
+
+	t.Run("S3 actions are all unscoped", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"s3:CreateBucket", "s3:GetObject", "s3:PutObject"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 2)
+		assert.ElementsMatch(t, []string{"s3:CreateBucket", "s3:GetObject", "s3:PutObject"}, doc.Statement[0].Action)
+		assert.Nil(t, doc.Statement[0].Condition)
+	})
+
+	t.Run("multiple scoped statements all get condition", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:TerminateInstances"}, Resource: "*"},
+			{Effect: "Allow", Action: []string{"ec2:DeleteVolume"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 3)
+		for _, stmt := range doc.Statement[:2] {
+			strEq := stmt.Condition["StringEquals"]
+			assert.Equal(t, ccaws.InfraResourceTagValue, strEq[conditionKey])
+		}
+	})
+
+	t.Run("empty infraName skips condition", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:TerminateInstances"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, "")
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		assert.Nil(t, doc.Statement[0].Condition)
+	})
+
+	t.Run("empty infraName preserves existing condition without mutation", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{
+				Effect:   "Allow",
+				Action:   []string{"ec2:TerminateInstances"},
+				Resource: "*",
+				PolicyCondition: minterv1.IAMPolicyCondition{
+					"StringEquals": minterv1.IAMPolicyConditionKeyValue{
+						"ec2:Region": "us-east-1",
+					},
+				},
+			},
+		}
+		snapshot := entries[0].PolicyCondition.DeepCopy()
+
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, "")
+		require.NoError(t, err)
+
+		assert.Equal(t, *snapshot, entries[0].PolicyCondition)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		assert.Equal(t, "us-east-1", doc.Statement[0].Condition["StringEquals"]["ec2:Region"])
+	})
+
+	t.Run("mixed scoped and unscoped actions are split", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{
+				Effect:   "Allow",
+				Action:   []string{"ec2:RunInstances", "ec2:TerminateInstances", "ec2:DescribeInstances"},
+				Resource: "*",
+			},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		// Scoped (TerminateInstances) + unscoped (RunInstances, DescribeInstances) + iam:GetUser = 3
+		require.Len(t, doc.Statement, 3)
+
+		assert.Equal(t, []string{"ec2:TerminateInstances"}, doc.Statement[0].Action)
+		assert.Equal(t, ccaws.InfraResourceTagValue, doc.Statement[0].Condition["StringEquals"][conditionKey])
+
+		assert.ElementsMatch(t, []string{"ec2:RunInstances", "ec2:DescribeInstances"}, doc.Statement[1].Action)
+		assert.Nil(t, doc.Statement[1].Condition)
+
+		assert.Equal(t, []string{"iam:GetUser"}, doc.Statement[2].Action)
+	})
+
+	t.Run("mixed statement preserves original condition on both halves", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{
+				Effect:   "Allow",
+				Action:   []string{"ec2:RunInstances", "ec2:TerminateInstances"},
+				Resource: "*",
+				PolicyCondition: minterv1.IAMPolicyCondition{
+					"Bool": minterv1.IAMPolicyConditionKeyValue{
+						"kms:GrantIsForAWSResource": true,
+					},
+				},
+			},
+		}
+		snapshot := entries[0].PolicyCondition.DeepCopy()
+
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		assert.Equal(t, *snapshot, entries[0].PolicyCondition)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 3)
+
+		assert.Equal(t, true, doc.Statement[0].Condition["Bool"]["kms:GrantIsForAWSResource"])
+		assert.Equal(t, ccaws.InfraResourceTagValue, doc.Statement[0].Condition["StringEquals"][conditionKey])
+
+		assert.Equal(t, true, doc.Statement[1].Condition["Bool"]["kms:GrantIsForAWSResource"])
+		_, hasStringEquals := doc.Statement[1].Condition["StringEquals"]
+		assert.False(t, hasStringEquals)
+	})
+
+	t.Run("Deny statements are never conditioned", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Deny", Action: []string{"s3:DeleteBucket"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		assert.Nil(t, doc.Statement[0].Condition)
+	})
+
+	t.Run("iam:GetUser self-lookup has no infra condition", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:TerminateInstances"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		getUserStmt := doc.Statement[len(doc.Statement)-1]
+		assert.Equal(t, []string{"iam:GetUser"}, getUserStmt.Action)
+		assert.Empty(t, getUserStmt.Condition)
+	})
+
+	t.Run("unknown action returns error", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"ec2:TerminateInstances", "foo:BarAction"}, Resource: "*"},
+		}
+		_, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "foo:BarAction")
+		assert.Contains(t, err.Error(), "openshift/cloud-credential-operator")
+	})
+
+	t.Run("unknown action with empty infraName is not checked", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"foo:BarAction"}, Resource: "*"},
+		}
+		_, err := a.getDesiredUserPolicy(entries, userARN, "")
+		require.NoError(t, err)
+	})
+
+	t.Run("KMS actions are scoped via key resource type", func(t *testing.T) {
+		entries := []minterv1.StatementEntry{
+			{Effect: "Allow", Action: []string{"kms:Decrypt", "kms:Encrypt"}, Resource: "*"},
+		}
+		policyJSON, err := a.getDesiredUserPolicy(entries, userARN, infraName)
+		require.NoError(t, err)
+
+		var doc PolicyDocument
+		require.NoError(t, json.Unmarshal([]byte(policyJSON), &doc))
+
+		require.Len(t, doc.Statement, 2)
+		strEq := doc.Statement[0].Condition["StringEquals"]
+		assert.Equal(t, ccaws.InfraResourceTagValue, strEq[conditionKey])
+	})
 }

--- a/pkg/aws/utils.go
+++ b/pkg/aws/utils.go
@@ -16,6 +16,15 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 )
 
+const (
+	// InfraResourceTagKeyPrefix is the IAM policy condition key prefix used to scope
+	// actions to resources tagged with a cluster's infrastructure ID.
+	InfraResourceTagKeyPrefix = "aws:ResourceTag/kubernetes.io/cluster/"
+
+	// InfraResourceTagValue is the expected tag value for cluster-owned resources.
+	InfraResourceTagValue = "owned"
+)
+
 // credMintingActions is a list of AWS verbs needed to run in the mode where the
 // cloud-credential-operator can mint new creds to satisfy CredentialRequest CRDs
 var (
@@ -92,6 +101,154 @@ var (
 		"iam:ListAccessKeys",
 	}
 
+	// infraResourceTagScopedActions is the set of AWS actions for which the
+	// aws:ResourceTag condition is known to work. Only these actions get the
+	// cluster-scoping condition added to their Allow statements. Actions not
+	// in this set are either known-incompatible (Describe/List/Create/S3/IAM/
+	// Route53) or unrecognized. Unrecognized actions cause an error at policy
+	// generation time.
+	//
+	// This list was compiled by cross-referencing every action in the
+	// OpenShift payload's CredentialsRequests against the AWS Service
+	// Authorization Reference (docs.aws.amazon.com/service-authorization).
+	//
+	// To update this list, file a bug against openshift/cloud-credential-operator
+	// and modify this map in pkg/aws/utils.go.
+	infraResourceTagScopedActions = map[string]bool{
+		// EC2 — actions on existing, cluster-owned tagged resources.
+		// Note: CreateSnapshot and DeleteSnapshot are intentionally absent — see
+		// infraResourceTagUnscopedActions for the rationale.
+		"ec2:AttachVolume":               true,
+		"ec2:DeleteVolume":               true,
+		"ec2:DetachVolume":               true,
+		"ec2:EnableFastSnapshotRestores": true,
+		"ec2:ModifyVolume":               true,
+		"ec2:ReleaseHosts":               true,
+		"ec2:TerminateInstances":         true,
+		// ELB — mutating actions on tagged resources
+		"elasticloadbalancing:DeregisterTargets":                 true,
+		"elasticloadbalancing:RegisterInstancesWithLoadBalancer": true,
+		"elasticloadbalancing:RegisterTargets":                   true,
+		// KMS — all actions on the key resource type support ResourceTag
+		"kms:CreateGrant":                     true,
+		"kms:Decrypt":                         true,
+		"kms:DescribeKey":                     true,
+		"kms:Encrypt":                         true,
+		"kms:GenerateDataKey":                 true,
+		"kms:GenerateDataKeyWithoutPlainText": true,
+		"kms:ListGrants":                      true,
+		"kms:ReEncrypt*":                      true,
+		"kms:ReEncryptFrom":                   true,
+		"kms:ReEncryptTo":                     true,
+		"kms:RevokeGrant":                     true,
+	}
+
+	// infraResourceTagUnscopedActions is the set of AWS actions known to be
+	// incompatible with the aws:ResourceTag condition. These are kept
+	// separate from the scoped set so that unknown actions can be detected
+	// (an action in neither set triggers an error).
+	infraResourceTagUnscopedActions = map[string]bool{
+		// EC2 — Describe/List (no resource-level permissions)
+		"ec2:DescribeAvailabilityZones":         true,
+		"ec2:DescribeCapacityReservations":      true,
+		"ec2:DescribeDhcpOptions":               true,
+		"ec2:DescribeImages":                    true,
+		"ec2:DescribeInstanceStatus":            true,
+		"ec2:DescribeInstanceTypeOfferings":     true,
+		"ec2:DescribeInstanceTypes":             true,
+		"ec2:DescribeInstances":                 true,
+		"ec2:DescribeInternetGateways":          true,
+		"ec2:DescribeLaunchTemplates":           true,
+		"ec2:DescribeNetworkInterfaceAttribute": true,
+		"ec2:DescribeNetworkInterfaces":         true,
+		"ec2:DescribeRegions":                   true,
+		"ec2:DescribeSecurityGroups":            true,
+		"ec2:DescribeSnapshots":                 true,
+		"ec2:DescribeSpotPriceHistory":          true,
+		"ec2:DescribeSubnets":                   true,
+		"ec2:DescribeTags":                      true,
+		"ec2:DescribeVolumes":                   true,
+		"ec2:DescribeVolumesModifications":      true,
+		"ec2:DescribeVpcs":                      true,
+		// EC2 — tagging actions must be unscoped: they are used to apply the
+		// cluster ownership tag to newly created resources that do not yet carry
+		// it, so an aws:ResourceTag condition is unsatisfiable at call time.
+		"ec2:CreateTags": true,
+		"ec2:DeleteTags": true,
+		// EC2 — snapshot operations: aws:ResourceTag is evaluated against the
+		// snapshot resource type. CreateSnapshot creates a new snapshot whose
+		// tags are not yet set at authorization time, so the condition always
+		// fails. DeleteSnapshot is paired here for consistency — snapshots may
+		// be created without the cluster tag if creation-time tagging races.
+		"ec2:CreateSnapshot": true,
+		"ec2:DeleteSnapshot": true,
+		// EC2 — ENI IP assignment actions target network interfaces that
+		// are not tagged with the cluster ownership tag.
+		"ec2:AssignIpv6Addresses":        true,
+		"ec2:AssignPrivateIpAddresses":   true,
+		"ec2:UnassignIpv6Addresses":      true,
+		"ec2:UnassignPrivateIpAddresses": true,
+		// EC2 — AWS evaluates the aws:ResourceTag condition against the security
+		// groups referenced by this action, which may not carry the cluster
+		// ownership tag (e.g. security groups created by external providers).
+		"ec2:ModifyNetworkInterfaceAttribute": true,
+		// EC2 — Create/Delete for fleet resources (not cluster-tagged)
+		"ec2:AllocateHosts":        true,
+		"ec2:CreateFleet":          true,
+		"ec2:CreateLaunchTemplate": true,
+		"ec2:CreateVolume":         true,
+		"ec2:DeleteLaunchTemplate": true,
+		"ec2:RunInstances":         true,
+		// S3 — none support aws:ResourceTag
+		"s3:AbortMultipartUpload":       true,
+		"s3:CreateBucket":               true,
+		"s3:DeleteBucket":               true,
+		"s3:DeleteObject":               true,
+		"s3:GetBucketLocation":          true,
+		"s3:GetBucketPublicAccessBlock": true,
+		"s3:GetBucketTagging":           true,
+		"s3:GetEncryptionConfiguration": true,
+		"s3:GetLifecycleConfiguration":  true,
+		"s3:GetObject":                  true,
+		"s3:ListBucket":                 true,
+		"s3:ListBucketMultipartUploads": true,
+		"s3:ListMultipartUploadParts":   true,
+		"s3:PutBucketPublicAccessBlock": true,
+		"s3:PutBucketTagging":           true,
+		"s3:PutEncryptionConfiguration": true,
+		"s3:PutLifecycleConfiguration":  true,
+		"s3:PutObject":                  true,
+		// ELB — Describe (no resource-level permissions)
+		"elasticloadbalancing:DescribeLoadBalancers": true,
+		"elasticloadbalancing:DescribeTargetGroups":  true,
+		"elasticloadbalancing:DescribeTargetHealth":  true,
+		// IAM — none of these support aws:ResourceTag
+		"iam:AddRoleToInstanceProfile":      true,
+		"iam:CreateInstanceProfile":         true,
+		"iam:CreateServiceLinkedRole":       true,
+		"iam:DeleteInstanceProfile":         true,
+		"iam:GetInstanceProfile":            true,
+		"iam:GetUser":                       true,
+		"iam:GetUserPolicy":                 true,
+		"iam:ListAccessKeys":                true,
+		"iam:ListInstanceProfiles":          true,
+		"iam:PassRole":                      true,
+		"iam:RemoveRoleFromInstanceProfile": true,
+		"iam:TagInstanceProfile":            true,
+		// Route53 — none support aws:ResourceTag
+		"route53:ChangeResourceRecordSets": true,
+		"route53:ListHostedZones":          true,
+		"route53:ListTagsForResources":     true,
+		// STS — AssumeRole does not support aws:ResourceTag
+		"sts:AssumeRole": true,
+		// Pricing API — no resource-level permissions
+		"pricing:GetProducts": true,
+		// SSM — parameter is not cluster-owned
+		"ssm:GetParameter": true,
+		// Resource Groups Tagging API
+		"tag:GetResources": true,
+	}
+
 	credentailRequestScheme = runtime.NewScheme()
 )
 
@@ -99,6 +256,25 @@ func init() {
 	if err := minterv1.AddToScheme(credentailRequestScheme); err != nil {
 		panic(err)
 	}
+}
+
+// SupportsInfraResourceTagCondition checks whether an AWS action supports the
+// aws:ResourceTag condition for cluster-scoped policy enforcement. Returns:
+//   - (true, nil) if the action is in the allowlist
+//   - (false, nil) if the action is known-incompatible
+//   - (false, error) if the action is unrecognized
+func SupportsInfraResourceTagCondition(action string) (bool, error) {
+	if infraResourceTagScopedActions[action] {
+		return true, nil
+	}
+	if infraResourceTagUnscopedActions[action] {
+		return false, nil
+	}
+	return false, fmt.Errorf(
+		"unrecognized AWS action %q has no aws:ResourceTag classification; "+
+			"file a bug against openshift/cloud-credential-operator to add it "+
+			"to infraResourceTagScopedActions or infraResourceTagUnscopedActions "+
+			"in pkg/aws/utils.go", action)
 }
 
 // SimulateParams captures any additional details that should be used
@@ -170,6 +346,10 @@ func CheckPermissionsUsingQueryClient(ctx context.Context, queryClient, targetCl
 				ContextKeyValues: []string{params.Region},
 			})
 		}
+		// NOTE: We intentionally do NOT inject aws:ResourceTag context here.
+		// The simulation validates base IAM permissions, not minted policy
+		// conditions. Injecting the tag makes create-action simulations
+		// falsely pass (the resource doesn't exist yet at call time).
 	}
 
 	// Either all actions are allowed and we'll return 'true', or it's a failure

--- a/pkg/aws/utils_test.go
+++ b/pkg/aws/utils_test.go
@@ -1,0 +1,207 @@
+package aws
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// payloadAWSAction pairs an action string from a payload CredentialsRequest
+// with its expected scoping classification (true = scoped, false = unscoped).
+type payloadAWSAction struct {
+	action string
+	scoped bool
+}
+
+// payloadAWSActions is the complete set of AWS IAM actions used in
+// CredentialsRequest manifests across the OpenShift payload. Every action
+// listed here must be classified in either infraResourceTagScopedActions or
+// infraResourceTagUnscopedActions. If a new CredentialsRequest adds an
+// action not on this list, add it here AND to the appropriate map in
+// utils.go.
+//
+// Source: grep -r '"action"' across all openshift/*-operator
+// CredentialsRequest manifests in the payload.
+var payloadAWSActions = []payloadAWSAction{
+	// aws-ebs-csi-driver-operator / openshift-machine-api-aws (shared)
+	{"ec2:AttachVolume", true},
+	// ec2:CreateSnapshot is unscoped: aws:ResourceTag is evaluated against the
+	// new snapshot resource, which has no tags at IAM authorization time.
+	{"ec2:CreateSnapshot", false},
+	{"ec2:CreateTags", false},
+	{"ec2:CreateVolume", false},
+	// ec2:DeleteSnapshot is unscoped for the same reason as CreateSnapshot.
+	{"ec2:DeleteSnapshot", false},
+	{"ec2:DeleteTags", false},
+	{"ec2:DeleteVolume", true},
+	{"ec2:DescribeInstances", false},
+	{"ec2:DescribeSnapshots", false},
+	{"ec2:DescribeTags", false},
+	{"ec2:DescribeVolumes", false},
+	{"ec2:DescribeVolumesModifications", false},
+	{"ec2:DetachVolume", true},
+	{"ec2:ModifyVolume", true},
+	{"ec2:DescribeAvailabilityZones", false},
+	{"ec2:EnableFastSnapshotRestores", true},
+	{"kms:ReEncrypt*", true},
+	{"kms:Decrypt", true},
+	{"kms:Encrypt", true},
+	{"kms:GenerateDataKey", true},
+	{"kms:GenerateDataKeyWithoutPlainText", true},
+	{"kms:DescribeKey", true},
+	{"kms:RevokeGrant", true},
+	{"kms:CreateGrant", true},
+	{"kms:ListGrants", true},
+
+	// openshift-machine-api-aws
+	{"ec2:AllocateHosts", false},
+	{"ec2:CreateFleet", false},
+	{"ec2:CreateLaunchTemplate", false},
+	{"ec2:DeleteLaunchTemplate", false},
+	{"ec2:DescribeCapacityReservations", false},
+	{"ec2:DescribeDhcpOptions", false},
+	{"ec2:DescribeImages", false},
+	{"ec2:DescribeInstanceTypeOfferings", false},
+	{"ec2:DescribeInstanceTypes", false},
+	{"ec2:DescribeInternetGateways", false},
+	{"ec2:DescribeLaunchTemplates", false},
+	{"ec2:DescribeSecurityGroups", false},
+	{"ec2:DescribeRegions", false},
+	{"ec2:DescribeSpotPriceHistory", false},
+	{"ec2:DescribeSubnets", false},
+	{"ec2:DescribeVpcs", false},
+	{"ec2:ReleaseHosts", true},
+	{"ec2:RunInstances", false},
+	{"ec2:TerminateInstances", true},
+	{"elasticloadbalancing:DescribeLoadBalancers", false},
+	{"elasticloadbalancing:DescribeTargetGroups", false},
+	{"elasticloadbalancing:DescribeTargetHealth", false},
+	{"elasticloadbalancing:RegisterInstancesWithLoadBalancer", true},
+	{"elasticloadbalancing:RegisterTargets", true},
+	{"elasticloadbalancing:DeregisterTargets", true},
+	{"iam:AddRoleToInstanceProfile", false},
+	{"iam:CreateInstanceProfile", false},
+	{"iam:CreateServiceLinkedRole", false},
+	{"iam:DeleteInstanceProfile", false},
+	{"iam:GetInstanceProfile", false},
+	{"iam:ListInstanceProfiles", false},
+	{"iam:PassRole", false},
+	{"iam:RemoveRoleFromInstanceProfile", false},
+	{"iam:TagInstanceProfile", false},
+	{"pricing:GetProducts", false},
+	{"ssm:GetParameter", false},
+
+	// openshift-ingress
+	{"route53:ListHostedZones", false},
+	{"route53:ListTagsForResources", false},
+	{"route53:ChangeResourceRecordSets", false},
+	{"tag:GetResources", false},
+	{"sts:AssumeRole", false},
+
+	// openshift-image-registry
+	{"s3:CreateBucket", false},
+	{"s3:DeleteBucket", false},
+	{"s3:PutBucketTagging", false},
+	{"s3:GetBucketTagging", false},
+	{"s3:PutBucketPublicAccessBlock", false},
+	{"s3:GetBucketPublicAccessBlock", false},
+	{"s3:PutEncryptionConfiguration", false},
+	{"s3:GetEncryptionConfiguration", false},
+	{"s3:PutLifecycleConfiguration", false},
+	{"s3:GetLifecycleConfiguration", false},
+	{"s3:GetBucketLocation", false},
+	{"s3:ListBucket", false},
+	{"s3:GetObject", false},
+	{"s3:PutObject", false},
+	{"s3:DeleteObject", false},
+	{"s3:ListBucketMultipartUploads", false},
+	{"s3:AbortMultipartUpload", false},
+	{"s3:ListMultipartUploadParts", false},
+
+	// cloud-credential-operator-iam-ro
+	{"iam:GetUser", false},
+	{"iam:GetUserPolicy", false},
+	{"iam:ListAccessKeys", false},
+
+	// openshift-cloud-network-config-controller-aws
+	{"ec2:DescribeInstanceStatus", false},
+	{"ec2:DescribeNetworkInterfaceAttribute", false},
+	{"ec2:DescribeNetworkInterfaces", false},
+	// ec2:ModifyNetworkInterfaceAttribute is unscoped: AWS evaluates the
+	// aws:ResourceTag condition against referenced security groups, which may
+	// not carry the kubernetes.io/cluster/ ownership tag.
+	{"ec2:ModifyNetworkInterfaceAttribute", false},
+	{"ec2:AssignIpv6Addresses", false},
+	{"ec2:AssignPrivateIpAddresses", false},
+	{"ec2:UnassignIpv6Addresses", false},
+	{"ec2:UnassignPrivateIpAddresses", false},
+}
+
+func TestPayloadActionsAreCovered(t *testing.T) {
+	for _, pa := range payloadAWSActions {
+		t.Run(pa.action, func(t *testing.T) {
+			supported, err := SupportsInfraResourceTagCondition(pa.action)
+			require.NoError(t, err, "action %q from payload CredentialsRequests is not classified — add it to infraResourceTagScopedActions or infraResourceTagUnscopedActions in pkg/aws/utils.go", pa.action)
+			assert.Equal(t, pa.scoped, supported,
+				"action %q classification mismatch: expected scoped=%v", pa.action, pa.scoped)
+		})
+	}
+}
+
+func TestSupportsInfraResourceTagCondition(t *testing.T) {
+	t.Run("scoped action returns true", func(t *testing.T) {
+		supported, err := SupportsInfraResourceTagCondition("ec2:TerminateInstances")
+		require.NoError(t, err)
+		assert.True(t, supported)
+	})
+
+	t.Run("unscoped action returns false", func(t *testing.T) {
+		supported, err := SupportsInfraResourceTagCondition("ec2:DescribeInstances")
+		require.NoError(t, err)
+		assert.False(t, supported)
+	})
+
+	t.Run("snapshot create is unscoped", func(t *testing.T) {
+		supported, err := SupportsInfraResourceTagCondition("ec2:CreateSnapshot")
+		require.NoError(t, err)
+		assert.False(t, supported)
+	})
+
+	t.Run("snapshot delete is unscoped", func(t *testing.T) {
+		supported, err := SupportsInfraResourceTagCondition("ec2:DeleteSnapshot")
+		require.NoError(t, err)
+		assert.False(t, supported)
+	})
+
+	t.Run("ModifyNetworkInterfaceAttribute is unscoped", func(t *testing.T) {
+		supported, err := SupportsInfraResourceTagCondition("ec2:ModifyNetworkInterfaceAttribute")
+		require.NoError(t, err)
+		assert.False(t, supported)
+	})
+
+	t.Run("unknown action returns error", func(t *testing.T) {
+		_, err := SupportsInfraResourceTagCondition("foo:BarAction")
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "foo:BarAction")
+	})
+
+	t.Run("all scoped and unscoped maps are disjoint", func(t *testing.T) {
+		for action := range infraResourceTagScopedActions {
+			assert.False(t, infraResourceTagUnscopedActions[action],
+				"action %q appears in both scoped and unscoped maps", action)
+		}
+	})
+
+	t.Run("no trailing whitespace in action keys", func(t *testing.T) {
+		for action := range infraResourceTagScopedActions {
+			assert.Equal(t, strings.TrimSpace(action), action,
+				"scoped action %q has whitespace", action)
+		}
+		for action := range infraResourceTagUnscopedActions {
+			assert.Equal(t, strings.TrimSpace(action), action,
+				"unscoped action %q has whitespace", action)
+		}
+	})
+}


### PR DESCRIPTION
  PR #1043 fixed CVE-2026-10843 by adding an
  `aws:ResourceTag/kubernetes.io/cluster/<infra>: "owned"` condition to the
  Allow statements in minted IAM user policies, restricting minted
  credentials to resources tagged as belonging to the cluster. PR #1057
  reverted it because snapshot-related tests in `e2e-aws-csi` began
  permafailing immediately after merge.

  *Why the revert happened*

  PR #1043 classified `ec2:CreateSnapshot` and `ec2:DeleteSnapshot` as actions
  that support the `aws:ResourceTag` condition
  (`infraResourceTagScopedActions`). This was wrong.

  When IAM evaluates `aws:ResourceTag` for `ec2:CreateSnapshot`, it checks the
  tag on the new snapshot resource — not the source volume. The snapshot
  does not yet exist at authorization time, so it has no tags. The
  `StringEquals` condition always evaluates to false → IAM denies every
  snapshot creation → every snapshot e2e test fails.

  `ec2:ModifyNetworkInterfaceAttribute` had the same classification problem
  for a different reason: AWS evaluates the condition against the
  referenced security groups, which may not carry the cluster ownership
  tag (e.g. security groups from external providers). PR #1053 fixed this
  separately but was also effectively reverted when PR #1057 removed the
  action maps entirely.

  *What this PR does*

  Re-lands the PR #1043 approach with three corrections:

  1. ec2:CreateSnapshot → infraResourceTagUnscopedActions — the
  authorization resource is the new snapshot, which has no tags at call
  time.
  2. ec2:DeleteSnapshot → infraResourceTagUnscopedActions — paired with
  CreateSnapshot for consistency; snapshots may be created without the
  cluster tag if tagging races at creation time.
  3. ec2:ModifyNetworkInterfaceAttribute → infraResourceTagUnscopedActions
  — re-applies PR #1053: AWS evaluates the condition against referenced
  security groups, which may not carry the cluster ownership tag.

  *Changes*

  - pkg/aws/utils.go — adds
  InfraResourceTagKeyPrefix/InfraResourceTagValue constants; adds
  infraResourceTagScopedActions and infraResourceTagUnscopedActions
  classification maps; adds SupportsInfraResourceTagCondition().
  - pkg/aws/actuator/actuator.go — extends getDesiredUserPolicy to accept
  infraName and split each Allow statement into a scoped sub-statement
  (with the cluster tag condition) and an unscoped sub-statement (without
  it); updates userHasExpectedTags and tagUser to use the shared
  InfraResourceTagValue constant.
  - pkg/aws/utils_test.go — complete payload action coverage test
  (TestPayloadActionsAreCovered) with corrected classifications for all
  three reclassified actions.
  - pkg/aws/actuator/actuator_test.go — unit tests for the new
  getDesiredUserPolicy behavior, including an explicit "snapshot actions
  are unscoped" case.
  - hack/verify-action-maps.sh — restored; extracts actions from a live
  release payload and diffs against the maps to catch future
  classification gaps at review time.

  *Security value preserved*

  After this fix, the following actions are scoped to cluster-owned
  resources: ec2:TerminateInstances, ec2:DeleteVolume, ec2:DetachVolume,
  ec2:AttachVolume, ec2:ModifyVolume, ec2:EnableFastSnapshotRestores,
  ec2:ReleaseHosts, all KMS key actions, and the ELB target registration
  actions. Snapshot create/delete, RunInstances, CreateVolume, S3,
  Route53, and IAM operations remain unconstrained because aws:ResourceTag
  is not evaluated for those action/resource-type combinations.

  *Verification*

  Before merge, run:
  /payload-job periodic-ci-openshift-release-main-nightly-5.0-e2e-aws-csi

  This is the job that surfaced the original regression (OCPBUGS-96892).

  xref: OCPBUGS-87829, OCPBUGS-96892, OCPBUGS-95187

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AWS permissions now support infrastructure-scoped resource tags for compatible actions, improving how access is constrained.
  * AWS user tagging now uses a consistent cluster tag value.

* **Bug Fixes**
  * Mixed AWS permission statements are now handled more safely by separating scoped and unscoped actions.
  * Policy generation now preserves existing conditions and avoids applying infra scoping where it is unsupported.

* **Tests**
  * Added coverage for AWS policy scoping, tag handling, and action classification consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->