### PR TITLE
CCO-849: bump go toolchain to 1.26.5 to resolve snyk complaints

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -2,7 +2,7 @@ module github.com/openshift/cloud-credential-operator
 
 go 1.26.0
 
-toolchain go1.26.4
+toolchain go1.26.5
 
 require (
 	cloud.google.com/go/iam v1.5.3


### PR DESCRIPTION
ci/prow/security is failing... again...

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Go toolchain to version 1.26.5.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->