### PR TITLE
TEST: Trigger manual-oidc tests with no code changes

### DIFF
--- a/pkg/azure/actuator_test.go
+++ b/pkg/azure/actuator_test.go
@@ -818,3 +818,4 @@ func testAuthentication(issuer string) *openshiftapiv1.Authentication {
 		},
 	}
 }
+


### PR DESCRIPTION
This PR adds only a blank line to test if the manual-oidc tests are currently broken on master. No functional code changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a trailing newline to improve file formatting consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->