### PR TITLE
OCPBUGS-83624: Embed credentials_request.yaml template in test binary

### DIFF
--- a/test/extend/cloudcredential.go
+++ b/test/extend/cloudcredential.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"regexp"
 	"strings"
 	"time"
@@ -416,15 +415,12 @@ data:
 		o.Expect(degradedStatus).To(o.Equal("False"))
 
 		g.By("Create 1st CredentialsRequest whose namespace does not exist")
-		// NOTE: tests run with repo root as CWD, so use an explicit path.
-		crTemp := filepath.Join("test", "extend", "testdata", "credentials_request.yaml")
 		crName1 := "cloud-credential-operator-iam-ro-1"
 		crNamespace := "namespace-does-not-exist"
 		credentialsRequest1 := credentialsRequest{
 			name:      crName1,
 			namespace: crNamespace,
 			provider:  providerSpec,
-			template:  crTemp,
 		}
 		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("CredentialsRequest", crName1, "-n", DefaultNamespace, "--ignore-not-found").Execute()
 		credentialsRequest1.create(oc)
@@ -453,7 +449,6 @@ data:
 			name:      crName2,
 			namespace: crNamespace,
 			provider:  providerSpec,
-			template:  crTemp,
 		}
 		defer oc.AsAdmin().WithoutNamespace().Run("delete").Args("CredentialsRequest", crName2, "-n", DefaultNamespace, "--ignore-not-found").Execute()
 		credentialsRequest2.create(oc)
@@ -554,7 +549,6 @@ data:
 			name:      crName,
 			namespace: targetNs,
 			provider:  "AWSProviderSpec",
-			template:  filepath.Join("test", "extend", "testdata", "credentials_request.yaml"),
 		}
 		defer func() {
 			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("CredentialsRequest", crName, "-n", DefaultNamespace).Execute()
@@ -670,7 +664,6 @@ spec:
 			name:      crName,
 			namespace: targetNs,
 			provider:  "AzureProviderSpec",
-			template:  filepath.Join("test", "extend", "testdata", "credentials_request.yaml"),
 		}
 		defer func() {
 			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("CredentialsRequest", crName, "-n", DefaultNamespace).Execute()
@@ -748,7 +741,6 @@ spec:
 			name:      crName,
 			namespace: targetNs,
 			provider:  "GCPProviderSpec",
-			template:  filepath.Join("test", "extend", "testdata", "credentials_request.yaml"),
 		}
 		defer func() {
 			_ = oc.AsAdmin().WithoutNamespace().Run("delete").Args("CredentialsRequest", crName, "-n", DefaultNamespace).Execute()

--- a/test/extend/cloudcredential_util.go
+++ b/test/extend/cloudcredential_util.go
@@ -1,9 +1,11 @@
 package extend
 
 import (
+	_ "embed"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -13,6 +15,9 @@ import (
 	g "github.com/onsi/ginkgo/v2"
 	o "github.com/onsi/gomega"
 )
+
+//go:embed testdata/credentials_request.yaml
+var credentialsRequestTemplate []byte
 
 const (
 	ccoCap                   = "CloudCredential"
@@ -47,7 +52,6 @@ type credentialsRequest struct {
 	name      string
 	namespace string
 	provider  string
-	template  string
 }
 
 type azureCredential struct {
@@ -260,7 +264,13 @@ func patchResourceAsAdmin(oc *CLI, ns, resource, rsname, patch string) {
 }
 
 func (cr *credentialsRequest) create(oc *CLI) {
-	applyNsResourceFromTemplate(oc, DefaultNamespace, "--ignore-unknown-parameters=true", "-f", cr.template, "-p", "NAME="+cr.name, "NAMESPACE="+cr.namespace, "PROVIDER="+cr.provider)
+	tmpFile, err := os.CreateTemp("", "credentials-request-*.yaml")
+	o.Expect(err).NotTo(o.HaveOccurred())
+	defer os.Remove(tmpFile.Name())
+	_, err = tmpFile.Write(credentialsRequestTemplate)
+	o.Expect(err).NotTo(o.HaveOccurred())
+	o.Expect(tmpFile.Close()).NotTo(o.HaveOccurred())
+	applyNsResourceFromTemplate(oc, DefaultNamespace, "--ignore-unknown-parameters=true", "-f", tmpFile.Name(), "-p", "NAME="+cr.name, "NAMESPACE="+cr.namespace, "PROVIDER="+cr.provider)
 }
 
 // Check if CCO conditions are healthy


### PR DESCRIPTION
## Summary
- Fix conformance test failure where `oc process` can't find `test/extend/testdata/credentials_request.yaml` when the test binary runs outside the source tree in CI
- Use `go:embed` to compile the template into the test binary so it's available regardless of working directory
- Affects 4 tests (PolarionIDs: 64885, 45975, 69971, 75429)

## Test plan
- [ ] Verify `go build ./cmd/cloud-credential-tests-ext/` compiles cleanly
- [ ] Run the failing conformance test `Critical-CCO-based flow for olm managed operators and AWS STS` in CI
- [ ] Confirm the other 3 affected tests (45975, 69971, 75429) also pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated cloud credential test setup to apply embedded request templates through temporary files.
  * Removed unused template data from test request construction while preserving existing credential fields and test flows.
  * Added cleanup of temporary template files after use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->