### PR TITLE
[release-4.22] OCPBUGS-101875: Bump golang.org/x/net to v0.55.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4 // indirect
 	golang.org/x/crypto v0.47.0 // indirect
 	golang.org/x/exp v0.0.0-20240719175910-8a7402abbf56 // indirect
-	golang.org/x/net v0.49.0 // indirect
+	golang.org/x/net v0.55.0 // indirect
 	golang.org/x/sync v0.19.0 // indirect
 	golang.org/x/sys v0.40.0 // indirect
 	golang.org/x/term v0.39.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1213,7 +1213,7 @@ golang.org/x/exp/slices
 golang.org/x/mod/internal/lazyregexp
 golang.org/x/mod/module
 golang.org/x/mod/semver
-# golang.org/x/net v0.49.0 => golang.org/x/net v0.49.0
+# golang.org/x/net v0.55.0 => golang.org/x/net v0.49.0
 ## explicit; go 1.24.0
 golang.org/x/net/context
 golang.org/x/net/html


### PR DESCRIPTION
https://redhat.atlassian.net/browse/OCPBUGS-101875 — CVE-2026-33814. golang.org/x/net -> v0.55.0.