### PR TITLE
OCPBUGS-112282: In testing skip pod-identity-webhook checks on external platform

### DIFF
--- a/test/extend/cloudcredential.go
+++ b/test/extend/cloudcredential.go
@@ -292,7 +292,7 @@ data:
 		o.Expect(seccompProfileType).To(o.Equal("RuntimeDefault"))
 		//Check IAAS platform type
 		iaasPlatform := checkPlatform(oc)
-		if iaasPlatform == "aws" || (iaasPlatform == "azure" && isWorkloadIdentityCluster(oc)) || iaasPlatform == "gcp" {
+		if !isPlatformExternal(oc) && (iaasPlatform == "aws" || (iaasPlatform == "azure" && isWorkloadIdentityCluster(oc)) || iaasPlatform == "gcp") {
 			g.By(fmt.Sprintf("2.Check pod-identity-webhook pod for %s", iaasPlatform))
 			if isSNOCluster(oc) {
 				checkWebhookSecurityContext(oc, 1)
@@ -312,7 +312,7 @@ data:
 
 		podsToCheck := ccoOperatorPodList
 		iaasPlatform := checkPlatform(oc)
-		if iaasPlatform == "aws" || iaasPlatform == "gcp" || (iaasPlatform == "azure" && isWorkloadIdentityCluster(oc)) {
+		if !isPlatformExternal(oc) && (iaasPlatform == "aws" || iaasPlatform == "gcp" || (iaasPlatform == "azure" && isWorkloadIdentityCluster(oc))) {
 			g.GinkgoT().Logf("Checking pod-identity-webhook pod for readOnlyRootFilesystem enable")
 			podIdentityWebhookPods, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("pod", "-l", "app=pod-identity-webhook", "-n", DefaultNamespace, "-o=jsonpath={.items[*].metadata.name}").Output()
 			o.Expect(err).NotTo(o.HaveOccurred())
@@ -345,7 +345,7 @@ data:
 		skipIfHypershiftHostedCluster(oc)
 		//Check IAAS platform type
 		iaasPlatform := checkPlatform(oc)
-		if iaasPlatform != "aws" {
+		if isPlatformExternal(oc) || iaasPlatform != "aws" {
 			g.Skip("IAAS platform is " + iaasPlatform + " while 48360 is for AWS - skipping test ...")
 		}
 		g.By("1.Check the Mutating Webhook Configuration service port is 443")

--- a/test/extend/cloudcredential_util.go
+++ b/test/extend/cloudcredential_util.go
@@ -180,6 +180,18 @@ func getIaasPlatform(oc *CLI) (string, error) {
 	return iaasPlatform, nil
 }
 
+// isPlatformExternal returns true when the cluster's infrastructure platform
+// type is "External". In that mode CCO runs as a no-op, so platform components
+// such as pod-identity-webhook are not deployed even though the underlying IaaS
+// (reported by getIaasPlatform) may be aws/gcp/azure.
+func isPlatformExternal(oc *CLI) bool {
+	platformType, err := oc.AsAdmin().WithoutNamespace().Run("get").Args("infrastructure", "cluster", "-o=jsonpath={.status.platformStatus.type}").Output()
+	if err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(platformType), "External")
+}
+
 func checkPlatform(oc *CLI) string {
 	p, err := getIaasPlatform(oc)
 	if err != nil {


### PR DESCRIPTION
On platform-external clusters CCO runs as a no-op and does not deploy the pod-identity-webhook, but getIaasPlatform resolves External to the underlying IaaS name (e.g. aws), causing the PSA and readOnlyRootFilesystem conformance tests to assert on webhook pods that never exist.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform-specific pod identity webhook checks to correctly exclude external infrastructure platforms.
  * Improved AWS webhook reconciliation test handling for unsupported platform types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->